### PR TITLE
Update README.md

### DIFF
--- a/appengine/flexible/wordpress/README.md
+++ b/appengine/flexible/wordpress/README.md
@@ -63,7 +63,7 @@ for more details.
 Then change the root password for your instance:
 
 ```
-$ gcloud sql users set-password root % \
+$ gcloud sql users set-password root --host=% \
   --instance wp --password=YOUR_INSTANCE_ROOT_PASSWORD # Don't use this password!
 ```
 


### PR DESCRIPTION
When executing the command for changing the root password, I have got the next error:

ERROR: (gcloud.sql.users.set-password) Positional argument deprecated_host has been removed. Use --host instead.
Usage: gcloud sql users set-password USERNAME --instance=INSTANCE, -i INSTANCE [optional flags]
  optional flags may be  --async | --help | --host | --password |
                         --prompt-for-password

For detailed information on this command and its flags, run:
  gcloud sql users set-password --help

Corrected the command.