### PR TITLE
Update WP docs to install cli-bundle instead of cli-core

### DIFF
--- a/appengine/php72/wordpress/README.md
+++ b/appengine/php72/wordpress/README.md
@@ -166,7 +166,7 @@ as follows (be sure to keep the Cloud SQL proxy running):
 
 ```
 # Install the wp-cli utility
-$ composer require wp-cli/wp-cli
+$ composer require wp-cli/wp-cli-bundle
 # Now you can run the "wp" command to update Wordpress itself
 $ vendor/bin/wp core update --path=wordpress
 # You can also update all the plugins and themes


### PR DESCRIPTION
With only the core cli you can't run commands like plugin update, etc.  Installing cli-bundle now gets you what just installing -cli used to get you.