### PR TITLE
updating Mailjet code samples for Send API v3.1

### DIFF
--- a/appengine/flexible/mailjet/app.php
+++ b/appengine/flexible/mailjet/app.php
@@ -40,23 +40,27 @@ $app->post('/send', function () use ($app) {
     /** @var Mailjet\Client $mailjet */
     $mailjet = $app['mailjet'];
     $recipient = $request->get('recipient');
-
     # [START send_email]
     $body = [
-        'FromEmail' => "test@example.com",
-        'FromName' => "Testing Mailjet",
-        'Subject' => "Your email flight plan!",
-        'Text-part' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
-        'Html-part' => "<h3>Dear passenger, welcome to Mailjet!</h3><br/>May the delivery force be with you!",
-        'Recipients' => [
-            [
-                'Email' => $recipient,
-            ]
+    'Messages' => [
+        [
+            'From' => [
+                'Email' => "pilot@mailjet.com",
+                'Name' => "Mailjet Pilot"
+            ],
+            'To' => [
+                [
+                    'Email' => $recipient
+                ]
+            ],
+            'Subject' => "Your email flight plan!",
+            'TextPart' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
+            'HTMLPart' => "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!"
         ]
-    ];
-
+    ]
+];
     // trigger the API call
-    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body]);
+    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3']);
     if ($response->success()) {
         // if the call succed, data will go here
         return sprintf(
@@ -64,7 +68,6 @@ $app->post('/send', function () use ($app) {
             json_encode($response->getData(), JSON_PRETTY_PRINT)
         );
     }
-
     return 'Error: ' . print_r($response->getStatus(), true);
     # [END send_email]
 });

--- a/appengine/flexible/mailjet/app.php
+++ b/appengine/flexible/mailjet/app.php
@@ -42,23 +42,23 @@ $app->post('/send', function () use ($app) {
     $recipient = $request->get('recipient');
     # [START send_email]
     $body = [
-    'Messages' => [
-        [
-            'From' => [
-                'Email' => "pilot@mailjet.com",
-                'Name' => "Mailjet Pilot"
-            ],
-            'To' => [
-                [
-                    'Email' => $recipient
-                ]
-            ],
-            'Subject' => "Your email flight plan!",
-            'TextPart' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
-            'HTMLPart' => "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!"
+        'Messages' => [
+            [
+                'From' => [
+                    'Email' => "pilot@mailjet.com",
+                    'Name' => "Mailjet Pilot"
+                ],
+                'To' => [
+                    [
+                        'Email' => $recipient
+                    ]
+                ],
+                'Subject' => "Your email flight plan!",
+                'TextPart' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
+                'HTMLPart' => "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!"
+            ]
         ]
-    ]
-];
+    ];
     // trigger the API call
     $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3']);
     if ($response->success()) {

--- a/appengine/flexible/mailjet/app.php
+++ b/appengine/flexible/mailjet/app.php
@@ -60,7 +60,7 @@ $app->post('/send', function () use ($app) {
         ]
     ];
     // trigger the API call
-    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3']);
+    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3.1']);
     if ($response->success()) {
         // if the call succed, data will go here
         return sprintf(

--- a/appengine/flexible/mailjet/composer.json
+++ b/appengine/flexible/mailjet/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "silex/silex": "^1.3",
-        "mailjet/mailjet-apiv3-php": "^1.1",
+        "mailjet/mailjet-apiv3-php": "^1.2",
         "guzzlehttp/guzzle": "~6.1.0"
     },
     "require-dev": {

--- a/appengine/standard/mailjet/app.php
+++ b/appengine/standard/mailjet/app.php
@@ -40,23 +40,27 @@ $app->post('/send', function () use ($app) {
     /** @var Mailjet\Client $mailjet */
     $mailjet = $app['mailjet'];
     $recipient = $request->get('recipient');
-
     # [START send_email]
     $body = [
-        'FromEmail' => "test@example.com",
-        'FromName' => "Testing Mailjet",
-        'Subject' => "Your email flight plan!",
-        'Text-part' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
-        'Html-part' => "<h3>Dear passenger, welcome to Mailjet!</h3><br/>May the delivery force be with you!",
-        'Recipients' => [
-            [
-                'Email' => $recipient,
-            ]
+    'Messages' => [
+        [
+            'From' => [
+                'Email' => "pilot@mailjet.com",
+                'Name' => "Mailjet Pilot"
+            ],
+            'To' => [
+                [
+                    'Email' => $recipient
+                ]
+            ],
+            'Subject' => "Your email flight plan!",
+            'TextPart' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
+            'HTMLPart' => "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!"
         ]
-    ];
-
+    ]
+];
     // trigger the API call
-    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body]);
+    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3']);
     if ($response->success()) {
         // if the call succed, data will go here
         return sprintf(
@@ -64,7 +68,6 @@ $app->post('/send', function () use ($app) {
             json_encode($response->getData(), JSON_PRETTY_PRINT)
         );
     }
-
     return 'Error: ' . print_r($response->getStatus(), true);
     # [END send_email]
 });

--- a/appengine/standard/mailjet/app.php
+++ b/appengine/standard/mailjet/app.php
@@ -42,23 +42,23 @@ $app->post('/send', function () use ($app) {
     $recipient = $request->get('recipient');
     # [START send_email]
     $body = [
-    'Messages' => [
-        [
-            'From' => [
-                'Email' => "pilot@mailjet.com",
-                'Name' => "Mailjet Pilot"
-            ],
-            'To' => [
-                [
-                    'Email' => $recipient
-                ]
-            ],
-            'Subject' => "Your email flight plan!",
-            'TextPart' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
-            'HTMLPart' => "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!"
+        'Messages' => [
+            [
+                'From' => [
+                    'Email' => "pilot@mailjet.com",
+                    'Name' => "Mailjet Pilot"
+                ],
+                'To' => [
+                    [
+                        'Email' => $recipient
+                    ]
+                ],
+                'Subject' => "Your email flight plan!",
+                'TextPart' => "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
+                'HTMLPart' => "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!"
+            ]
         ]
-    ]
-];
+    ];
     // trigger the API call
     $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3']);
     if ($response->success()) {

--- a/appengine/standard/mailjet/app.php
+++ b/appengine/standard/mailjet/app.php
@@ -60,7 +60,7 @@ $app->post('/send', function () use ($app) {
         ]
     ];
     // trigger the API call
-    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3']);
+    $response = $mailjet->post(Mailjet\Resources::$Email, ['body' => $body], ['version' => 'v3.1']);
     if ($response->success()) {
         // if the call succed, data will go here
         return sprintf(

--- a/appengine/standard/mailjet/composer.json
+++ b/appengine/standard/mailjet/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "silex/silex": "^1.3",
-        "mailjet/mailjet-apiv3-php": "^1.1",
+        "mailjet/mailjet-apiv3-php": "^1.2",
         "guzzlehttp/guzzle": "~6.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Mailjet Send API v3.1 is being released, so updating the code samples to match the new Send API v3.1 configuration. Reference can be found [here](https://dev.mailjet.com/beta/).
