### PR TITLE
Add wp-cli.yml into the WordPress project

### DIFF
--- a/appengine/wordpress/src/WordPressSetup.php
+++ b/appengine/wordpress/src/WordPressSetup.php
@@ -350,6 +350,7 @@ class WordPressSetup extends Command
                 'cron.yaml' => '/',
                 'composer.json' => '/',
                 'php.ini' => '/',
+                'wp-cli.yml' => '/',
                 'wp-config.php' => '/wordpress/',
             );
             $templateDir = __DIR__ . '/files/standard';
@@ -373,6 +374,7 @@ class WordPressSetup extends Command
                 'composer.json' => '/',
                 'nginx-app.conf' => '/',
                 'php.ini' => '/',
+                'wp-cli.yml' => '/',
                 'wp-config.php' => '/wordpress/',
             );
             $templateDir = __DIR__ . '/files/flexible';

--- a/appengine/wordpress/src/files/flexible/wp-cli.yml
+++ b/appengine/wordpress/src/files/flexible/wp-cli.yml
@@ -1,0 +1,1 @@
+path: wordpress

--- a/appengine/wordpress/src/files/standard/wp-cli.yml
+++ b/appengine/wordpress/src/files/standard/wp-cli.yml
@@ -1,0 +1,1 @@
+path: wordpress


### PR DESCRIPTION
`wp-cli.yml` is a configuration file for the WP-CLI command.
If there is the file, we can run WP-CLI command without `--path` parameter under the `wordpress-project` directory.
And also, we can launch local development server with `wp server` command to browse `http://localhost:8080`.
The combination of `cloud_sql_proxy` and `wp server` is very nice for me.

Thanks!