### PR TITLE
Fixes link to https://cloud.google.com/kms.

### DIFF
--- a/kms/README.md
+++ b/kms/README.md
@@ -7,8 +7,7 @@
 
 ## Description
 
-These samples show how to use the [Google Cloud KMS API]
-(https://cloud.google.com/kms/).
+These samples show how to use the [Google Cloud KMS API](https://cloud.google.com/kms/).
 
 ## Build and Run
 1.  **Enable APIs** - [Enable the KMS API](https://console.cloud.google.com/flows/enableapi?apiid=cloudkms.googleapis.com)


### PR DESCRIPTION
If the link spans 2 lines, the link won't render correctly.