### PR TITLE
Delete unused Datastore region tags / samples. 

### DIFF
--- a/datastore/api/src/functions/concepts.php
+++ b/datastore/api/src/functions/concepts.php
@@ -18,9 +18,7 @@
 namespace Google\Cloud\Samples\Datastore;
 
 use DateTime;
-// [START datastore_use]
 use Google\Cloud\Datastore\DatastoreClient;
-// [END datastore_use]
 use Google\Cloud\Datastore\Entity;
 use Google\Cloud\Datastore\EntityIterator;
 use Google\Cloud\Datastore\Key;
@@ -33,9 +31,7 @@ use Google\Cloud\Datastore\Query\Query;
  */
 function initialize_client()
 {
-    // [START datastore_initialize_client]
     $datastore = new DatastoreClient();
-    // [END datastore_initialize_client]
     return $datastore;
 }
 


### PR DESCRIPTION
These samples/region tags aren't used on cloud.google.com, so I'm deleting them.

Related:

- GoogleCloudPlatform/python-docs-samples#1531
- googleapis/nodejs-datastore#110
- GoogleCloudPlatform/java-docs-samples#1138
- GoogleCloudPlatform/dotnet-docs-samples#569
- GoogleCloudPlatform/ruby-docs-samples#292
- GoogleCloudPlatform/golang-samples#516