### PR TITLE
fix: use DELETE FROM for consistency

### DIFF
--- a/spanner/src/delete_data_with_dml.php
+++ b/spanner/src/delete_data_with_dml.php
@@ -41,7 +41,7 @@ function delete_data_with_dml($instanceId, $databaseId)
 
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
-            "DELETE Singers WHERE FirstName = 'Alice'");
+            "DELETE FROM Singers WHERE FirstName = 'Alice'");
         $t->commit();
         printf('Deleted %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/delete_data_with_partitioned_dml.php
+++ b/spanner/src/delete_data_with_partitioned_dml.php
@@ -50,7 +50,7 @@ function delete_data_with_partitioned_dml($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $rowCount = $database->executePartitionedUpdate(
-        "DELETE Singers WHERE SingerId > 10"
+        "DELETE FROM Singers WHERE SingerId > 10"
     );
 
     printf('Deleted %d row(s).' . PHP_EOL, $rowCount);


### PR DESCRIPTION
Being consistent with [docs](https://cloud.google.com/spanner/docs/dml-syntax#delete_examples).