### PR TITLE
Add DLP code samples for custom info types

### DIFF
--- a/dlp/src/inspect_bigquery.php
+++ b/dlp/src/inspect_bigquery.php
@@ -20,6 +20,10 @@ namespace Google\Cloud\Samples\Dlp;
 # [START dlp_inspect_bigquery]
 use Google\Cloud\Dlp\V2\DlpServiceClient;
 use Google\Cloud\Dlp\V2\BigQueryOptions;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary_WordList;
+use Google\Cloud\Dlp\V2\CustomInfoType_Regex;
 use Google\Cloud\Dlp\V2\InfoType;
 use Google\Cloud\Dlp\V2\InspectConfig;
 use Google\Cloud\Dlp\V2\StorageConfig;
@@ -64,6 +68,28 @@ function inspect_bigquery(
         ->setName('CREDIT_CARD_NUMBER');
     $infoTypes = [$personNameInfoType, $creditCardNumberInfoType];
 
+    // Custom info type of doctor names.
+    $doctorNamesTypeName = (new InfoType())
+        ->setName('DOCTOR_NAMES');
+    $doctorNamesTypePhrases = ['Dr. Smith', 'Dr. Jones'];
+    $doctorNamesTypeWordList = (new CustomInfoType_Dictionary_WordList())
+        ->setWords($doctorNamesTypePhrases);
+    $doctorNamesTypeDictionary = (new CustomInfoType_Dictionary())
+        ->setWordList($doctorNamesTypeWordList);
+    $doctorNamesType = (new CustomInfoType())
+        ->setInfoType($doctorNamesTypeName)
+        ->setDictionary($doctorNamesTypeDictionary);
+    // Custom info type of medical record number.
+    $medicalRecordNumberTypeName = (new InfoType())
+        ->setName('MEDICAL_RECORD_NUMBER');
+    $medicalRecordNumberTypeRegex = (new CustomInfoType_Regex())
+        ->setPattern('\\d-\\d{6}-\\d{2}');
+    $medicalRecordNumberType = (new CustomInfoType())
+        ->setInfoType($medicalRecordNumberTypeName)
+        ->setRegex($medicalRecordNumberTypeRegex);
+    // The customInfoTypes to match
+    $customInfoTypes = [$doctorNamesType, $medicalRecordNumberType];
+
     // The minimum likelihood required before returning a match
     $minLikelihood = likelihood::LIKELIHOOD_UNSPECIFIED;
 
@@ -87,7 +113,8 @@ function inspect_bigquery(
     $inspectConfig = (new InspectConfig())
         ->setMinLikelihood($minLikelihood)
         ->setLimits($limits)
-        ->setInfoTypes($infoTypes);
+        ->setInfoTypes($infoTypes)
+        ->setCustomInfoTypes($customInfoTypes);
 
     // Construct the action to run when job completes
     $pubSubAction = (new Action_PublishToPubSub())

--- a/dlp/src/inspect_datastore.php
+++ b/dlp/src/inspect_datastore.php
@@ -20,6 +20,10 @@ namespace Google\Cloud\Samples\Dlp;
 # [START dlp_inspect_datastore]
 use Google\Cloud\Dlp\V2\DlpServiceClient;
 use Google\Cloud\Dlp\V2\DatastoreOptions;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary_WordList;
+use Google\Cloud\Dlp\V2\CustomInfoType_Regex;
 use Google\Cloud\Dlp\V2\InfoType;
 use Google\Cloud\Dlp\V2\Action;
 use Google\Cloud\Dlp\V2\Action_PublishToPubSub;
@@ -66,6 +70,28 @@ function inspect_datastore(
         ->setName('PHONE_NUMBER');
     $infoTypes = [$personNameInfoType, $phoneNumberInfoType];
 
+    // Custom info type of doctor names.
+    $doctorNamesTypeName = (new InfoType())
+        ->setName('DOCTOR_NAMES');
+    $doctorNamesTypePhrases = ['Dr. Smith', 'Dr. Jones'];
+    $doctorNamesTypeWordList = (new CustomInfoType_Dictionary_WordList())
+        ->setWords($doctorNamesTypePhrases);
+    $doctorNamesTypeDictionary = (new CustomInfoType_Dictionary())
+        ->setWordList($doctorNamesTypeWordList);
+    $doctorNamesType = (new CustomInfoType())
+        ->setInfoType($doctorNamesTypeName)
+        ->setDictionary($doctorNamesTypeDictionary);
+    // Custom info type of medical record number.
+    $medicalRecordNumberTypeName = (new InfoType())
+        ->setName('MEDICAL_RECORD_NUMBER');
+    $medicalRecordNumberTypeRegex = (new CustomInfoType_Regex())
+        ->setPattern('\\d-\\d{6}-\\d{2}');
+    $medicalRecordNumberType = (new CustomInfoType())
+        ->setInfoType($medicalRecordNumberTypeName)
+        ->setRegex($medicalRecordNumberTypeRegex);
+    // The customInfoTypes to match
+    $customInfoTypes = [$doctorNamesType, $medicalRecordNumberType];
+
     // The minimum likelihood required before returning a match
     $minLikelihood = likelihood::LIKELIHOOD_UNSPECIFIED;
 
@@ -88,6 +114,7 @@ function inspect_datastore(
     // Construct the inspect config object
     $inspectConfig = (new InspectConfig())
         ->setInfoTypes($infoTypes)
+        ->setCustomInfoTypes($customInfoTypes)
         ->setMinLikelihood($minLikelihood)
         ->setLimits($limits);
 

--- a/dlp/src/inspect_file.php
+++ b/dlp/src/inspect_file.php
@@ -20,6 +20,10 @@ namespace Google\Cloud\Samples\Dlp;
 # [START dlp_inspect_file]
 use Google\Cloud\Dlp\V2\DlpServiceClient;
 use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary_WordList;
+use Google\Cloud\Dlp\V2\CustomInfoType_Regex;
 use Google\Cloud\Dlp\V2\InfoType;
 use Google\Cloud\Dlp\V2\InspectConfig;
 use Google\Cloud\Dlp\V2\Likelihood;
@@ -48,6 +52,28 @@ function inspect_file(
         ->setName('PHONE_NUMBER');
     $infoTypes = [$usNameInfoType, $phoneNumberInfoType];
 
+    // Custom info type of doctor names.
+    $doctorNamesTypeName = (new InfoType())
+        ->setName('DOCTOR_NAMES');
+    $doctorNamesTypePhrases = ['Dr. Smith', 'Dr. Jones'];
+    $doctorNamesTypeWordList = (new CustomInfoType_Dictionary_WordList())
+        ->setWords($doctorNamesTypePhrases);
+    $doctorNamesTypeDictionary = (new CustomInfoType_Dictionary())
+        ->setWordList($doctorNamesTypeWordList);
+    $doctorNamesType = (new CustomInfoType())
+        ->setInfoType($doctorNamesTypeName)
+        ->setDictionary($doctorNamesTypeDictionary);
+    // Custom info type of medical record number.
+    $medicalRecordNumberTypeName = (new InfoType())
+        ->setName('MEDICAL_RECORD_NUMBER');
+    $medicalRecordNumberTypeRegex = (new CustomInfoType_Regex())
+        ->setPattern('\\d-\\d{6}-\\d{2}');
+    $medicalRecordNumberType = (new CustomInfoType())
+        ->setInfoType($medicalRecordNumberTypeName)
+        ->setRegex($medicalRecordNumberTypeRegex);
+    // The customInfoTypes to match
+    $customInfoTypes = [$doctorNamesType, $medicalRecordNumberType];
+
     // The minimum likelihood required before returning a match
     $minLikelihood = likelihood::LIKELIHOOD_UNSPECIFIED;
 
@@ -63,6 +89,7 @@ function inspect_file(
         ->setMinLikelihood($minLikelihood)
         ->setLimits($limits)
         ->setInfoTypes($infoTypes)
+        ->setCustomInfoTypes($customInfoTypes)
         ->setIncludeQuote($includeQuote);
 
     // Create the content item objects

--- a/dlp/src/inspect_gcs.php
+++ b/dlp/src/inspect_gcs.php
@@ -21,6 +21,10 @@ namespace Google\Cloud\Samples\Dlp;
 use Google\Cloud\Dlp\V2\DlpServiceClient;
 use Google\Cloud\Dlp\V2\CloudStorageOptions;
 use Google\Cloud\Dlp\V2\CloudStorageOptions_FileSet;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary_WordList;
+use Google\Cloud\Dlp\V2\CustomInfoType_Regex;
 use Google\Cloud\Dlp\V2\InfoType;
 use Google\Cloud\Dlp\V2\InspectConfig;
 use Google\Cloud\Dlp\V2\StorageConfig;
@@ -63,6 +67,28 @@ function inspect_gcs(
         ->setName('CREDIT_CARD_NUMBER');
     $infoTypes = [$personNameInfoType, $creditCardNumberInfoType];
 
+    // Custom info type of doctor names.
+    $doctorNamesTypeName = (new InfoType())
+        ->setName('DOCTOR_NAMES');
+    $doctorNamesTypePhrases = ['Dr. Smith', 'Dr. Jones'];
+    $doctorNamesTypeWordList = (new CustomInfoType_Dictionary_WordList())
+        ->setWords($doctorNamesTypePhrases);
+    $doctorNamesTypeDictionary = (new CustomInfoType_Dictionary())
+        ->setWordList($doctorNamesTypeWordList);
+    $doctorNamesType = (new CustomInfoType())
+        ->setInfoType($doctorNamesTypeName)
+        ->setDictionary($doctorNamesTypeDictionary);
+    // Custom info type of medical record number.
+    $medicalRecordNumberTypeName = (new InfoType())
+        ->setName('MEDICAL_RECORD_NUMBER');
+    $medicalRecordNumberTypeRegex = (new CustomInfoType_Regex())
+        ->setPattern('\\d-\\d{6}-\\d{2}');
+    $medicalRecordNumberType = (new CustomInfoType())
+        ->setInfoType($medicalRecordNumberTypeName)
+        ->setRegex($medicalRecordNumberTypeRegex);
+    // The customInfoTypes to match
+    $customInfoTypes = [$doctorNamesType, $medicalRecordNumberType];
+
     // The minimum likelihood required before returning a match
     $minLikelihood = likelihood::LIKELIHOOD_UNSPECIFIED;
 
@@ -84,7 +110,8 @@ function inspect_gcs(
     $inspectConfig = (new InspectConfig())
         ->setMinLikelihood($minLikelihood)
         ->setLimits($limits)
-        ->setInfoTypes($infoTypes);
+        ->setInfoTypes($infoTypes)
+        ->setCustomInfoTypes($customInfoTypes);
 
     // Construct the action to run when job completes
     $pubSubAction = (new Action_PublishToPubSub())

--- a/dlp/src/inspect_string.php
+++ b/dlp/src/inspect_string.php
@@ -20,6 +20,10 @@ namespace Google\Cloud\Samples\Dlp;
 # [START dlp_inspect_string]
 use Google\Cloud\Dlp\V2\DlpServiceClient;
 use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType_Dictionary_WordList;
+use Google\Cloud\Dlp\V2\CustomInfoType_Regex;
 use Google\Cloud\Dlp\V2\InfoType;
 use Google\Cloud\Dlp\V2\InspectConfig;
 use Google\Cloud\Dlp\V2\Likelihood;
@@ -47,6 +51,28 @@ function inspect_string(
         ->setName('PHONE_NUMBER');
     $infoTypes = [$personNameInfoType, $phoneNumberInfoType];
 
+    // Custom info type of doctor names.
+    $doctorNamesTypeName = (new InfoType())
+        ->setName('DOCTOR_NAMES');
+    $doctorNamesTypePhrases = ['Dr. Smith', 'Dr. Jones'];
+    $doctorNamesTypeWordList = (new CustomInfoType_Dictionary_WordList())
+        ->setWords($doctorNamesTypePhrases);
+    $doctorNamesTypeDictionary = (new CustomInfoType_Dictionary())
+        ->setWordList($doctorNamesTypeWordList);
+    $doctorNamesType = (new CustomInfoType())
+        ->setInfoType($doctorNamesTypeName)
+        ->setDictionary($doctorNamesTypeDictionary);
+    // Custom info type of medical record number.
+    $medicalRecordNumberTypeName = (new InfoType())
+        ->setName('MEDICAL_RECORD_NUMBER');
+    $medicalRecordNumberTypeRegex = (new CustomInfoType_Regex())
+        ->setPattern('\\d-\\d{6}-\\d{2}');
+    $medicalRecordNumberType = (new CustomInfoType())
+        ->setInfoType($medicalRecordNumberTypeName)
+        ->setRegex($medicalRecordNumberTypeRegex);
+    // The customInfoTypes to match
+    $customInfoTypes = [$doctorNamesType, $medicalRecordNumberType];
+
     // The minimum likelihood required before returning a match
     $minLikelihood = likelihood::LIKELIHOOD_UNSPECIFIED;
 
@@ -62,6 +88,7 @@ function inspect_string(
         ->setMinLikelihood($minLikelihood)
         ->setLimits($limits)
         ->setInfoTypes($infoTypes)
+        ->setCustomInfoTypes($customInfoTypes)
         ->setIncludeQuote($includeQuote);
 
     $content = (new ContentItem())

--- a/dlp/test/data/test.txt
+++ b/dlp/test/data/test.txt
@@ -1,1 +1,2 @@
 Robert Jordan wrote the Wheel of Time.
+The attending doctor for patient 0-256334-12 is Dr. Smith.

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -91,6 +91,8 @@ class dlpTest extends \PHPUnit_Framework_TestCase
             'path' => __DIR__ . '/data/test.txt'
         ]);
         $this->assertContains('PERSON_NAME', $output);
+        $this->assertContains('MEDICAL_RECORD_NUMBER', $output);
+        $this->assertContains('DOCTOR_NAMES', $output);
 
         // inspect an image file with results
         $output = $this->runCommand('inspect-file', [
@@ -123,6 +125,14 @@ class dlpTest extends \PHPUnit_Framework_TestCase
             'string' => 'The name Zolo is not very common.'
         ]);
         $this->assertContains('No findings', $output);
+
+        // inspect a string with custom info types
+        $output = $this->runCommand('inspect-string', [
+            'calling-project' => getenv('GOOGLE_PROJECT_ID'),
+            'string' => 'The attending doctor for patient 0-256334-12 is Dr. Smith.'
+        ]);
+        $this->assertContains('MEDICAL_RECORD_NUMBER', $output);
+        $this->assertContains('DOCTOR_NAMES', $output);
     }
 
     public function testListInfoTypes()


### PR DESCRIPTION
The DLP team is in the process of expanding code samples to include features that we have launched since the initial samples were written.

In this pull request, I updated inspect_*.php to include dictionary and regex based custom info types, along with some tests.