### PR TITLE
Fix link to latest WordPress version

### DIFF
--- a/appengine/wordpress/src/WordPressSetup.php
+++ b/appengine/wordpress/src/WordPressSetup.php
@@ -29,7 +29,7 @@ class WordPressSetup extends Command
 {
     const DEFAULT_DIR = 'my-wordpress-project';
     const DEFAULT_ERROR = 1;
-    const LATEST_WP = 'https://wordpress.org/4.8.1.tar.gz';
+    const LATEST_WP = 'https://wordpress.org/wordpress-4.8.2.tar.gz';
     const LATEST_BATCACHE =
         'https://downloads.wordpress.org/plugin/batcache.1.4.zip';
     const LATEST_MEMCACHED =


### PR DESCRIPTION
As it is, without this fix, WordPress setup is broken as the link is not valid without the `wordpress-` bit. Updated to the latest patch because might as well. Thanks!