### PR TITLE
More changes to Cloud Spanner budget-transfer samples

### DIFF
--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -158,7 +158,7 @@ class spannerTest extends TestCase
     {
         $this->runCommand('update-data');
         $output = $this->runCommand('read-write-transaction');
-        $this->assertContains('Setting first album\'s budget to 0 and the second album\'s budget to 600000', $output);
+        $this->assertContains('Setting first album\'s budget to 300000 and the second album\'s budget to 300000', $output);
         $this->assertContains('Transaction complete.', $output);
     }
 


### PR DESCRIPTION
After #895 was merged, @jsimonweb asked me to take a slightly different approach to these changes. See, for example, my PR for the Java samples: GoogleCloudPlatform/java-docs-samples#1438

This pull request updates the PHP samples to reflect the new approach.