### PR TITLE
fix coveralls error for partial testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,12 @@ script:
   - testing/run_all_tests.sh
 
 after_success:
-  - composer require "satooshi/php-coveralls:^1.0"
-  - travis_retry php vendor/bin/coveralls -v
+  - |
+    # if we are running all the tests, run coveralls
+    FILES_CHANGED=$(git diff --name-only HEAD $(git merge-base HEAD master))
+    if grep -q ^testing\/ <<< "$FILES_CHANGED" || \
+      grep -qv \/ <<< "$FILES_CHANGED" || \
+      [ -e $TRAVIS_PULL_REQUEST_BRANCH ]; then
+      composer require "satooshi/php-coveralls:^1.0"
+      travis_retry php vendor/bin/coveralls -v
+    fi


### PR DESCRIPTION
Errors get thrown in travis `after_success` for partial tests because the coverage files aren't there. This adds logic to ensure we've run all the tests before running coveralls.