### PR TITLE
Fix typo in cloudsql cli argument

### DIFF
--- a/appengine/php72/wordpress/README.md
+++ b/appengine/php72/wordpress/README.md
@@ -35,8 +35,7 @@ command:
     ```
 1. Finally, change the root password for your instance:
     ```sh
-    $ gcloud sql users set-password root \
-        --host=% \
+    $ gcloud sql users set-password root % \
         --instance wordpress \
         --password=YOUR_INSTANCE_ROOT_PASSWORD # Don't use this password!
     ```


### PR DESCRIPTION
Switch "host" from a flag to an argument as expected by gcloud SK 195.0.0