### PR TITLE
allows gcloud to fail

### DIFF
--- a/bigquery/api/mainTest.php
+++ b/bigquery/api/mainTest.php
@@ -30,9 +30,14 @@ class mainTest extends PHPUnit_Framework_TestCase
         if (!self::$hasCredentials) {
             $this->markTestSkipped('No application credentials were found.');
         }
+
+        if (!$projectId = getenv('GOOGLE_PROJECT_ID')) {
+            $this->markTestSkipped('No project ID');
+        }
+
         // Invoke main.php.
         global $argc, $argv;
-        $argv[1] = getenv('GOOGLE_PROJECT_ID');
+        $argv[1] = $projectId;
         $argc = 2;
         // Capture stdout.
         ob_start();

--- a/managed_vms/drupal8/tests/run-tests.sh
+++ b/managed_vms/drupal8/tests/run-tests.sh
@@ -30,10 +30,10 @@ if [ "${PREREQ}" = "false" ]; then
 fi
 
 # Install drupal console
-if [ ! -e ${HOME}/bin/drupal ]; then
+if [ ! -e ${DIR}/drupal ]; then
     curl https://drupalconsole.com/installer -L -o drupal
     chmod +x drupal
-    mv drupal "${HOME}/bin/drupal"
+    mv drupal "${DIR}/drupal"
 fi
 
 # cleanup installation dir
@@ -49,14 +49,14 @@ sed -i -e "s/@@DRUPAL_ADMIN_USERNAME@@/${DRUPAL_ADMIN_USERNAME}/" $INSTALL_FILE
 sed -i -e "s/@@DRUPAL_ADMIN_PASSWORD@@/${DRUPAL_ADMIN_PASSWORD}/" $INSTALL_FILE
 
 # download and install
-drupal init --root=$DIR
-drupal chain --file=$INSTALL_FILE
+${DIR}/drupal init --root=$DIR
+${DIR}/drupal chain --file=$INSTALL_FILE
 
 cd $DRUPAL_DIR
 
 # run some setup commands
-drupal theme:download bootstrap 8.x-3.0-beta2
-drupal cache:rebuild all
+${DIR}/drupal theme:download bootstrap 8.x-3.0-beta2
+${DIR}/drupal cache:rebuild all
 
 ## Perform steps outlined in the README ##
 
@@ -74,6 +74,8 @@ if [ -z "${GOOGLE_VERSION_ID}" ]; then
 fi
 
 # Deploy to gcloud (try 3 times)
+# "unset -e" temporarily to allow deployments to fail
+unset -e
 attempts=0
 until [ $attempts -ge 3 ]
 do
@@ -85,6 +87,7 @@ do
   attempts=$[$attempts+1]
   sleep 1
 done
+set -e
 
 # Determine the deployed URL
 if [ -z "${GOOGLE_MODULE}" ]; then

--- a/managed_vms/symfony/tests/run-tests.sh
+++ b/managed_vms/symfony/tests/run-tests.sh
@@ -64,6 +64,8 @@ if [ -z "${GOOGLE_VERSION_ID}" ]; then
 fi
 
 # Deploy to gcloud (try 3 times)
+# "unset -e" temporarily to allow deployments to fail
+unset -e
 attempts=0
 until [ $attempts -ge 3 ]
 do
@@ -75,6 +77,7 @@ do
   attempts=$[$attempts+1]
   sleep 1
 done
+set -e
 
 # Determine the deployed URL
 if [ -z "${GOOGLE_MODULE}" ]; then


### PR DESCRIPTION
also:
 - ensures drupal path is correct
 - fails bigquery without project ID