### PR TITLE
Modify link used to enable the translate api

### DIFF
--- a/translate/api/README.md
+++ b/translate/api/README.md
@@ -6,7 +6,7 @@ These samples show how to use the [Google Cloud Translate API](
 https://cloud.google.com/translate/).
 
 ## Build and Run
-1.  **Enable APIs** - [Enable the Translate API](https://console.cloud.google.com/flows/enableapi?apiid=translate.googleapis.com)
+1.  **Enable APIs** - [Enable the Translate API](https://console.cloud.google.com/flows/enableapi?apiid=translate)
     and create a new project or select an existing project.
 2.  **Download The Credentials** - Click "Go to credentials" after enabling the APIs. Click "Create Credentials"
     and select "API key". Copy the API key.


### PR DESCRIPTION
translate.googleapis.com will stop working.

Eng team suggests forcing the user to explicitly select a project.