### PR TITLE
Added php7.4 flexible environment sample

### DIFF
--- a/appengine/php74/.alpine/etc/nginx/conf.d/default.conf
+++ b/appengine/php74/.alpine/etc/nginx/conf.d/default.conf
@@ -1,0 +1,20 @@
+server {
+  server_name localhost;
+  listen      8080;
+  root        /var/www/html/public;
+  index       index.php;
+
+  error_log  /var/log/nginx/error.log;
+  access_log /var/log/nginx/access.log;
+
+  location / {
+    try_files $uri /index.php?$args;
+  }
+
+  location ~ \.php$ {
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    fastcgi_pass 127.0.0.1:9000;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  }
+}

--- a/appengine/php74/.alpine/etc/supervisor/supervisord.conf
+++ b/appengine/php74/.alpine/etc/supervisor/supervisord.conf
@@ -1,0 +1,30 @@
+[supervisord]
+nodaemon = true
+logfile = /dev/null
+logfile_maxbytes = 0
+pidfile = /var/run/supervisord.pid
+
+[program:php-fpm]
+command = php-fpm
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes=0
+user = root
+autostart = true
+autorestart = true
+priority = 5
+
+[program:nginx]
+command = /usr/sbin/nginx -g 'pid /tmp/nginx.pid; daemon off;'
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes=0
+user = root
+autostart = true
+autorestart = true
+priority = 10
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/appengine/php74/.alpine/usr/local/etc/php/conf.d/opcache.ini
+++ b/appengine/php74/.alpine/usr/local/etc/php/conf.d/opcache.ini
@@ -1,0 +1,10 @@
+[opcache]
+
+opcache.enable=1
+opcache.revalidate_freq=0
+opcache.validate_timestamps=${PHP_OPCACHE_VALIDATE_TIMESTAMPS}
+opcache.max_accelerated_files=10000
+opcache.memory_consumption=192
+opcache.max_wasted_percentage=10
+opcache.interned_strings_buffer=16
+opcache.fast_shutdown=1

--- a/appengine/php74/Dockerfile
+++ b/appengine/php74/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:7.4-fpm-alpine
+
+WORKDIR /var/www/html
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+COPY ./ /var/www/html/
+
+RUN apk update && \
+    apk add --no-cache libzip-dev bash nginx supervisor && \
+    docker-php-ext-install zip mysqli pdo pdo_mysql bcmath opcache && \
+    docker-php-ext-configure zip && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    composer install --no-scripts
+
+COPY ./.alpine /
+
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/appengine/php74/README.md
+++ b/appengine/php74/README.md
@@ -1,0 +1,16 @@
+# App Engine for PHP 7.4
+
+Google cloud does't support php 7.4 yet, alternatively it can be done by creating a flexible environment.
+[Read the docs](https://cloud.google.com/appengine/docs/flexible/php)
+
+## Code Samples
+
+* [Implementing `Google Auth`](auth)
+* [Connecting to `Cloud SQL`](cloudsql)
+* [Enabling `Stackdriver Error Reporting`](errorreporting)
+* [Using `Stackdriver Logging`](logging)
+* [Implementing a `front controller`](front-controller)
+* [Making `gRPC` calls](grpc)
+* [Using the `Metadata` server](metadata)
+* [Using `Cloud Storage`](storage)
+* [Enabling `Cloud Trace`](trace)

--- a/appengine/php74/app.yaml
+++ b/appengine/php74/app.yaml
@@ -1,0 +1,5 @@
+runtime: custom
+env: flex
+
+env_variables:
+  PHP_OPCACHE_VALIDATE_TIMESTAMPS: 0


### PR DESCRIPTION
Adds a sample how to setup an AppEngine application with PHP 7.4, even though it uses a specific php version it's possible to change to any other as official PHP image well as any custom docker image.

The sample uses Alpine, changing from alpine to any debina base image is also quite similar.

Dockerfile installs opcache extension with a basic setup (which is enough for having requests below 20ms on a symfony app), nginx as webserver and supervisor to make sure nginx and php-fpm keep running.

This setup approach follows the standard/supported PHP versions (5.6, 7.0, 7.1 and 7.2) for AppEngine.

https://cloud.google.com/appengine/docs/php/