### PR TITLE
Added PHP code samples for SecurityCenter

### DIFF
--- a/securitycenter/composer.json
+++ b/securitycenter/composer.json
@@ -1,0 +1,10 @@
+{
+
+    "require": {
+        "google/cloud-security-center": "^0.5.0",
+        "google/cloud-pubsub": "^1.21"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    }
+}

--- a/securitycenter/phpunit.xml.dist
+++ b/securitycenter/phpunit.xml.dist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2020 Google LLC.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<phpunit backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="../testing/bootstrap.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    timeoutForSmallTests="10"
+    timeoutForMediumTests="30"
+    timeoutForLargeTests="120">
+  <testsuites>
+    <testsuite name="PHP SecurityCenter tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <log type="coverage-clover" target="./build/logs/clover.xml"/>
+  </logging>
+  <filter>
+    <whitelist addUncoveredFilesFromWhitelist="true">
+      <directory>./src</directory>
+      <exclude>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/securitycenter/src/create_notification.php
+++ b/securitycenter/src/create_notification.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+if (count($argv) < 1) {
+    return printf("Usage: php %s PROJECT_ID STRING\n", __FILE__);
+}
+list($_, $organizationId, $notificationConfigId, $projectId, $topicName) = $argv;
+
+// [START scc_create_notification_config]
+
+use \Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
+use \Google\Cloud\SecurityCenter\V1\NotificationConfig;
+
+
+/** Uncomment and populate these variables in your code */
+// $organizationId = "{your-org-id}";
+// $notificationConfigId = {"your-unique-id"};
+// $projectId = "{your-project}"";
+// $topicName = "{your-topic}";
+
+$securityCenterClient = new SecurityCenterClient();
+$organizationName = "organizations/" . $organizationId;
+$pubsubTopic = "projects/" . $projectId . "/topics/" . $topicName;
+
+try {
+    $streamingConfig = new NotificationConfig\StreamingConfig();
+    $streamingConfig->setFilter("state = \"ACTIVE\"");
+    $notificationConfig = new NotificationConfig();
+    $notificationConfig->setDescription("PHP notification config");
+    $notificationConfig->setPubsubTopic($pubsubTopic);
+    $notificationConfig->setStreamingConfig($streamingConfig);
+
+    $response = $securityCenterClient->createNotificationConfig($organizationName, $notificationConfigId, $notificationConfig);
+    printf("Notification config was created: %s", $response->getName());
+
+} finally {
+    $securityCenterClient->close();
+}
+
+// [END scc_create_notification_config]

--- a/securitycenter/src/delete_notification.php
+++ b/securitycenter/src/delete_notification.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+if (count($argv) < 1) {
+    return printf("Usage: php %s PROJECT_ID STRING\n", __FILE__);
+}
+list($_, $organizationId, $notificationConfigId) = $argv;
+
+// [START scc_delete_notification_config]
+
+use \Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
+
+/** Uncomment and populate these variables in your code */
+// $organizationId = "{your-org-id}";
+// $notificationConfigId = {"your-unique-id"};
+
+$securityCenterClient = new SecurityCenterClient();
+$organizationName = "organizations/" . $organizationId;
+$notificationConfigName = $organizationName . "/notificationConfigs/" . $notificationConfigId;
+
+try {
+    $response = $securityCenterClient->deleteNotificationConfig($notificationConfigName);
+    printf("Notification config was deleted");
+
+} finally {
+    $securityCenterClient->close();
+}
+
+// [END scc_delete_notification_config]

--- a/securitycenter/src/get_notification.php
+++ b/securitycenter/src/get_notification.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+if (count($argv) < 1) {
+    return printf("Usage: php %s PROJECT_ID STRING\n", __FILE__);
+}
+list($_, $organizationId, $notificationConfigId) = $argv;
+
+// [START scc_get_notification_config]
+
+use \Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
+
+/** Uncomment and populate these variables in your code */
+// $organizationId = "{your-org-id}";
+// $notificationConfigId = {"your-unique-id"};
+
+$securityCenterClient = new SecurityCenterClient();
+$organizationName = "organizations/" . $organizationId;
+$notificationConfigName = $organizationName . "/notificationConfigs/" . $notificationConfigId;
+
+try {
+    $response = $securityCenterClient->getNotificationConfig($notificationConfigName);
+    printf("Notification config was retrieved: %s", $response->getName());
+
+} finally {
+    $securityCenterClient->close();
+}
+// [END scc_get_notification_config]

--- a/securitycenter/src/list_notification.php
+++ b/securitycenter/src/list_notification.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+if (count($argv) < 1) {
+    return printf("Usage: php %s PROJECT_ID STRING\n", __FILE__);
+}
+list($_, $organizationId) = $argv;
+
+// [START scc_list_notification_configs]
+
+use \Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
+
+/** Uncomment and populate these variables in your code */
+// $organizationId = "{your-org-id}";
+
+$securityCenterClient = new SecurityCenterClient();
+$organizationName = "organizations/" . $organizationId;
+
+try {
+    $pagedResponse = $securityCenterClient->listNotificationConfigs($organizationName);
+    $count = 0;
+    foreach ($pagedResponse->iterateAllElements() as $element) {
+        $count += 1;
+    }
+
+    printf("Notification configs were listed");
+    return $count;
+
+} finally {
+    $securityCenterClient->close();
+}
+
+// [END scc_list_notification_configs]

--- a/securitycenter/src/receive_notification.php
+++ b/securitycenter/src/receive_notification.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+if (count($argv) < 1) {
+    return printf("Usage: php %s PROJECT_ID STRING\n", __FILE__);
+}
+list($_, $projectId, $subscriptionId) = $argv;
+
+// [START scc_receive_notifications]
+
+use Google\Cloud\PubSub\PubSubClient;
+
+/** Uncomment and populate these variables in your code */
+// String projectId = "{your-project}";
+// String subscriptionId = "{your-subscription}";
+
+$projectSubscriptionName = "projects/" . $projectId . "/subscriptions/" . $subscriptionId;
+$subscription = $pubsub->subscription($projectSubscriptionName);
+
+$pubsub = new PubSubClient([
+    'projectId' => $projectId,
+]);
+
+foreach ($subscription->pull() as $message) {
+    printf('Message: %s' . PHP_EOL, $message->data());
+    // Acknowledge the Pub/Sub message has been received, so it will not be pulled multiple times.
+    $subscription->acknowledge($message);
+}
+// [END scc_receive_notifications]

--- a/securitycenter/src/update_notification.php
+++ b/securitycenter/src/update_notification.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+if (count($argv) < 1) {
+    return printf("Usage: php %s PROJECT_ID STRING\n", __FILE__);
+}
+list($_, $organizationId, $notificationConfigId, $projectId, $topicName) = $argv;
+
+// [START scc_update_notification_config]
+
+use \Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
+use \Google\Cloud\SecurityCenter\V1\NotificationConfig;
+use \Google\Protobuf\FieldMask;
+
+/** Uncomment and populate these variables in your code */
+// $organizationId = "{your-org-id}";
+// $notificationConfigId = {"your-unique-id"};
+// $projectId = "{your-project}"";
+// $topicName = "{your-topic}";
+
+$securityCenterClient = new SecurityCenterClient();
+$organizationName = "organizations/" . $organizationId;
+
+// Ensure this ServiceAccount has the "pubsub.topics.setIamPolicy" permission on the topic.
+$pubsubTopic = "projects/" . $projectId . "/topics/" . $topicName;
+$notificationConfigName = $organizationName . "/notificationConfigs/" . $notificationConfigId;
+
+try {
+    $streamingConfig = new NotificationConfig\StreamingConfig();
+    $streamingConfig->setFilter("state = \"ACTIVE\"");
+    $notificationConfig = new NotificationConfig();
+    $notificationConfig->setName($notificationConfigName);
+    $notificationConfig->setDescription("Updated description.");
+    $notificationConfig->setPubsubTopic($pubsubTopic);
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(array("description", "pubsub_topic"));
+
+    $response = $securityCenterClient->updateNotificationConfig($notificationConfig, array($fieldMask));
+    printf("Notification config was updated: %s", $response->getName());
+
+} finally {
+    $securityCenterClient->close();
+}
+
+// [END scc_update_notification_config]

--- a/securitycenter/test/securitycenterTest.php
+++ b/securitycenter/test/securitycenterTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+class securitycenterTest extends TestCase
+{
+    use TestTrait;
+
+    public function testCreateNotification()
+    {
+        $createOutput = $this->runSnippet('create_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-create",
+            self::getProject(),
+            self::getTopicName()
+        ]);
+
+        $this->assertContains('Notification config was created', $createOutput);
+
+        $deleteOutput = $this->runSnippet('delete_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-create",
+        ]);
+
+        $this->assertContains('Notification config was deleted', $deleteOutput);
+    }
+
+    public function testGetNotificationConfig()
+    {
+        $createOutput = $this->runSnippet('create_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-get",
+            self::getProject(),
+            self::getTopicName()
+        ]);
+
+        $this->assertContains('Notification config was created', $createOutput);
+
+        $getOutput = $this->runSnippet('get_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-get",
+        ]);
+
+        $this->assertContains('Notification config was retrieved', $getOutput);
+
+        $deleteOutput = $this->runSnippet('delete_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-get",
+        ]);
+
+        $this->assertContains('Notification config was deleted', $deleteOutput);
+
+    }
+
+    public function testUpdateNotificationConfig()
+    {
+        $createOutput = $this->runSnippet('create_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-update",
+            self::getProject(),
+            self::getTopicName()
+        ]);
+
+        $this->assertContains('Notification config was created', $createOutput);
+
+        $getOutput = $this->runSnippet('update_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-update",
+            self::getProject(),
+            self::getTopicName()
+        ]);
+
+        $this->assertContains('Notification config was updated', $getOutput);
+
+        $deleteOutput = $this->runSnippet('delete_notification', [
+            self::getOrganizationId(),
+            "php-notification-config-update",
+        ]);
+
+        $this->assertContains('Notification config was deleted', $deleteOutput);
+
+    }
+
+    public function testListNotificationConfig()
+    {
+        $listOutput = $this->runSnippet('list_notification', [
+            self::getOrganizationId(),
+        ]);
+
+        $this->assertContains('Notification configs were listed', $listOutput);
+
+    }
+
+    private static function getOrganizationId() {
+        return "1081635000895";
+    }
+
+    private static function getProject() {
+        return "project-a-id";
+    }
+
+    private static function getTopicName() {
+        return "notifications-sample-topic";
+    }
+}


### PR DESCRIPTION
Added PHP code samples for SecurityCenter. These Code Samples are for the new Notification APIs and follow the same exact code samples used for other languages.

Link to java code samples for comparison: https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets