### PR TITLE
Update visionTest.php

### DIFF
--- a/vision/test/visionTest.php
+++ b/vision/test/visionTest.php
@@ -240,10 +240,10 @@ class visionTest extends TestCase
         $path = __DIR__ . '/data/wakeupcat.jpg';
         $output = $this->runCommand('crop-hints', ['path' => $path]);
         $this->assertContains('Crop hints:', $output);
-        $this->assertContains('(0,0)', $output);
-        $this->assertContains('(599,0)', $output);
-        $this->assertContains('(599,475)', $output);
-        $this->assertContains('(0,475)', $output);
+        $this->assertContains('(210,0)', $output);
+        $this->assertContains('(476,0)', $output);
+        $this->assertContains('(476,475)', $output);
+        $this->assertContains('(210,475)', $output);
     }
 
     public function testCropHintsCommandGcs()
@@ -253,10 +253,10 @@ class visionTest extends TestCase
         $path = 'gs://' . $bucketName . '/vision/wakeupcat.jpg';
         $output = $this->runCommand('crop-hints', ['path' => $path]);
         $this->assertContains('Crop hints:', $output);
-        $this->assertContains('(0,0)', $output);
-        $this->assertContains('(599,0)', $output);
-        $this->assertContains('(599,475)', $output);
-        $this->assertContains('(0,475)', $output);
+        $this->assertContains('(210,0)', $output);
+        $this->assertContains('(476,0)', $output);
+        $this->assertContains('(476,475)', $output);
+        $this->assertContains('(210,475)', $output);
     }
 
     public function testDocumentTextCommand()


### PR DESCRIPTION
Crop hints return different results now.
Tested with Python and similar results as this new change. This was causing other PR to fail.

```
def detect_crop_hints(path):
    """Detects crop hints in an image."""
    from google.cloud import vision
    import io
    client = vision.ImageAnnotatorClient()

    # [START vision_python_migration_crop_hints]
    with io.open(path, 'rb') as image_file:
        content = image_file.read()
    image = vision.types.Image(content=content)

    crop_hints_params = vision.types.CropHintsParams(aspect_ratios=[1.77])
    image_context = vision.types.ImageContext(
        crop_hints_params=crop_hints_params)

    # response = client.crop_hints(image=image, image_context=image_context)
    response = client.crop_hints(image=image)
    hints = response.crop_hints_annotation.crop_hints

    for n, hint in enumerate(hints):
        print('\nCrop Hint: {}'.format(n))

        vertices = (['({},{})'.format(vertex.x, vertex.y)
                    for vertex in hint.bounding_poly.vertices])

        print('bounds: {}'.format(','.join(vertices)))

detect_crop_hints("wakeupcat.jpg")
```