### PR TITLE
Adds example for generating Cloud CDN Signed URLs

### DIFF
--- a/cdn/README.md
+++ b/cdn/README.md
@@ -1,0 +1,15 @@
+# Google Cloud CDN Sign URL
+
+PHP implementation of [`gcloud compute sign-url`](https://cloud.google.com/sdk/gcloud/reference/compute/sign-url) based on [Google Cloud CDN Documentation](https://cloud.google.com/cdn/docs/using-signed-urls#signing_urls).
+The provided file includes implementation of base64url encode and decode functions based on [RFC4648 Section 5](https://tools.ietf.org/html/rfc4648#section-5).
+
+## Usage
+
+```
+<?php
+  require_once 'signUrl.php';
+  $base64url_key = 'wpLL7f4VB9RNe_WI0BBGmA=='; // head -c 16 /dev/urandom | base64 | tr +/ -_
+  $signed_url = signUrl('https://example.com/foo', 'my-key', $base64url_key, time() + 1800);
+  echo $signed_url;
+?>
+```

--- a/cdn/phpunit.xml.dist
+++ b/cdn/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2018 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<phpunit bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Cloud CDN Sign URL Test">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+    <filter>
+        <whitelist>
+            <file>signUrl.php</file>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/cdn/phpunit.xml.dist
+++ b/cdn/phpunit.xml.dist
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="./vendor/autoload.php">
+<phpunit>
     <testsuites>
         <testsuite name="Cloud CDN Sign URL Test">
             <directory>test</directory>

--- a/cdn/signUrl.php
+++ b/cdn/signUrl.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START signed_url]
+/**
+ * Creates signed URL for Google Cloud CDN
+ * Details about order of operations: https://cloud.google.com/cdn/docs/using-signed-urls#creating_signed_urls
+ *
+ * @param string $url             URL of the endpoint served by Cloud CDN
+ * @param string $keyName         Name of the signing key added to the Google Cloud Storage bucket or service
+ * @param string $key             Signing key as base64 encoded string
+ * @param int    $expiration_time Expiration time as a UNIX timestamp (GMT, e.g. time())
+ */
+function signUrl($url, $keyName, $key, $expiration_time)
+{
+    // Decode the key
+    $decoded_key = base64_decode($key, true);
+
+    // Determine which separator makes sense given a URL
+    $separator = (strpos($url, '?') === false) ? '?' : '&';
+
+    // Concatenate url with expected query parameters Expires and KeyName
+    $url = "{$url}{$separator}Expires={$expiration_time}&KeyName={$keyName}";
+
+    // Sign the url using the key and encode the signature using base64
+    $signature = hash_hmac('sha1', $url, $decoded_key, true);
+    $encoded_signature = base64_encode($signature);
+
+    // Concatenate the URL and encoded signature
+    return "{$url}&Signature={$encoded_signature}";
+}
+// [END signed_url]
+
+// Example function call (In production store the key safely with other secrets)
+$base64_key = '4RfgBoqmotRolLCtU-82Ew=='; // head -c 16 /dev/urandom | base64 | tr +/ -_
+$signed_url = signUrl('https://example.com/foo', 'MY-KEY', $base64_key, time() + 1800);
+echo $signed_url."\n";

--- a/cdn/signUrl.php
+++ b/cdn/signUrl.php
@@ -51,34 +51,34 @@ function base64url_encode($input, $padding = true)
  * Example function invocation (In production store the key safely with other secrets):
  *
  *     <?php
- *     $base64url_key = 'wpLL7f4VB9RNe_WI0BBGmA=='; // head -c 16 /dev/urandom | base64 | tr +/ -_
- *     $signed_url = signUrl('https://example.com/foo', 'my-key', $base64url_key, time() + 1800);
- *     echo $signed_url;
+ *     $base64UrlKey = 'wpLL7f4VB9RNe_WI0BBGmA=='; // head -c 16 /dev/urandom | base64 | tr +/ -_
+ *     $signedUrl = sign_url('https://example.com/foo', 'my-key', $base64UrlKey, time() + 1800);
+ *     echo $signedUrl;
  *     ?>
  *
  * @param string $url             URL of the endpoint served by Cloud CDN
  * @param string $keyName         Name of the signing key added to the Google Cloud Storage bucket or service
- * @param string $base64url_key   Signing key as base64url (RFC4648 Section 5) encoded string
- * @param int    $expiration_time Expiration time as a UNIX timestamp (GMT, e.g. time())
+ * @param string $base64UrlKey    Signing key as base64url (RFC4648 Section 5) encoded string
+ * @param int    $expirationTime  Expiration time as a UNIX timestamp (GMT, e.g. time())
  *
  * @return string
  */
-function signUrl($url, $keyName, $base64url_key, $expiration_time)
+function sign_url($url, $keyName, $base64UrlKey, $expirationTime)
 {
     // Decode the key
-    $decoded_key = base64url_decode($base64url_key, true);
+    $decodedKey = base64url_decode($base64UrlKey, true);
 
     // Determine which separator makes sense given a URL
     $separator = (strpos($url, '?') === false) ? '?' : '&';
 
     // Concatenate url with expected query parameters Expires and KeyName
-    $url = "{$url}{$separator}Expires={$expiration_time}&KeyName={$keyName}";
+    $url = "{$url}{$separator}Expires={$expirationTime}&KeyName={$keyName}";
 
     // Sign the url using the key and encode the signature using base64url
-    $signature = hash_hmac('sha1', $url, $decoded_key, true);
-    $encoded_signature = base64url_encode($signature);
+    $signature = hash_hmac('sha1', $url, $decodedKey, true);
+    $encodedSignature = base64url_encode($signature);
 
     // Concatenate the URL and encoded signature
-    return "{$url}&Signature={$encoded_signature}";
+    return "{$url}&Signature={$encodedSignature}";
 }
 // [END signed_url]

--- a/cdn/test/signUrlTest.php
+++ b/cdn/test/signUrlTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__."/../signUrl.php";
+
+class signUrlTest extends TestCase
+{
+    public function testBase64UrlEncode()
+    {
+        $this->assertEquals(base64url_encode(hex2bin("9d9b51a2174d17d9b770a336e0870ae3")), "nZtRohdNF9m3cKM24IcK4w==");
+    }
+
+    public function testBase64UrlEncodeWithoutPadding()
+    {
+        $this->assertEquals(base64url_encode(hex2bin("9d9b51a2174d17d9b770a336e0870ae3"), false), "nZtRohdNF9m3cKM24IcK4w");
+    }
+
+    public function testBase64UrlDecode()
+    {
+        $this->assertEquals(hex2bin("9d9b51a2174d17d9b770a336e0870ae3"), base64url_decode("nZtRohdNF9m3cKM24IcK4w=="));
+    }
+
+    public function testBase64UrlDecodeWithoutPadding()
+    {
+        $this->assertEquals(hex2bin("9d9b51a2174d17d9b770a336e0870ae3"), base64url_decode("nZtRohdNF9m3cKM24IcK4w"));
+    }
+
+    public function testSignUrl()
+    {
+        $encoded_key="nZtRohdNF9m3cKM24IcK4w=="; // base64url encoded key
+
+        $cases = array(
+            array("http://35.186.234.33/index.html", "my-key", 1558131350,
+                  "http://35.186.234.33/index.html?Expires=1558131350&KeyName=my-key&Signature=fm6JZSmKNsB5sys8VGr-JE4LiiE="),
+            array("https://www.google.com/", "my-key", 1549751401,
+                  "https://www.google.com/?Expires=1549751401&KeyName=my-key&Signature=M_QO7BGHi2sGqrJO-MDr0uhDFuc="),
+            array("https://www.example.com/some/path?some=query&another=param", "my-key", 1549751461,
+                  "https://www.example.com/some/path?some=query&another=param&Expires=1549751461&KeyName=my-key&Signature=sTqqGX5hUJmlRJ84koAIhWW_c3M="),
+        );
+
+        foreach($cases as $c)
+        {
+            $this->assertEquals(signUrl($c[0], $c[1], $encoded_key, $c[2]), $c[3]);
+        }
+    }
+}

--- a/cdn/test/signUrlTest.php
+++ b/cdn/test/signUrlTest.php
@@ -56,7 +56,7 @@ class signUrlTest extends TestCase
 
         foreach($cases as $c)
         {
-            $this->assertEquals(signUrl($c[0], $c[1], $encoded_key, $c[2]), $c[3]);
+            $this->assertEquals(sign_url($c[0], $c[1], $encoded_key, $c[2]), $c[3]);
         }
     }
 }


### PR DESCRIPTION
Example implementation of generating URL signature for Cloud CDN.
Based on: https://cloud.google.com/cdn/docs/using-signed-urls#creating_signed_urls

@ahmetb 