### PR TITLE
Use gcloud instead of appcfg.py.

### DIFF
--- a/app_engine/phpmyadmin/app-e2e.yaml
+++ b/app_engine/phpmyadmin/app-e2e.yaml
@@ -1,22 +1,20 @@
-application: {{your_project_id}}
-version: 1
 module: phpmyadmin
 runtime: php55
 api_version: 1
 
 handlers:
 
-- url: /(.+\.(ico|jpg|png|gif))$
+- url: /(.+\.(ico|jpg|png|gif))
   static_files: \1
   upload: (.+\.(ico|jpg|png|gif))$
   application_readable: true
 
-- url: /(.+\.(htm|html|css|js))$
+- url: /(.+\.(htm|html|css|js))
   static_files: \1
   upload: (.+\.(htm|html|css|js))$
   application_readable: true
 
-- url: /(.+\.php)$
+- url: /(.+\.php)
   script: \1
 
 - url: /.*

--- a/app_engine/phpmyadmin/tests/DeployTest.php
+++ b/app_engine/phpmyadmin/tests/DeployTest.php
@@ -130,10 +130,11 @@ class DeployTest extends \PHPUnit_Framework_TestCase
 
     public static function deploy($project_id, $e2e_test_version, $target)
     {
-        $command = "appcfg.py -q "
+        $command = "gcloud -q preview app deploy --no-promote "
+            . "--no-stop-previous-version "
             . "--version $e2e_test_version "
-            . "--application $project_id "
-            . "update $target";
+            . "--project $project_id "
+            . "$target/app.yaml";
         for ($i = 0; $i <= 3; $i++) {
             exec($command, $output, $ret);
             foreach ($output as $line) {


### PR DESCRIPTION
Because there's no way to automate auth with appcfg.py. I need to ommit
the trailing '$' to workaround the following bug:
https://code.google.com/p/google-cloud-sdk/issues/detail?id=573