### PR TITLE
Change to endpoints managed rollout

### DIFF
--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -14,5 +14,5 @@ endpoints_api_service:
   #     gcloud endpoints configs list --service=YOUR-PROJECT-ID.appspot.com
   #
   name: ENDPOINTS-SERVICE-NAME
-  config_id: ENDPOINTS-CONFIG-ID
+  rollout_strategy: managed
 # [END configuration]

--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           "--http_port", "8081",
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
-          "--version", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
         ]
       # [END esp]
         ports:


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag:
**--version=SERVICE_CONFIG_ID**