### PR TITLE
fixed cron.yaml file

### DIFF
--- a/appengine/wordpress/src/files/standard/cron.yaml
+++ b/appengine/wordpress/src/files/standard/cron.yaml
@@ -1,4 +1,4 @@
 cron:
-- description: wordpress cron tasks
+- description: "wordpress cron tasks"
   url: /wp-cron.php
   schedule: every 15 minutes


### PR DESCRIPTION
Change to cron.yaml file to add quotes to description to avoid deployment error.