### PR TITLE
Update detect_intent_stream.php

### DIFF
--- a/dialogflow/src/detect_intent_stream.php
+++ b/dialogflow/src/detect_intent_stream.php
@@ -83,24 +83,24 @@ function detect_intent_stream($projectId, $path, $sessionId, $languageCode = 'en
         if ($recognitionResult) {
             $transcript = $recognitionResult->getTranscript();
             printf('Intermediate transcript: %s' . PHP_EOL, $transcript);
+        }else{
+            // get final response and relevant info
+            $queryResult = $response->getQueryResult();
+            $queryText = $queryResult->getQueryText();
+            $intent = $queryResult->getIntent();
+            $displayName = $intent->getDisplayName();
+            $confidence = $queryResult->getIntentDetectionConfidence();
+            $fulfilmentText = $queryResult->getFulfillmentText();
+
+            // output relevant info
+            printf('Query text: %s' . PHP_EOL, $queryText);
+            printf('Detected intent: %s (confidence: %f)' . PHP_EOL, $displayName,
+                $confidence);
+            print(PHP_EOL);
+            printf('Fulfilment text: %s' . PHP_EOL, $fulfilmentText);
         }
     }
     print(str_repeat("=", 20) . PHP_EOL);
-
-    // get final response and relevant info
-    $queryResult = $response->getQueryResult();
-    $queryText = $queryResult->getQueryText();
-    $intent = $queryResult->getIntent();
-    $displayName = $intent->getDisplayName();
-    $confidence = $queryResult->getIntentDetectionConfidence();
-    $fulfilmentText = $queryResult->getFulfillmentText();
-
-    // output relevant info
-    printf('Query text: %s' . PHP_EOL, $queryText);
-    printf('Detected intent: %s (confidence: %f)' . PHP_EOL, $displayName,
-        $confidence);
-    print(PHP_EOL);
-    printf('Fulfilment text: %s' . PHP_EOL, $fulfilmentText);
 
     $sessionsClient->close();
 }


### PR DESCRIPTION
The query result block was missing reference to the response. Hence it was throwing error "Fatal error: Uncaught Error: Call to a member function getQueryText() on null in ...". Moving it inside the loop fixes the issue.