### PR TITLE
Fix Cloud Spanner budget-transfer samples

### DIFF
--- a/spanner/src/read_write_transaction.php
+++ b/spanner/src/read_write_transaction.php
@@ -32,7 +32,7 @@ use UnexpectedValueException;
  * Performs a read-write transaction to update two sample records in the
  * database.
  *
- * This will transfer 200,000 from the `MarketingBudget` field for the second
+ * This will transfer 100,000 from the `MarketingBudget` field for the second
  * Album to the first Album. If the `MarketingBudget` is too low, it will
  * raise an exception.
  *
@@ -68,7 +68,7 @@ function read_write_transaction($instanceId, $databaseId)
         if ($secondAlbumBudget < 300000) {
             // Throwing an exception will automatically roll back the transaction.
             throw new UnexpectedValueException(
-                'The second album doesn\'t have enough funds to transfer'
+                'The second album\'s budget doesn\'t meet the required minimum'
             );
         }
 
@@ -86,22 +86,24 @@ function read_write_transaction($instanceId, $databaseId)
         $firstAlbumBudget = $firstRow['MarketingBudget'];
 
         // Update the budgets.
-        $transferAmmount = 200000;
-        $secondAlbumBudget -= $transferAmmount;
-        $firstAlbumBudget += $transferAmmount;
-        printf('Setting first album\'s budget to %s and the second album\'s ' .
-            'budget to %s.' . PHP_EOL, $firstAlbumBudget, $secondAlbumBudget);
+        $transferAmount = 100000;
+        if ($firstAlbumBudget >= $transferAmount) {
+            $secondAlbumBudget += $transferAmount;
+            $firstAlbumBudget -= $transferAmount;
+            printf('Setting first album\'s budget to %s and the second album\'s ' .
+                'budget to %s.' . PHP_EOL, $firstAlbumBudget, $secondAlbumBudget);
 
-        // Update the rows.
-        $t->updateBatch('Albums', [
-            ['SingerId' => 1, 'AlbumId' => 1, 'MarketingBudget' => $firstAlbumBudget],
-            ['SingerId' => 2, 'AlbumId' => 2, 'MarketingBudget' => $secondAlbumBudget],
-        ]);
+            // Update the rows.
+            $t->updateBatch('Albums', [
+                ['SingerId' => 1, 'AlbumId' => 1, 'MarketingBudget' => $firstAlbumBudget],
+                ['SingerId' => 2, 'AlbumId' => 2, 'MarketingBudget' => $secondAlbumBudget],
+            ]);
 
-        // Commit the transaction!
-        $t->commit();
+            // Commit the transaction!
+            $t->commit();
+
+            print('Transaction complete.' . PHP_EOL);
+        }
     });
-
-    print('Transaction complete.' . PHP_EOL);
 }
 // [END spanner_read_write_transaction]

--- a/spanner/src/write_data_with_dml_transaction.php
+++ b/spanner/src/write_data_with_dml_transaction.php
@@ -31,7 +31,7 @@ use Google\Cloud\Spanner\Transaction;
  * Performs a read-write transaction to update two sample records in the
  * database.
  *
- * This will transfer 200,000 from the `MarketingBudget` field for the first
+ * This will transfer 100,000 from the `MarketingBudget` field for the first
  * Album to the second Album. If the `MarketingBudget` is too low, it will
  * raise an exception.
  *
@@ -39,7 +39,7 @@ use Google\Cloud\Spanner\Transaction;
  * to populate the fields.
  * Example:
  * ```
- * read_write_transaction($instanceId, $databaseId);
+ * write_data_with_dml_transaction($instanceId, $databaseId);
  * ```
  *
  * @param string $instanceId The Spanner instance ID.
@@ -55,20 +55,22 @@ function write_data_with_dml_transaction($instanceId, $databaseId)
         // Transfer marketing budget from one album to another. We do it in a transaction to
         // ensure that the transfer is atomic.
         $results = $t->execute(
-            "SELECT MarketingBudget from Albums WHERE SingerId = 1 and AlbumId = 1");
+            "SELECT MarketingBudget from Albums WHERE SingerId = 1 and AlbumId = 1"
+        );
         $resultsRow = $results->rows()->current();
         $album1budget = $resultsRow['MarketingBudget'];
+        $transferAmount = 100000;
 
         // Transaction will only be committed if this condition still holds at the time of
         // commit. Otherwise it will be aborted and the callable will be rerun by the
         // client library.
-        if ($album1budget > 300000) {
+        if ($album1budget >= $transferAmount) {
             $results = $t->execute(
-                "SELECT MarketingBudget from Albums WHERE SingerId = 2 and AlbumId = 2");
+                "SELECT MarketingBudget from Albums WHERE SingerId = 2 and AlbumId = 2"
+            );
             $resultsRow = $results->rows()->current();
             $album2budget = $resultsRow['MarketingBudget'];
 
-            $transferAmount = 200000;
             $album2budget += $transferAmount;
             $album1budget -= $transferAmount;
 

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -48,7 +48,7 @@ class spannerTest extends TestCase
             self::markTestSkipped('GOOGLE_PROJECT_ID must be set.');
         }
         if (!$instanceId = getenv('GOOGLE_SPANNER_INSTANCE_ID')) {
-            self::markTestSkipped('GOOGLE_PROJECT_ID must be set.');
+            self::markTestSkipped('GOOGLE_SPANNER_INSTANCE_ID must be set.');
         }
 
         $spanner = new SpannerClient([
@@ -156,8 +156,9 @@ class spannerTest extends TestCase
      */
     public function testReadWriteTransaction()
     {
+        $this->runCommand('update-data');
         $output = $this->runCommand('read-write-transaction');
-        $this->assertContains('Setting first album\'s budget to 300000 and the second album\'s budget to 300000', $output);
+        $this->assertContains('Setting first album\'s budget to 0 and the second album\'s budget to 600000', $output);
         $this->assertContains('Transaction complete.', $output);
     }
 


### PR DESCRIPTION
The `write_data_with_dml_transaction` function moved $200,000 from Album1 to Album2. However, Album1 is initialized with a budget of $100,000. As a result, you couldn't work through the [getting started doc](https://cloud.google.com/spanner/docs/getting-started/php/) from start to finish. This function also checked whether Album1's budget exceeded a minimum, which isn't consistent with the equivalent snippets for other languages.

In addition, the `read_write_transaction` function moved $200,000, but in the opposite direction, which was somewhat confusing.

Finally, neither function confirmed that the source album's budget was at least as large as the transfer amount.

I made both functions transfer $100,000 from Album1 to Album2. I also fixed the logic errors and updated the tests as needed.