### PR TITLE
Changed GOOGLE_BUCKET_NAME to GOOGLE_STORAGE_BUCKET

### DIFF
--- a/appengine/php72/getting-started/app.yaml
+++ b/appengine/php72/getting-started/app.yaml
@@ -2,10 +2,9 @@ runtime: php72
 instance_class: F2
 
 env_variables:
-    GOOGLE_BUCKET_NAME: ""
+    GOOGLE_STORAGE_BUCKET: ""
     # populate these to use the "mysql" or "postres" backends
     CLOUDSQL_CONNECTION_NAME: ""
     CLOUDSQL_USER: ""
     CLOUDSQL_PASSWORD: ""
-    ## Uncomment to give your database a name other than "bookshelf"
-    # CLOUDSQL_DATABASE_NAME: ""
+    CLOUDSQL_DATABASE_NAME: ""


### PR DESCRIPTION
I'm having users pick their own database names so thought removing the comment made sense.