### PR TITLE
Added a blog_id for gcs media upload.

### DIFF
--- a/managed_vms/wordpress/src/files/gcs-media.php
+++ b/managed_vms/wordpress/src/files/gcs-media.php
@@ -42,9 +42,11 @@ defined('ABSPATH') or die('No direct access!');
 add_filter('upload_dir', 'GCS\Media\filter_upload_dir');
 function filter_upload_dir($values)
 {
-    $basedir = 'gs://' . GOOGLE_CLOUD_STORAGE_BUCKET;
+    $basedir = 'gs://' . GOOGLE_CLOUD_STORAGE_BUCKET
+        . '/' . get_current_blog_id();
     $baseurl = 'https://storage.googleapis.com/'
-        . GOOGLE_CLOUD_STORAGE_BUCKET;
+        . GOOGLE_CLOUD_STORAGE_BUCKET
+        . '/' . get_current_blog_id();
     $values = array(
         'path' => $basedir . $values['subdir'],
         'subdir' => $values['subdir'],


### PR DESCRIPTION
WordPress has a feature called `multisites` that allows you to host multiple blogs from a single WordPress installation. With adding the blog_id as a sub directory, you can have separate directory for each blog.