### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+
+# The php-admins team is the default owner for anything not
+# explicitly taken by someone else.
+*                               @GoogleCloudPlatform/php-admins
+
+/storage/                          @GoogleCloudPlatform/storage-dpe @GoogleCloudPlatform/php-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,10 @@
 
 # The php-admins team is the default owner for anything not
 # explicitly taken by someone else.
-*                               @GoogleCloudPlatform/php-admins
+*                         @GoogleCloudPlatform/php-admins
 
-/storage/                          @GoogleCloudPlatform/storage-dpe @GoogleCloudPlatform/php-admins
+/bigtable/                @GoogleCloudPlatform/bigtable-dpe @GoogleCloudPlatform/php-admins
+/cloud_sql/               @GoogleCloudPlatform/cloud-sql-dpes @GoogleCloudPlatform/php-admins
+/datastore/               @GoogleCloudPlatform/firestore-dpe @GoogleCloudPlatform/php-admins
+/firestore/               @GoogleCloudPlatform/firestore-dpe @GoogleCloudPlatform/php-admins
+/storage/                 @GoogleCloudPlatform/storage-dpe @GoogleCloudPlatform/php-admins


### PR DESCRIPTION
crwilcox@ requested teams for repo access across the board for SoDa teams. Adding a CODEOWNERS file with php-admins as default but with the storage team.