### PR TITLE
Fix fragile translation test.

### DIFF
--- a/translate/test/quickstartTest.php
+++ b/translate/test/quickstartTest.php
@@ -43,6 +43,6 @@ class quickstartTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('text', $translation);
         $this->assertEquals('en', $translation['source']);
         $this->assertEquals('Hello, world!', $translation['input']);
-        $this->assertEquals('Привет мир!', $translation['text']);
+        $this->assertContains('мир', $translation['text']);
     }
 }


### PR DESCRIPTION
The test required an exact string match.  So as the translation API improved, the test broke.

Make the test less fragile by just confirming the Russian word for "world" appears in the output.