### PR TITLE
Refactor BigQuery sample tests

### DIFF
--- a/bigquery/api/snippets/import_from_local_csv.php
+++ b/bigquery/api/snippets/import_from_local_csv.php
@@ -25,7 +25,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 if (count($argv) != 5) {
-    return print("Usage: php snippets/import_from_file.php PROJECT_ID DATASET_ID TABLE_ID SOURCE\n");
+    return print("Usage: php snippets/import_from_local_csv.php PROJECT_ID DATASET_ID TABLE_ID SOURCE\n");
 }
 
 list($_, $projectId, $datasetId, $tableId, $source) = $argv;

--- a/bigquery/api/snippets/import_from_storage_csv.php
+++ b/bigquery/api/snippets/import_from_storage_csv.php
@@ -30,7 +30,6 @@ if (count($argv) != 3) {
 list($_, $projectId, $datasetId) = $argv;
 # [START bigquery_load_table_gcs_csv]
 use Google\Cloud\BigQuery\BigQueryClient;
-use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Core\ExponentialBackoff;
 
 /** Uncomment and populate these variables in your code */

--- a/bigquery/api/snippets/import_from_storage_json.php
+++ b/bigquery/api/snippets/import_from_storage_json.php
@@ -28,7 +28,7 @@ if (count($argv) != 3) {
 }
 
 list($_, $projectId, $datasetId) = $argv;
-# [START bigquery_load_table_gcs_csv]
+# [START bigquery_load_table_gcs_json]
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Core\ExponentialBackoff;
@@ -70,4 +70,4 @@ if (isset($job->info()['status']['errorResult'])) {
 } else {
     print('Data imported successfully' . PHP_EOL);
 }
-# [END bigquery_load_table_gcs_csv]
+# [END bigquery_load_table_gcs_json]

--- a/bigquery/api/snippets/import_from_storage_json.php
+++ b/bigquery/api/snippets/import_from_storage_json.php
@@ -30,7 +30,6 @@ if (count($argv) != 3) {
 list($_, $projectId, $datasetId) = $argv;
 # [START bigquery_load_table_gcs_json]
 use Google\Cloud\BigQuery\BigQueryClient;
-use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Core\ExponentialBackoff;
 
 /** Uncomment and populate these variables in your code */

--- a/bigquery/api/test/bigqueryTest.php
+++ b/bigquery/api/test/bigqueryTest.php
@@ -242,14 +242,14 @@ class FunctionsTest extends TestCase
     public function testListDatasets()
     {
         $output = $this->runSnippet('list_datasets');
-        $this->assertContains('test_dataset', $output);
+        $this->assertContains(self::$datasetId, $output);
     }
 
     public function testListTables()
     {
-        $this->createTempEmptyTable();
+        $tempTableId = $this->createTempEmptyTable();
         $output = $this->runSnippet('list_tables', [self::$datasetId]);
-        $this->assertContains('test_table', $output);
+        $this->assertContains($tempTableId, $output);
     }
 
     public function testStreamRow()

--- a/bigquery/api/test/bigqueryTest.php
+++ b/bigquery/api/test/bigqueryTest.php
@@ -172,7 +172,7 @@ class FunctionsTest extends TestCase
         $tempTableId = $this->createTempEmptyTable();
 
         // run the import
-        $output = $this->runSnippet('import_from_file', [
+        $output = $this->runSnippet('import_from_local_csv', [
             self::$datasetId,
             $tempTableId,
             $source,
@@ -328,7 +328,7 @@ class FunctionsTest extends TestCase
     {
         $tempTableId = $this->createTempEmptyTable();
         $source = __DIR__ . '/data/test_data.csv';
-        $output = $this->runSnippet('import_from_file', [
+        $output = $this->runSnippet('import_from_local_csv', [
             self::$datasetId,
             $tempTableId,
             $source,

--- a/bigquery/api/test/data/test_data.sql
+++ b/bigquery/api/test/data/test_data.sql
@@ -1,4 +1,4 @@
--- This file is used to test ../../src/functions/import_from_file.php
+-- This file is used to test ../../snippets/insert_sql.php
 -- These are comments.
 -- Each query to be executed should be on a single line.
 


### PR DESCRIPTION
Tests can now be run without relying on the test runner having certain files in GCS and tables in BigQuery. The temporary dataset and tables are now generated during the test run and the GCS files are in the cloud samples bucket, which is consistent with canonical.