### PR TITLE
PHP 7.3 runtime is no longer in beta

### DIFF
--- a/appengine/php72/helloworld/README.md
+++ b/appengine/php72/helloworld/README.md
@@ -1,6 +1,6 @@
-# Hello World on App Engine Standard for PHP 7
+# Hello World on App Engine Standard for PHP 7.2 and 7.3
 
 This sample demonstrates how to deploy a *very* basic application to the
-PHP 7 standard environment in Google App Engine.
+PHP 7.2 and 7.3 standard environment in Google App Engine.
 
 ## View the [full tutorial](https://cloud.google.com/appengine/docs/standard/php7/quickstart)

--- a/appengine/php72/helloworld/README.md
+++ b/appengine/php72/helloworld/README.md
@@ -1,6 +1,6 @@
-# Hello World on App Engine Standard for PHP 7.2
+# Hello World on App Engine Standard for PHP 7
 
-This sample demonstrates how to deploy a *very* basic application to Google
-App Engine for PHP 7.2.
+This sample demonstrates how to deploy a *very* basic application to the
+PHP 7 standard environment in Google App Engine.
 
 ## View the [full tutorial](https://cloud.google.com/appengine/docs/standard/php7/quickstart)

--- a/appengine/php72/helloworld/app.yaml
+++ b/appengine/php72/helloworld/app.yaml
@@ -1,4 +1,4 @@
-# Use the PHP 7.3 runtime (BETA) by replacing "php72" below with "php73"
+# Use PHP 7.3 by replacing "php72" below with "php73"
 runtime: php72
 
 # Defaults to "serve index.php" and "serve public/index.php". Can be used to


### PR DESCRIPTION
Removing the "beta" tag from PHP 7.3. Also, I'm updating the App Engine doc to call the runtime the "PHP 7" runtime, since it supports 7.2 and 7.3, and will soon launch a beta for 7.4. So I've made a slight edit here to match the language in the App Engine doc.