### PR TITLE
Add option to use standard SQL syntax to BigQuery sample.

### DIFF
--- a/bigquery/api/src/QueryCommand.php
+++ b/bigquery/api/src/QueryCommand.php
@@ -65,6 +65,12 @@ EOF
                 InputOption::VALUE_NONE,
                 'run the query syncronously'
             )
+            ->addOption(
+                'standardSql',
+                null,
+                InputOption::VALUE_NONE,
+                'run the query using standard SQL instead of legacy SQL syntax'
+            )
         ;
     }
 
@@ -87,9 +93,15 @@ EOF
 
         try {
             if ($input->getOption('sync')) {
-                run_query($projectId, $query);
+                run_query(
+                    $projectId,
+                    $query,
+                    !$input->getOption('standardSql'));
             } else {
-                run_query_as_job($projectId, $query);
+                run_query_as_job(
+                    $projectId,
+                    $query,
+                    !$input->getOption('standardSql'));
             }
         } catch (BadRequestException $e) {
             $response = $e->getServiceException()->getResponse();

--- a/bigquery/api/src/functions/run_query.php
+++ b/bigquery/api/src/functions/run_query.php
@@ -32,13 +32,15 @@ use Google\Cloud\ServiceBuilder;
  * ```
  * $query = 'SELECT TOP(corpus, 10) as title, COUNT(*) as unique_words ' .
  *          'FROM [publicdata:samples.shakespeare]';
- * run_query($projectId, $query);
+ * run_query($projectId, $query, true);
  * ```.
  *
  * @param string $projectId The Google project ID.
  * @param string $query     A SQL query to run.
+ * @param bool $useLegacySql Specifies whether to use BigQuery's legacy SQL
+ *        syntax or standard SQL syntax for this query.
  */
-function run_query($projectId, $query)
+function run_query($projectId, $query, $useLegacySql)
 {
     # [START build_service]
     $builder = new ServiceBuilder([
@@ -47,7 +49,9 @@ function run_query($projectId, $query)
     $bigQuery = $builder->bigQuery();
     # [END build_service]
     # [START run_query]
-    $queryResults = $bigQuery->runQuery($query);
+    $queryResults = $bigQuery->runQuery(
+        $query,
+        ['useLegacySql' => $useLegacySql]);
     # [END run_query]
 
     # [START print_results]

--- a/bigquery/api/src/functions/run_query_as_job.php
+++ b/bigquery/api/src/functions/run_query_as_job.php
@@ -34,19 +34,23 @@ use Google\Cloud\ExponentialBackoff;
  * ```
  * $query = 'SELECT TOP(corpus, 10) as title, COUNT(*) as unique_words ' .
  *          'FROM [publicdata:samples.shakespeare]';
- * run_query_as_job($projectId, $query);
+ * run_query_as_job($projectId, $query, true);
  * ```.
  *
  * @param string $projectId The Google project ID.
- * @param string $query     A SQL query to run.
+ * @param string $query     A SQL query to run. *
+ * @param bool $useLegacySql Specifies whether to use BigQuery's legacy SQL
+ *        syntax or standard SQL syntax for this query.
  */
-function run_query_as_job($projectId, $query)
+function run_query_as_job($projectId, $query, $useLegacySql)
 {
     $builder = new ServiceBuilder([
         'projectId' => $projectId,
     ]);
     $bigQuery = $builder->bigQuery();
-    $job = $bigQuery->runQueryAsJob($query);
+    $job = $bigQuery->runQueryAsJob(
+        $query,
+        ['jobConfig' => ['useLegacySql' => $useLegacySql]]);
     $backoff = new ExponentialBackoff(10);
     $backoff->execute(function () use ($job) {
         print('Waiting for job to complete' . PHP_EOL);

--- a/bigquery/api/test/QueryCommandTest.php
+++ b/bigquery/api/test/QueryCommandTest.php
@@ -105,6 +105,38 @@ class QueryCommandTest extends \PHPUnit_Framework_TestCase
         $this->expectOutputRegex('/Found 1 row\(s\)/');
     }
 
+    public function testQueryStandardSql()
+    {
+        if (!self::$hasCredentials) {
+            $this->markTestSkipped('No application credentials were found.');
+        }
+        if (!$projectId = getenv('GOOGLE_PROJECT_ID')) {
+            $this->markTestSkipped('No project ID');
+        }
+        if (!$datasetId = getenv('GOOGLE_BIGQUERY_DATASET')) {
+            $this->markTestSkipped('No bigquery dataset name');
+        }
+        if (!$tableId = getenv('GOOGLE_BIGQUERY_TABLE')) {
+            $this->markTestSkipped('No bigquery table name');
+        }
+
+        $query = sprintf('SELECT * FROM `%s.%s` LIMIT 1', $datasetId, $tableId);
+
+        $application = new Application();
+        $application->add(new QueryCommand());
+        $commandTester = new CommandTester($application->get('query'));
+        $commandTester->execute(
+            [
+              'query' => $query,
+              '--project' => $projectId,
+              '--sync',
+              '--standardSql'],
+            ['interactive' => false]
+        );
+
+        $this->expectOutputRegex('/Found 1 row\(s\)/');
+    }
+
     public function testQueryAsJob()
     {
         if (!self::$hasCredentials) {
@@ -127,6 +159,34 @@ class QueryCommandTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($application->get('query'));
         $commandTester->execute(
             ['query' => $query, '--project' => $projectId],
+            ['interactive' => false]
+        );
+
+        $this->expectOutputRegex('/Found 1 row\(s\)/');
+    }
+
+    public function testQueryAsJobStandardSql()
+    {
+        if (!self::$hasCredentials) {
+            $this->markTestSkipped('No application credentials were found.');
+        }
+        if (!$projectId = getenv('GOOGLE_PROJECT_ID')) {
+            $this->markTestSkipped('No project ID');
+        }
+        if (!$datasetId = getenv('GOOGLE_BIGQUERY_DATASET')) {
+            $this->markTestSkipped('No bigquery dataset name');
+        }
+        if (!$tableId = getenv('GOOGLE_BIGQUERY_TABLE')) {
+            $this->markTestSkipped('No bigquery table name');
+        }
+
+        $query = sprintf('SELECT * FROM `%s.%s` LIMIT 1', $datasetId, $tableId);
+
+        $application = new Application();
+        $application->add(new QueryCommand());
+        $commandTester = new CommandTester($application->get('query'));
+        $commandTester->execute(
+            ['query' => $query, '--project' => $projectId, '--standardSql'],
             ['interactive' => false]
         );
 


### PR DESCRIPTION
This is so that we can include PHP in the list of languages when we add veneer samples to https://cloud.google.com/bigquery/sql-reference/enabling-standard-sql.

I fully expect that I have a style issue on every single line. The last time I used PHP, the latest version was 4.3.