### PR TITLE
Acknowledge received Pub/Sub messages

### DIFF
--- a/pubsub/api/src/functions/pull_messages.php
+++ b/pubsub/api/src/functions/pull_messages.php
@@ -40,6 +40,7 @@ function pull_messages($projectId, $subscriptionName)
     $subscription = $pubsub->subscription($subscriptionName);
     foreach ($subscription->pull() as $message) {
         printf('Message: %s' . PHP_EOL, $message->data());
+        $subscription->acknowledge($message);
     }
 }
 # [END pull_message]

--- a/pubsub/api/src/functions/pull_messages.php
+++ b/pubsub/api/src/functions/pull_messages.php
@@ -40,6 +40,7 @@ function pull_messages($projectId, $subscriptionName)
     $subscription = $pubsub->subscription($subscriptionName);
     foreach ($subscription->pull() as $message) {
         printf('Message: %s' . PHP_EOL, $message->data());
+        // Acknowledge the Pub/Sub message has been received, so it will not be pulled multiple times.
         $subscription->acknowledge($message);
     }
 }


### PR DESCRIPTION
Currently, the PHP snippet [here](https://cloud.google.com/pubsub/docs/pull#receive) lacks a demonstration of [Subscription::acknowledge()](https://googlecloudplatform.github.io/google-cloud-php/#/docs/google-cloud/master/pubsub%2Fsubscription?method=acknowledge) so this PR adds it.