### PR TITLE
Improve Spanner delete_data sample coverage

### DIFF
--- a/spanner/README.md
+++ b/spanner/README.md
@@ -103,7 +103,7 @@ To run the Spanner Samples:
       create-storing-index                 Adds an storing index to the example database.
       create-table-timestamp               Creates a table with a commit timestamp column.
       create-table-with-datatypes          Creates a table with supported datatypes.
-      delete-data                          Deletes sample data from the given database.d
+      delete-data                          Deletes sample data from the given database.
       delete-data-with-dml                 Remove sample data from the given database with a DML statement.
       deleted-data-with-partitioned-dml    Deletes sample data in the database by partition with a DML statement.
       help                                 Displays help for a command

--- a/spanner/README.md
+++ b/spanner/README.md
@@ -103,6 +103,7 @@ To run the Spanner Samples:
       create-storing-index                 Adds an storing index to the example database.
       create-table-timestamp               Creates a table with a commit timestamp column.
       create-table-with-datatypes          Creates a table with supported datatypes.
+      delete-data                          Deletes sample data from the given database.d
       delete-data-with-dml                 Remove sample data from the given database with a DML statement.
       deleted-data-with-partitioned-dml    Deletes sample data in the database by partition with a DML statement.
       help                                 Displays help for a command

--- a/spanner/composer.json
+++ b/spanner/composer.json
@@ -21,6 +21,7 @@
             "src/read_only_transaction.php",
             "src/read_stale_data.php",
             "src/batch_query_data.php",
+            "src/delete_data.php",
             "src/create_table_with_timestamp_column.php",
             "src/insert_data_with_timestamp_column.php",
             "src/add_timestamp_column.php",

--- a/spanner/spanner.php
+++ b/spanner/spanner.php
@@ -107,6 +107,19 @@ $application->add((new Command('read-stale-data'))
         );
     })
 );
+
+// Delete data command
+$application->add((new Command('delete-data'))
+    ->setDefinition($inputDefinition)
+    ->setDescription('Deletes sample data from the given database.')
+    ->setCode(function ($input, $output) {
+        delete_data(
+            $input->getArgument('instance_id'),
+            $input->getArgument('database_id')
+        );
+    })
+);
+
 // Add column command
 $application->add((new Command('add-column'))
     ->setDefinition($inputDefinition)

--- a/spanner/src/delete_data.php
+++ b/spanner/src/delete_data.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/spanner/README.md
+ */
+
+namespace Google\Cloud\Samples\Spanner;
+
+// [START spanner_delete_data]
+use Google\Cloud\Spanner\SpannerClient;
+use Google\Cloud\Spanner\KeyRange;
+use Google\Cloud\Core\Exception\GoogleException;
+
+/**
+ * Deletes sample data from the given database.
+ *
+ * @param string $instanceId The Spanner instance ID.
+ * @param string $databaseId The Spanner database ID.
+ * @throws GoogleException
+ */
+function delete_data($instanceId, $databaseId)
+{
+    $spanner = new SpannerClient();
+    $instance = $spanner->instance($instanceId);
+    $database = $instance->database($databaseId);
+
+    // Delete individual rows
+    $albumsToDelete = $spanner->keySet([
+        'keys' => [[2, 1], [2, 3]]
+    ]);
+    $database->delete('Albums', $albumsToDelete);
+
+    // Delete a range of rows where the column key is >=3 and <5
+    $singersRange = $spanner->keyRange([
+        'startType' => KeyRange::TYPE_CLOSED,
+        'start' => [3],
+        'endType' => KeyRange::TYPE_OPEN,
+        'end' => [5]
+    ]);
+    $singersToDelete = $spanner->keySet([
+        'ranges' => [$singersRange]
+    ]);
+    $database->delete('Singers', $singersToDelete);
+
+    // Delete remaining Singers rows, which will also delete the remaining
+    // Albums rows because Albums was defined with ON DELETE CASCADE
+    $remainingSingers = $spanner->keySet([
+        'all' => true
+    ]);
+    $database->delete('Singers', $remainingSingers);
+
+    print('Deleted data.' . PHP_EOL);
+}
+// [END spanner_delete_data]

--- a/spanner/src/delete_data.php
+++ b/spanner/src/delete_data.php
@@ -68,8 +68,6 @@ function delete_data($instanceId, $databaseId)
     ]);
     $database->delete('Singers', $remainingSingers);
 
-
-
     print('Deleted data.' . PHP_EOL);
 }
 // [END spanner_delete_data]

--- a/spanner/src/delete_data.php
+++ b/spanner/src/delete_data.php
@@ -48,6 +48,8 @@ function delete_data($instanceId, $databaseId)
     $database->delete('Albums', $albumsToDelete);
 
     // Delete a range of rows where the column key is >=3 and <5
+    // NOTE: A KeyRange must include a start and end.
+    // NOTE: startType and endType both default to KeyRange::TYPE_OPEN.
     $singersRange = $spanner->keyRange([
         'startType' => KeyRange::TYPE_CLOSED,
         'start' => [3],
@@ -65,6 +67,8 @@ function delete_data($instanceId, $databaseId)
         'all' => true
     ]);
     $database->delete('Singers', $remainingSingers);
+
+
 
     print('Deleted data.' . PHP_EOL);
 }

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -145,10 +145,13 @@ class spannerTest extends TestCase
         foreach ($results as $row) {
             $this->fail("Not all data was deleted.");
         }
+
+        $output = $this->runCommand('insert-data');
+        $this->assertEquals('Inserted data.' . PHP_EOL, $output);
     }
 
     /**
-     * @depends testInsertData
+     * @depends testDeleteData
      */
     public function testAddColumn()
     {

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -129,6 +129,15 @@ class spannerTest extends TestCase
     /**
      * @depends testInsertData
      */
+    public function testDeleteData()
+    {
+        $output = $this->runCommand('delete-data');
+        $this->assertContains('Deleted data.' . PHP_EOL, $output);
+    }
+
+    /**
+     * @depends testInsertData
+     */
     public function testAddColumn()
     {
         $output = $this->runCommand('add-column');

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -133,6 +133,18 @@ class spannerTest extends TestCase
     {
         $output = $this->runCommand('delete-data');
         $this->assertContains('Deleted data.' . PHP_EOL, $output);
+
+        $spanner = new SpannerClient();
+        $instance = $spanner->instance(spannerTest::$instanceId);
+        $database = $instance->database(spannerTest::$databaseId);
+
+        $results = $database->execute(
+            'SELECT SingerId FROM Albums UNION ALL SELECT SingerId FROM Singers'
+        );
+
+        foreach ($results as $row) {
+            $this->fail("Not all data was deleted.");
+        }
     }
 
     /**


### PR DESCRIPTION
The Deleting rows in a table section gives four different delete methods. The PHP section pointed at the documentation for $database->delete(). This only demonstrated one of the methods.

This PR adds the missing sample and includes the missing delete methods.