### PR TITLE
Add PHP 7.2 support for IAP

### DIFF
--- a/iap/composer.json
+++ b/iap/composer.json
@@ -2,8 +2,7 @@
     "require": {
         "symfony/console": "^2.8",
         "google/auth":"^1.2",
-        "lcobucci/jwt": "^3.2",
-        "mdanter/ecc":"^0.3.2"
+        "spomky-labs/jose": "^6.1|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/iap/src/validate_jwt.php
+++ b/iap/src/validate_jwt.php
@@ -24,10 +24,8 @@
 namespace Google\Cloud\Samples\Iap;
 
 # Imports OAuth Guzzle HTTP libraries.
-use GuzzleHttp\Client;
-use Lcobucci\JWT\Parser;
-use Lcobucci\JWT\ValidationData;
-use Lcobucci\JWT\Signer\Ecdsa\Sha256;
+use Jose\Factory\JWKFactory;
+use Jose\Loader;
 
 /**
  * Validate a JWT passed to your App Engine app by Identity-Aware Proxy.
@@ -76,27 +74,23 @@ function validate_jwt_from_compute_engine($iap_jwt, $cloud_project_number, $back
 
 function validate_jwt($iap_jwt, $expected_audience)
 {
-    // Validate the algorithm and kid headers. Also fetch the public key using the kid.
-    $token = (new Parser())->parse((string) $iap_jwt); // Parses from a string
-    $algorithm = $token->getHeader('alg');
-    assert($algorithm =='ES256');
-    $kid = $token->getHeader('kid');
-    $client = new Client(['base_uri' => 'https://www.gstatic.com/']);
-    $response = $client->request('GET', 'iap/verify/public_key');
-    $body_content = json_decode((string) $response->getBody());
-    $public_key = $body_content->$kid;
+    // Create a JWK Key Set from the gstatic URL
+    $jwk_set = JWKFactory::createFromJKU('https://www.gstatic.com/iap/verify/public_key-jwk');
 
-    // Validate token by checking issuer and audience fields. The JWT library automatically checks the time constraints.
-    $data = new ValidationData();
-    $data->setIssuer('https://cloud.google.com/iap');
-    $data->setAudience($expected_audience);
-    assert($token->validate($data));
+    // Validate the signature using the key set and ES256 algorithm.
+    $loader = new Loader();
+    $jws = $loader->loadAndVerifySignatureUsingKeySet(
+        $iap_jwt,
+        $jwk_set,
+        ['ES256'],
+        $signature_index
+    );
 
-    // Verify the signature using the JWT library.
-    $signer = new Sha256();
-    assert($token->verify($signer, $public_key));
+    // Validate token by checking issuer and audience fields.
+    assert($jws->getClaim('iss') == 'https://cloud.google.com/iap');
+    assert($jws->getClaim('aud') == $expected_audience);
 
     // Return the user identity (subject and user email) if JWT verification is successful.
-    return array('sub' => $token->getClaim('sub'), 'email' => $token->getClaim('email'));
+    return array('sub' => $jws->getClaim('sub'), 'email' => $jws->getClaim('email'));
 }
 # [END validate_jwt]

--- a/iap/src/validate_jwt.php
+++ b/iap/src/validate_jwt.php
@@ -82,8 +82,7 @@ function validate_jwt($iap_jwt, $expected_audience)
     $jws = $loader->loadAndVerifySignatureUsingKeySet(
         $iap_jwt,
         $jwk_set,
-        ['ES256'],
-        $signature_index
+        ['ES256']
     );
 
     // Validate token by checking issuer and audience fields.


### PR DESCRIPTION
Adds PHP 7.2 support to IAP samples by using a different JWT library which supports PHP 7.2


