### PR TITLE
drupal8 test fixes and improvements

### DIFF
--- a/appengine/flexible/drupal8/README.md
+++ b/appengine/flexible/drupal8/README.md
@@ -32,7 +32,7 @@ cd /path/to/drupal
 /path/to/drush dl drupal
 ```
 
-Alternatively, you can download a compressed file of Druapl 8 from the [Drupal Website][5].
+Alternatively, you can download a compressed file of Drupal 8 from the [Drupal Website][5].
 
 ### Installation
 
@@ -59,24 +59,16 @@ Alternatively, you can download a compressed file of Druapl 8 from the [Drupal W
 You will want to use the Cloud SQL credentials you created in the **Prerequisites** section as your
 Drupal backend.
 
-## Copy over App Engine files
+## Add app.yaml
 
-For your app to deploy on App Engine Flexible, you will need to copy over the files in this
-directory:
+Add a file `app.yaml` with the following contents to the root of your Drupal project:
 
-```sh
-# clone this repo somewhere
-git clone https://github.com/GoogleCloudPlatform/php-docs-samples /path/to/php-docs-samples
-cd /path/to/php-docs-samples/
-
-# copy the two files below to the root directory of your Drupal project
-cp appengine/flexible/drupal8/{app.yaml,php.ini} /path/to/drupal
+```yaml
+runtime: php
+env: flex
 ```
 
-The two files needed are as follows:
-
-  1. [`app.yaml`](app.yaml) - The App Engine configuration for your project
-  1. [`php.ini`](php.ini) - Optional ini used to extend the runtime configuration.
+`app.yaml` is the App Engine configuration for your project.
 
 ## Disable CSS and JS Cache
 

--- a/appengine/flexible/drupal8/php.ini
+++ b/appengine/flexible/drupal8/php.ini
@@ -1,6 +1,0 @@
-suhosin.post.max_vars = 1000
-suhosin.request.max_vars = 1000
-
-; we should tighten up these restrictions eventually
-suhosin.executor.func.blacklist =
-disable_functions =

--- a/appengine/flexible/drupal8/test/DeployTest.php
+++ b/appengine/flexible/drupal8/test/DeployTest.php
@@ -39,18 +39,21 @@ class DeployTest extends \PHPUnit_Framework_TestCase
         // download, install, and deploy
         $tmpDir = sys_get_temp_dir() . '/test-' . FileUtil::randomName(8);
         self::downloadAndInstallDrupal($tmpDir);
+
+        // set the directory in gcloud
+        self::$gcloudWrapper->setDir($tmpDir);
     }
 
     private static function verifyEnvironmentVariables()
     {
         $envVars = [
             'GOOGLE_PROJECT_ID',
-            'DRUPAL_ADMIN_USERNAME',
-            'DRUPAL_ADMIN_PASSWORD',
-            'DRUPAL_DATABASE_HOST',
-            'DRUPAL_DATABASE_NAME',
-            'DRUPAL_DATABASE_USER',
-            'DRUPAL_DATABASE_PASS',
+            'DRUPAL8_ADMIN_USERNAME',
+            'DRUPAL8_ADMIN_PASSWORD',
+            'DRUPAL8_DATABASE_HOST',
+            'DRUPAL8_DATABASE_NAME',
+            'DRUPAL8_DATABASE_USER',
+            'DRUPAL8_DATABASE_PASS',
         ];
         foreach ($envVars as $envVar) {
             if (false === getenv($envVar)) {
@@ -64,10 +67,10 @@ class DeployTest extends \PHPUnit_Framework_TestCase
         $console = __DIR__ . '/../vendor/bin/drush';
 
         $dbUrl = sprintf('mysql://%s:%s@%s/%s',
-            getenv('DRUPAL_DATABASE_USER'),
-            getenv('DRUPAL_DATABASE_PASS'),
-            getenv('DRUPAL_DATABASE_HOST'),
-            getenv('DRUPAL_DATABASE_NAME')
+            getenv('DRUPAL8_DATABASE_USER'),
+            getenv('DRUPAL8_DATABASE_PASS'),
+            getenv('DRUPAL8_DATABASE_HOST'),
+            getenv('DRUPAL8_DATABASE_NAME')
         );
 
         // download
@@ -83,8 +86,8 @@ class DeployTest extends \PHPUnit_Framework_TestCase
             '--db-url=%s --account-name=%s --account-pass=%s -y',
             $console,
             $dbUrl,
-            getenv('DRUPAL_ADMIN_USERNAME'),
-            getenv('DRUPAL_ADMIN_PASSWORD'));
+            getenv('DRUPAL8_ADMIN_USERNAME'),
+            getenv('DRUPAL8_ADMIN_PASSWORD'));
         $process = self::createProcess($installCmd);
         $process->setTimeout(null);
         self::executeProcess($process);
@@ -94,7 +97,7 @@ class DeployTest extends \PHPUnit_Framework_TestCase
         self::execute('rm composer.*');
 
         // move the code for the sample to the new drupal installation
-        $files = ['app.yaml', 'php.ini'];
+        $files = ['app.yaml'];
         foreach ($files as $file) {
             $source = sprintf('%s/../%s', __DIR__, $file);
             $target = sprintf('%s/%s', $targetDir, $file);


### PR DESCRIPTION
 - Removes `php.ini` as it's no longer required
 - Sets gcloud directory to fix e2e bug
 - Renames EnvVars to avoid conflicts with `drupal7`
 - Updates `README`