### PR TITLE
add comment for clarification of authentication sample in docs

### DIFF
--- a/iot/src/create_registry.php
+++ b/iot/src/create_registry.php
@@ -38,7 +38,12 @@ function create_registry(
 ) {
     print('Creating Registry' . PHP_EOL);
 
-    // Instantiate a client.
+    // The Google Cloud Client Library automatically checks the environment
+    // variable GOOGLE_APPLICATION_CREDENTIALS for the Service Account
+    // credentials, and defaults scopes to [
+    //    'https://www.googleapis.com/auth/cloud-platform',
+    //    'https://www.googleapis.com/auth/cloudiot'
+    // ].
     $deviceManager = new DeviceManagerClient();
     $locationName = $deviceManager->locationName($projectId, $location);
 


### PR DESCRIPTION
add the comment about default credentials/scope for adding to this sample:
https://cloud.google.com/iot/docs/how-tos/credentials/authenticating-applications#iot-core-service-accounts-php

Currently it's pointing to list_registries.php, but to keep it consistent with other samples, we will point it to create_registry.php instead and add this comment.