### PR TITLE
Update JobSearchHistogramSearch.php to actually pass in the queries

### DIFF
--- a/jobs/v4/JobSearchHistogramSearch.php
+++ b/jobs/v4/JobSearchHistogramSearch.php
@@ -56,7 +56,8 @@ function sampleSearchJobs($projectId, $tenantId, $query)
 
     try {
         // Iterate through all elements
-        $pagedResponse = $jobServiceClient->searchJobs($formattedParent, $requestMetadata, ['customRankingInfo' => $customRankingInfo, 'orderBy' => $orderBy]);
+        $pagedResponse = $jobServiceClient->searchJobs($formattedParent, $requestMetadata, ['customRankingInfo' => $customRankingInfo, 'orderBy' => $orderBy, 'histogramQueries' => $histogramQueries]);
+        
         foreach ($pagedResponse->iterateAllElements() as $responseItem) {
             printf('Job summary: %s'.PHP_EOL, $responseItem->getJobSummary());
             printf('Job title snippet: %s'.PHP_EOL, $responseItem->getJobTitleSnippet());


### PR DESCRIPTION
.. it wasn't before. I think the Ruby one might need it as well.

https://cloud.google.com/talent-solution/job-search/docs/histogram#job_search_histogram_search-ruby page as well never uses https://github.com/googleapis/google-cloud-php-talent/blob/master/src/V4beta1/SearchJobsResponse.php#L167 to show how to actually get the data off from the response -- should it? 

I can update the docs / file a bug if needed. 