### PR TITLE
Speech: Print out all results.

### DIFF
--- a/speech/quickstart.php
+++ b/speech/quickstart.php
@@ -43,8 +43,8 @@ $options = [
 # Detects speech in the audio file
 $results = $speech->recognize(fopen($fileName, 'r'), $options);
 
-foreach ($results[0]->alternatives() as $alternative) {
-    echo 'Transcription: ' . $alternative['transcript'] . PHP_EOL;
+foreach ($results as $result) {
+    echo 'Transcription: ' . $result->alternatives()[0]['transcript'] . PHP_EOL;
 }
 
 # [END speech_quickstart]

--- a/speech/src/transcribe_async.php
+++ b/speech/src/transcribe_async.php
@@ -67,8 +67,9 @@ function transcribe_async($audioFile, $languageCode = 'en-US', $options = [])
 
     // Print the results
     if ($operation->isComplete()) {
-        $alternatives = $operation->results()[0]->alternatives();
-        foreach ($alternatives as $alternative) {
+        $results = $operation->results();
+        foreach ($results as $result) {
+            $alternative = $result->alternatives()[0];
             printf('Transcript: %s' . PHP_EOL, $alternative['transcript']);
             printf('Confidence: %s' . PHP_EOL, $alternative['confidence']);
         }

--- a/speech/src/transcribe_async_gcs.php
+++ b/speech/src/transcribe_async_gcs.php
@@ -73,8 +73,9 @@ function transcribe_async_gcs($bucketName, $objectName, $languageCode = 'en-US',
 
     // Print the results
     if ($operation->isComplete()) {
-        $alternatives = $operation->results()[0]->alternatives();
-        foreach ($alternatives as $alternative) {
+        $results = $operation->results();
+        foreach ($results as $result) {
+            $alternative = $result->alternatives()[0];
             printf('Transcript: %s' . PHP_EOL, $alternative['transcript']);
             printf('Confidence: %s' . PHP_EOL, $alternative['confidence']);
         }

--- a/speech/src/transcribe_async_words.php
+++ b/speech/src/transcribe_async_words.php
@@ -70,8 +70,9 @@ function transcribe_async_words($audioFile, $languageCode = 'en-US', $options = 
 
     // Print the results
     if ($operation->isComplete()) {
-        $alternatives = $operation->results()[0]->alternatives();
-        foreach ($alternatives as $alternative) {
+        $results = $operation->results();
+        foreach ($results as $result) {
+            $alternative = $result->alternatives()[0];
             printf('Transcript: %s' . PHP_EOL, $alternative['transcript']);
             printf('Confidence: %s' . PHP_EOL, $alternative['confidence']);
             foreach ($alternative['words'] as $wordInfo) {

--- a/speech/src/transcribe_sync.php
+++ b/speech/src/transcribe_sync.php
@@ -54,8 +54,8 @@ function transcribe_sync($audioFile, $languageCode = 'en-US', $options = [])
     );
 
     // Print the results
-    $alternatives = $results[0]->alternatives();
-    foreach ($alternatives as $alternative) {
+    foreach ($results as $result) {
+        $alternative = $result->alternatives()[0];
         printf('Transcript: %s' . PHP_EOL, $alternative['transcript']);
         printf('Confidence: %s' . PHP_EOL, $alternative['confidence']);
     }

--- a/speech/src/transcribe_sync_gcs.php
+++ b/speech/src/transcribe_sync_gcs.php
@@ -59,8 +59,8 @@ function transcribe_sync_gcs($bucketName, $objectName, $languageCode = 'en-US', 
     );
 
     // Print the results
-    $alternatives = $results[0]->alternatives();
-    foreach ($alternatives as $alternative) {
+    foreach ($results as $result) {
+        $alternative = $result->alternatives()[0];
         printf('Transcript: %s' . PHP_EOL, $alternative['transcript']);
         printf('Confidence: %s' . PHP_EOL, $alternative['confidence']);
     }

--- a/speech/src/transcribe_sync_words.php
+++ b/speech/src/transcribe_sync_words.php
@@ -57,8 +57,8 @@ function transcribe_sync_words($audioFile, $languageCode = 'en-US', $options = [
     );
 
     // Print the results
-    $alternatives = $results[0]->alternatives();
-    foreach ($alternatives as $alternative) {
+    foreach ($results as $result) {
+        $alternative = $result->alternatives();
         printf('Transcript: %s' . PHP_EOL, $alternative['transcript']);
         printf('Confidence: %s' . PHP_EOL, $alternative['confidence']);
         foreach ($alternative['words'] as $wordInfo) {


### PR DESCRIPTION
There was some confusion where folks thought the API was only transcribing the first portion of the audio, when in fact it was because they were only using the first result. I'm updating the samples to try to reduce that confusion. See b/64934785