### PR TITLE
IAP test fix 

### DIFF
--- a/iap/test/iapTest.php
+++ b/iap/test/iapTest.php
@@ -58,7 +58,6 @@ class iapTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Printing user identity information from ID token payload:', $output);
         $this->assertContains('sub: accounts.google.com', $output);
         $this->assertContains('email:', $output);
-        $this->assertContains($projectId, $output);
     }
 
     private function runCommand($name, $options = [])


### PR DESCRIPTION
This is necessary for Travis tests since we are now using different projects for IAP service account and IAP-protected App Engine app.