### PR TITLE
Add available db regions

### DIFF
--- a/appengine/wordpress/src/WordPressSetup.php
+++ b/appengine/wordpress/src/WordPressSetup.php
@@ -45,10 +45,19 @@ class WordPressSetup extends Command
     const DEFAULT_DB_REGION = 'us-central1';
 
     private static $availableDbRegions = array(
+        'us-central',
         'us-central1',
         'us-east1',
+        'us-east4',
+        'us-west1',
+        'southamerica-east1',
         'europe-west1',
+        'europe-west2',
+        'europe-west3',
         'asia-east1',
+        'asia-northeast1',
+        'asia-south1',
+        'australia-southeast1',
     );
 
     protected function configure()


### PR DESCRIPTION
If we run `php wordpress-helper.php setup` with the option like `--db_region=asia-northeast1`, the value of the region in `app.yml` and `wp-config.php` will be empty, because some regions are not defined.

This PR adds those regions to `wordpress-helper.php`.