### PR TITLE
Update README.md

### DIFF
--- a/appengine/php72/symfony-framework/README.md
+++ b/appengine/php72/symfony-framework/README.md
@@ -218,6 +218,10 @@ composer require google/cloud-logging google/cloud-error-reporting
 
 ### Copy over App Engine files
 
+Firstly please install [Monolog extension](https://symfony.com/doc/current/logging.html). 
+After that you can find in `src/config` directory `yaml` files what you may change for 
+properly logging.
+
 For your Symfony application to integrate with Stackdriver Logging and Error Handling,
 you will need to copy over the `monolog.yaml` config file and the `ExceptionSubscriber.php`
 Exception Subscriber:


### PR DESCRIPTION
For my opinion describing about Monolog bundle it's important, because Monolog is absent in standart symfony collection.