### PR TITLE
[KMS] Remove global location from kms example to generalize for GCS

### DIFF
--- a/kms/src/functions.php
+++ b/kms/src/functions.php
@@ -41,10 +41,10 @@ use Google_Service_CloudKMS_UpdateCryptoKeyPrimaryVersionRequest;
  *        "serviceAccount:$serviceAccountEmail"
  * @param string $role Must be in the format "roles/$role",
  *        "organizations/$organizationId/roles/$role", or "projects/$projectId/roles/$role"
- * @param string $locationId [optional]
+ * @param string $locationId
  * @return null
  */
-function add_member_to_cryptokey_policy($projectId, $keyRingId, $cryptoKeyId, $member, $role, $locationId = 'global')
+function add_member_to_cryptokey_policy($projectId, $keyRingId, $cryptoKeyId, $member, $role, $locationId)
 {
     // Instantiate the client, authenticate, and add scopes.
     $client = new Google_Client();


### PR DESCRIPTION
Hi @bshaffer,

I'm removing global location mention to generalize sample for GCS CMEK documentation. The sample is used to show developers how to set an IAM policy on a KMS key, but global location aren't supported so I want to generalize that part of the sample.

PTAL, thank you!