### PR TITLE
Add region tags to BigQuery run_query_as_job.

### DIFF
--- a/bigquery/api/src/functions/run_query_as_job.php
+++ b/bigquery/api/src/functions/run_query_as_job.php
@@ -48,9 +48,11 @@ function run_query_as_job($projectId, $query, $useLegacySql)
         'projectId' => $projectId,
     ]);
     $bigQuery = $builder->bigQuery();
+    // [START run_query_as_job]
     $job = $bigQuery->runQueryAsJob(
         $query,
         ['jobConfig' => ['useLegacySql' => $useLegacySql]]);
+    // [END run_query_as_job]
     $backoff = new ExponentialBackoff(10);
     $backoff->execute(function () use ($job) {
         print('Waiting for job to complete' . PHP_EOL);


### PR DESCRIPTION
This will be used to show how to enable standard SQL.
https://cloud.google.com/bigquery/sql-reference/enabling-standard-sql
I chose the name based on the similar run_query region tags in
https://github.com/GoogleCloudPlatform/php-docs-samples/blob/60bf9879ad85475c20b2f23c9ad989b85296ed1a/bigquery/api/src/functions/run_query.php#L51