### PR TITLE
BigQuery: Fix extract table sample

### DIFF
--- a/bigquery/api/src/extract_table.php
+++ b/bigquery/api/src/extract_table.php
@@ -28,7 +28,7 @@ if (count($argv) != 5) {
     return printf("Usage: php %s PROJECT_ID DATASET_ID TABLE_ID BUCKET_NAME\n", __FILE__);
 }
 
-list($_, $projectId, $datasetId, $tableId, $bucketName, $objectName) = $argv;
+list($_, $projectId, $datasetId, $tableId, $bucketName) = $argv;
 
 # [START bigquery_extract_table]
 use Google\Cloud\BigQuery\BigQueryClient;

--- a/bigquery/api/test/bigqueryTest.php
+++ b/bigquery/api/test/bigqueryTest.php
@@ -111,10 +111,7 @@ class FunctionsTest extends TestCase
         $this->assertContains('Deleted table', $output);
     }
 
-    /**
-     * @dataProvider provideExtractTable
-     */
-    public function testExtractTable($objectName, $format)
+    public function testExtractTable()
     {
         $bucketName = $this->requireEnv('GOOGLE_STORAGE_BUCKET');
         $tableId = $this->createTempTable();
@@ -123,34 +120,20 @@ class FunctionsTest extends TestCase
         $output = $this->runSnippet('extract_table', [
             self::$datasetId,
             $tableId,
-            $bucketName,
-            $objectName,
-            $format,
+            $bucketName
         ]);
-
-        $this->assertContains('Data extracted successfully', $output);
 
         // verify the contents of the bucket
         $storage = new StorageClient([
             'projectId' => self::$projectId,
         ]);
-        $object = $storage->bucket($bucketName)->object($objectName);
+        $object = $storage->bucket($bucketName)->objects(['prefix' => $tableId])->current();
         $contents = $object->downloadAsString();
         $this->assertContains('Brent Shaffer', $contents);
         $this->assertContains('Takashi Matsuo', $contents);
         $this->assertContains('Jeffrey Rennie', $contents);
         $object->delete();
         $this->assertFalse($object->exists());
-    }
-
-    public function provideExtractTable()
-    {
-        $time = time();
-
-        return [
-            [sprintf('bigquery/test_data_%s.json', $time), 'json'],
-            [sprintf('bigquery/test_data_%s.csv', $time), 'csv'],
-        ];
     }
 
     public function testGetTable()


### PR DESCRIPTION
This PR fixes the extract table sample to properly set the file format. Previously, the format was being improperly set, which resulted in defaulting to 'CSV' every time. This was identified by an internal bug report. The sample now also follows the [python canonical sample](https://github.com/googleapis/google-cloud-python/blob/9908ed55bd9940852ca410a24a568c2c5c2d4f71/bigquery/docs/snippets.py#L1984) more closely, though the PHP library [cannot yet extract a public table](https://github.com/googleapis/google-cloud-php/issues/1512).