### PR TITLE
Removed deprecated argument and added requirement

### DIFF
--- a/appengine/wordpress/src/files/flexible/app.yaml
+++ b/appengine/wordpress/src/files/flexible/app.yaml
@@ -1,5 +1,5 @@
 runtime: php
-vm: true
+env: flex
 
 beta_settings:
   cloud_sql_instances: {{db_connection}}


### PR DESCRIPTION
Removed `vm:true` added `env: flex`. 
This resolves invalid an augment error on deploy as `env: flex` is reqiured and `vm:true` has been deprecated. 

Error Message:

`
Updating service [default]...failed.                                                                 
ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Deployments to App Engine Flexible require `env: flex` in app.yaml.
The `vm:true` setting has been deprecated.
`