### PR TITLE
Adds file to run all tests in PR

### DIFF
--- a/testing/RUN_ALL_TESTS
+++ b/testing/RUN_ALL_TESTS
@@ -1,0 +1,2 @@
+# Modify this file with whitespace in a PR in order to run all tests for the PR.
+# See "testing/run_test_suite.sh" for more details.

--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -66,9 +66,7 @@ FILES_CHANGED=$(git diff --name-only HEAD $(git merge-base HEAD master))
 
 # If any files outside the sample directories changed, or if we are not
 # on a Pull Request, run the whole test suite.
-if grep -q ^testing\/ <<< "$FILES_CHANGED" || \
-   grep -v ^.kokoro\/secrets.sh.enc$ <<< "$FILES_CHANGED" | grep -q ^.kokoro\/ || \
-    grep -qv \/ <<< "$FILES_CHANGED" || \
+if grep -q ^testing\/RUN_ALL_TESTS$ <<< "$FILES_CHANGED" || \
     [ -z "$IS_PULL_REQUEST" ]; then
     RUN_ALL_TESTS=1
 else

--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -64,8 +64,8 @@ FAILED_FLAKY_FILE=${TMP_REPORT_DIR}/failed_flaky
 # (will be empty if running from "master").
 FILES_CHANGED=$(git diff --name-only HEAD $(git merge-base HEAD master))
 
-# If any files outside the sample directories changed, or if we are not
-# on a Pull Request, run the whole test suite.
+# If the file RUN_ALL_TESTS is modified, or if we were not triggered from a Pull
+# Request, run the whole test suite.
 if grep -q ^testing\/RUN_ALL_TESTS$ <<< "$FILES_CHANGED" || \
     [ -z "$IS_PULL_REQUEST" ]; then
     RUN_ALL_TESTS=1


### PR DESCRIPTION
It's a bit annoying when a sample modifies `.kokoro`, root, or `testing` files and then we have to wait for 3 hours for all tests to pass. This makes it so PRs *never* run the entire test suite unless the `testing/RUN_ALL_TESTS` file is modified. Otherwise they only run tests for samples in the directories of the files modified.

It's a bit of a hack but it's the best I've come up with. Thoughts?