### PR TITLE
Local fallback for compiled views

### DIFF
--- a/appengine/php72/laravel-framework/config/view.php
+++ b/appengine/php72/laravel-framework/config/view.php
@@ -29,6 +29,6 @@ return [
     |
     */
 
-    'compiled' => storage_path(),
+    'compiled' => isset($_SERVER['GAE_SERVICE']) ? storage_path() : env('VIEW_COMPILED_PATH', realpath(storage_path('framework/views'))),
     # [END google-app-engine-deployment]
 ];


### PR DESCRIPTION
If global server variable 'GAE_SERVICE' is not set, then we are in local environment and fallback to default Laravel behavior.