### PR TITLE
Upgraded to google/cloud to 0.11.1

### DIFF
--- a/datastore/api/composer.json
+++ b/datastore/api/composer.json
@@ -1,10 +1,10 @@
 {
     "require": {
-        "google/cloud": "~1.0|~0.10"
+        "google/cloud": "~0.11"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",
-        "google/cloud-tools": "~1.0|~0.5"
+        "google/cloud-tools": "~0.5"
     },
     "autoload": {
         "psr-4": { "Google\\Cloud\\Samples\\Datastore\\": "src" },

--- a/datastore/api/composer.lock
+++ b/datastore/api/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "23ff977eebca4dfc0ebf4fdae9c9b881",
-    "content-hash": "73bb877c2f05f502073a5cfe66c42d20",
+    "hash": "ca98e1511e9c9af382326f6f1835f032",
+    "content-hash": "b666c02db1bf3a0b04fdc2c55ee3a34d",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -100,16 +100,16 @@
         },
         {
             "name": "google/cloud",
-            "version": "v0.10.2",
+            "version": "v0.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GoogleCloudPlatform/google-cloud-php.git",
-                "reference": "97d06b1106ee9bca591ad0573ee71e32a8500992"
+                "reference": "7207d5b9bfb55cc732b082588f488150594141c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/google-cloud-php/zipball/97d06b1106ee9bca591ad0573ee71e32a8500992",
-                "reference": "97d06b1106ee9bca591ad0573ee71e32a8500992",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/google-cloud-php/zipball/7207d5b9bfb55cc732b082588f488150594141c2",
+                "reference": "7207d5b9bfb55cc732b082588f488150594141c2",
                 "shasum": ""
             },
             "require": {
@@ -180,7 +180,7 @@
                 "translate",
                 "vision"
             ],
-            "time": "2016-10-11 17:58:10"
+            "time": "2016-10-13 20:41:02"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/datastore/api/index.yaml
+++ b/datastore/api/index.yaml
@@ -29,3 +29,15 @@ indexes:
   properties:
   - name: priority
   - name: created
+
+- kind: Task
+  properties:
+  - name: done
+  - name: priority
+    direction: desc
+
+- kind: Task
+  properties:
+  - name: priority
+    direction: desc
+  - name: created

--- a/datastore/api/test/ConceptsTest.php
+++ b/datastore/api/test/ConceptsTest.php
@@ -357,63 +357,242 @@ class ConceptsTest extends \PHPUnit_Framework_TestCase
 
     public function testBasicQuery()
     {
+        $key1 = self::$datastore->key('Task', generateRandomString());
+        $key2 = self::$datastore->key('Task', generateRandomString());
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        $entity1['priority'] = 4;
+        $entity1['done'] = false;
+        $entity2['priority'] = 5;
+        $entity2['done'] = false;
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $query = basic_query(self::$datastore);
         $this->assertInstanceOf(Query::class, $query);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $key2, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(2, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key2->path());
+                $this->assertTrue($entities[1]->key()->path() == $key1->path());
+            });
     }
 
     public function testRunQuery()
     {
+        $key1 = self::$datastore->key('Task', generateRandomString());
+        $key2 = self::$datastore->key('Task', generateRandomString());
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        $entity1['priority'] = 4;
+        $entity1['done'] = false;
+        $entity2['priority'] = 5;
+        $entity2['done'] = false;
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $query = basic_query(self::$datastore);
-        $result = run_query(self::$datastore, $query);
-        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertInstanceOf(Query::class, $query);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $key2, $query) {
+                $result = run_query(self::$datastore, $query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(2, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key2->path());
+                $this->assertTrue($entities[1]->key()->path() == $key1->path());
+            });
     }
 
     public function testPropertyFilter()
     {
+        $key1 = self::$datastore->key('Task', generateRandomString());
+        $key2 = self::$datastore->key('Task', generateRandomString());
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        $entity1['done'] = false;
+        $entity2['done'] = true;
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $query = property_filter(self::$datastore);
         $this->assertInstanceOf(Query::class, $query);
-        $result = self::$datastore->runQuery($query);
-        $this->assertInstanceOf(\Generator::class, $result);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(1, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key1->path());
+            });
     }
 
     public function testCompositeFilter()
     {
+        $key1 = self::$datastore->key('Task', generateRandomString());
+        $key2 = self::$datastore->key('Task', generateRandomString());
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        $entity1['done'] = false;
+        $entity1['priority'] = 4;
+        $entity2['done'] = false;
+        $entity2['priority'] = 5;
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $query = composite_filter(self::$datastore);
         $this->assertInstanceOf(Query::class, $query);
-        $result = self::$datastore->runQuery($query);
-        $this->assertInstanceOf(\Generator::class, $result);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(1, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key1->path());
+            });
     }
 
     public function testKeyFilter()
     {
+        $key1 = self::$datastore->key('Task', 'taskWhichShouldMatch');
+        $key2 = self::$datastore->key('Task', 'keyWhichShouldNotMatch');
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $query = key_filter(self::$datastore);
         $this->assertInstanceOf(Query::class, $query);
-        $result = self::$datastore->runQuery($query);
-        $this->assertInstanceOf(\Generator::class, $result);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(1, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key1->path());
+            });
     }
 
     public function testAscendingSort()
     {
+        $key1 = self::$datastore->key('Task', generateRandomString());
+        $key2 = self::$datastore->key('Task', generateRandomString());
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        $entity1['created'] = new \DateTime('2016-10-13 14:04:01');
+        $entity2['created'] = new \DateTime('2016-10-13 14:04:00');
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $query = ascending_sort(self::$datastore);
         $this->assertInstanceOf(Query::class, $query);
-        $result = self::$datastore->runQuery($query);
-        $this->assertInstanceOf(\Generator::class, $result);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $key2, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(2, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key2->path());
+                $this->assertTrue($entities[1]->key()->path() == $key1->path());
+            });
     }
 
     public function testDescendingSort()
     {
+        $key1 = self::$datastore->key('Task', generateRandomString());
+        $key2 = self::$datastore->key('Task', generateRandomString());
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        $entity1['created'] = new \DateTime('2016-10-13 14:04:00');
+        $entity2['created'] = new \DateTime('2016-10-13 14:04:01');
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $query = descending_sort(self::$datastore);
         $this->assertInstanceOf(Query::class, $query);
-        $result = self::$datastore->runQuery($query);
-        $this->assertInstanceOf(\Generator::class, $result);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $key2, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(2, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key2->path());
+                $this->assertTrue($entities[1]->key()->path() == $key1->path());
+            });
     }
 
     public function testMultiSort()
     {
+        $key1 = self::$datastore->key('Task', generateRandomString());
+        $key2 = self::$datastore->key('Task', generateRandomString());
+        $key3 = self::$datastore->key('Task', generateRandomString());
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        $entity3 = self::$datastore->entity($key3);
+        $entity3['created'] = new \DateTime('2016-10-13 14:04:03');
+        $entity3['priority'] = 5;
+        $entity2['created'] = new \DateTime('2016-10-13 14:04:01');
+        $entity2['priority'] = 4;
+        $entity1['created'] = new \DateTime('2016-10-13 14:04:02');
+        $entity1['priority'] = 4;
+        self::$keys = [$key1, $key2, $key3];
+        self::$datastore->upsertBatch([$entity1, $entity2, $entity3]);
         $query = multi_sort(self::$datastore);
         $this->assertInstanceOf(Query::class, $query);
-        $result = self::$datastore->runQuery($query);
-        $this->assertInstanceOf(\Generator::class, $result);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $key2, $key3, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(3, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key3->path());
+                $this->assertTrue($entities[1]->key()->path() == $key2->path());
+                $this->assertTrue($entities[2]->key()->path() == $key1->path());
+            });
     }
 
     public function testAncestorQuery()
@@ -439,11 +618,29 @@ class ConceptsTest extends \PHPUnit_Framework_TestCase
 
     public function testKindlessQuery()
     {
+        $key1 = self::$datastore->key('Task', 'taskWhichShouldMatch');
+        $key2 = self::$datastore->key('Task', 'entityWhichShouldNotMatch');
+        $entity1 = self::$datastore->entity($key1);
+        $entity2 = self::$datastore->entity($key2);
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $lastSeenKey = self::$datastore->key('Task', 'lastSeen');
         $query = kindless_query(self::$datastore, $lastSeenKey);
         $this->assertInstanceOf(Query::class, $query);
-        $result = self::$datastore->runQuery($query);
-        $this->assertInstanceOf(\Generator::class, $result);
+
+        $this->runEventuallyConsistentTest(
+            function () use ($key1, $key2, $query) {
+                $result = self::$datastore->runQuery($query);
+                $num = 0;
+                $entities = [];
+                /* @var Entity $e */
+                foreach ($result as $e) {
+                    $entities[] = $e;
+                    $num += 1;
+                }
+                self::assertEquals(1, $num);
+                $this->assertTrue($entities[0]->key()->path() == $key1->path());
+            });
     }
 
     public function testKeysOnlyQuery()
@@ -519,10 +716,8 @@ class ConceptsTest extends \PHPUnit_Framework_TestCase
         $entity1['category'] = 'work';
         $entity2['priority'] = 5;
         $entity2['category'] = 'work';
-        self::$keys[] = $key1;
-        self::$keys[] = $key2;
-        self::$datastore->upsert($entity1);
-        self::$datastore->upsert($entity2);
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         $this->runEventuallyConsistentTest(function () use ($key1) {
             $query = distinct_on(self::$datastore);
             $result = self::$datastore->runQuery($query);
@@ -760,10 +955,8 @@ class ConceptsTest extends \PHPUnit_Framework_TestCase
         $entity2 = self::$datastore->entity($key2);
         $entity1['balance'] = 100;
         $entity2['balance'] = 0;
-        self::$keys[] = $key1;
-        self::$keys[] = $key2;
-        self::$datastore->upsert($entity1);
-        self::$datastore->upsert($entity2);
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         transfer_funds(self::$datastore, $key1, $key2, 100);
         $fromAccount = self::$datastore->lookup($key1);
         $this->assertEquals(0, $fromAccount['balance']);
@@ -779,10 +972,8 @@ class ConceptsTest extends \PHPUnit_Framework_TestCase
         $entity2 = self::$datastore->entity($key2);
         $entity1['balance'] = 10;
         $entity2['balance'] = 0;
-        self::$keys[] = $key1;
-        self::$keys[] = $key2;
-        self::$datastore->upsert($entity1);
-        self::$datastore->upsert($entity2);
+        self::$keys = [$key1, $key2];
+        self::$datastore->upsertBatch([$entity1, $entity2]);
         transactional_retry(self::$datastore, $key1, $key2);
         $fromAccount = self::$datastore->lookup($key1);
         $this->assertEquals(0, $fromAccount['balance']);

--- a/datastore/api/test/ConceptsTest.php
+++ b/datastore/api/test/ConceptsTest.php
@@ -590,8 +590,13 @@ class ConceptsTest extends \PHPUnit_Framework_TestCase
                 }
                 self::assertEquals(3, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key3->path());
+                $this->assertEquals(5, $entities[0]['priority']);
                 $this->assertTrue($entities[1]->key()->path() == $key2->path());
+                $this->assertEquals(4, $entities[1]['priority']);
                 $this->assertTrue($entities[2]->key()->path() == $key1->path());
+                $this->assertEquals(4, $entities[2]['priority']);
+                $this->assertTrue($entities[0]['created'] > $entities[1]['created']);
+                $this->assertTrue($entities[1]['created'] < $entities[2]['created']);
             });
     }
 


### PR DESCRIPTION
* Use `hasAncestor` and `keysOnly` for simplicity.
* Simplified the transaction example.
* Complete some system tests.