### PR TITLE
Revert "updates php-cs-fixer for 2.0"

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,16 +1,17 @@
 <?php
 
-$finder = PhpCsFixer\Finder::create()
+$finder = Symfony\CS\Finder\DefaultFinder::create()
     ->in(__DIR__)
-    ->notPath('appengine/wordpress/src/files/flexible/wp-config.php')
-    ->notPath('appengine/wordpress/src/files/standard/wp-config.php')
 ;
 
-return PhpCsFixer\Config::create()
-    ->setRules([
-        '@PSR2' => true,
-        'concat_with_spaces' => true,
-        'no_unused_imports' => true,
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers([
+        'concat_with_spaces',
+        'unused_use',
+        'trailing_spaces',
+        'indentation',
+	'-psr0'
     ])
-    ->setFinder($finder)
+    ->finder($finder)
 ;

--- a/datastore/api/src/functions/concepts.php
+++ b/datastore/api/src/functions/concepts.php
@@ -733,7 +733,7 @@ function unindexed_property_query(DatastoreClient $datastore)
     // [START unindexed_property_query]
     $query = $datastore->query()
         ->kind('Task')
-        ->filter('description', '=', 'A task description.');
+        ->filter('description',  '=', 'A task description.');
     // [END unindexed_property_query]
     return $query;
 }

--- a/language/api/test/AllCommandTest.php
+++ b/language/api/test/AllCommandTest.php
@@ -48,7 +48,7 @@ class AllCommandTest extends \PHPUnit_Framework_TestCase
         $this->commandTester = new CommandTester($application->get('all'));
         $this->expectedPatterns = array(
             '/language: en/',
-            '/sentiment: /',
+            '/sentiment/',
             '/sentences:/',
             '/0: Do you know the way to San Jose\\?/',
             '/tokens:/',

--- a/language/api/test/SentimentCommandTest.php
+++ b/language/api/test/SentimentCommandTest.php
@@ -75,6 +75,6 @@ class SentimentCommandTest extends \PHPUnit_Framework_TestCase
         );
 
         $output = $this->commandTester->getDisplay();
-        $this->assertRegExp('/sentiment: /', $output);
+        $this->assertRegExp('/sentiment/', $output);
     }
 }


### PR DESCRIPTION
The `php-cs-fixer` team has rolled this change back, so we now have to roll it back as well 👎 