### PR TITLE
Fix Google Storage broken link

### DIFF
--- a/appengine/php72/wordpress/README.md
+++ b/appengine/php72/wordpress/README.md
@@ -199,7 +199,7 @@ the production environment.
 [mysql-client]: https://dev.mysql.com/doc/refman/5.7/en/mysql.html
 [composer]: https://getcomposer.org/
 [cloud-console]: https://console.cloud.google.com/
-[cloud-storage-console]: https://www.console.cloud.google.com/storage
+[cloud-storage-console]: https://console.cloud.google.com/storage
 [cloud-sql-api-enable]: https://console.cloud.google.com/flows/enableapi?apiid=sqladmin
 [app-engine-setting]: https://console.cloud.google.com/appengine/settings
 [gcloud-sdk]: https://cloud.google.com/sdk/


### PR DESCRIPTION
Fix the Google Storage Console link. The "www" part does not work, it's broken.