### PR TITLE
Migrate DLP samples to use regional syntax in parent field

### DIFF
--- a/dlp/README.md
+++ b/dlp/README.md
@@ -45,6 +45,23 @@ This simple command-line application demonstrates how to invoke
 
 See the [DLP Documentation](https://cloud.google.com/dlp/docs/inspecting-text) for more information.
 
+## Troubleshooting
+
+### bcmath extension missing
+
+If you see an error like this:
+
+```
+PHP Fatal error:  Uncaught Error: Call to undefined function Google\Protobuf\Internal\bccomp() in /usr/local/google/home/crwilson/github/GoogleCloudPlatform/php-docs-samples/dlp/vendor/google/protobuf/src/Google/Protobuf/Internal/Message.php:986
+```
+
+You may need to install the bcmath PHP extension.
+e.g. (may depend on your php version)
+```
+$ sudo apt-get install php7.3-bcmath
+```
+
+
 ## Contributing changes
 
 * See [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/dlp/src/categorical_stats.php
+++ b/dlp/src/categorical_stats.php
@@ -94,7 +94,7 @@ $riskJob = (new RiskAnalysisJobConfig())
     ->setActions([$action]);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";;
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/categorical_stats.php
+++ b/dlp/src/categorical_stats.php
@@ -94,7 +94,7 @@ $riskJob = (new RiskAnalysisJobConfig())
     ->setActions([$action]);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/categorical_stats.php
+++ b/dlp/src/categorical_stats.php
@@ -94,7 +94,7 @@ $riskJob = (new RiskAnalysisJobConfig())
     ->setActions([$action]);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/create_inspect_template.php
+++ b/dlp/src/create_inspect_template.php
@@ -86,7 +86,7 @@ $inspectTemplate = (new InspectTemplate())
     ->setDescription($description);
 
 // Run request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $template = $dlp->createInspectTemplate($parent, [
     'inspectTemplate' => $inspectTemplate,
     'templateId' => $templateId

--- a/dlp/src/create_inspect_template.php
+++ b/dlp/src/create_inspect_template.php
@@ -86,7 +86,7 @@ $inspectTemplate = (new InspectTemplate())
     ->setDescription($description);
 
 // Run request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $template = $dlp->createInspectTemplate($parent, [
     'inspectTemplate' => $inspectTemplate,
     'templateId' => $templateId

--- a/dlp/src/create_inspect_template.php
+++ b/dlp/src/create_inspect_template.php
@@ -86,7 +86,7 @@ $inspectTemplate = (new InspectTemplate())
     ->setDescription($description);
 
 // Run request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $template = $dlp->createInspectTemplate($parent, [
     'inspectTemplate' => $inspectTemplate,
     'templateId' => $templateId

--- a/dlp/src/create_trigger.php
+++ b/dlp/src/create_trigger.php
@@ -129,7 +129,7 @@ $jobTriggerObject = (new JobTrigger())
     ->setDescription($description);
 
 // Run trigger creation request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $trigger = $dlp->createJobTrigger($parent, [
     'jobTrigger' => $jobTriggerObject,
     'triggerId' => $triggerId

--- a/dlp/src/create_trigger.php
+++ b/dlp/src/create_trigger.php
@@ -129,7 +129,7 @@ $jobTriggerObject = (new JobTrigger())
     ->setDescription($description);
 
 // Run trigger creation request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $trigger = $dlp->createJobTrigger($parent, [
     'jobTrigger' => $jobTriggerObject,
     'triggerId' => $triggerId

--- a/dlp/src/create_trigger.php
+++ b/dlp/src/create_trigger.php
@@ -129,7 +129,7 @@ $jobTriggerObject = (new JobTrigger())
     ->setDescription($description);
 
 // Run trigger creation request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $trigger = $dlp->createJobTrigger($parent, [
     'jobTrigger' => $jobTriggerObject,
     'triggerId' => $triggerId

--- a/dlp/src/deidentify_dates.php
+++ b/dlp/src/deidentify_dates.php
@@ -151,7 +151,7 @@ $recordTransformations = (new RecordTransformations())
 $deidentifyConfig = (new DeidentifyConfig())
     ->setRecordTransformations($recordTransformations);
 
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_dates.php
+++ b/dlp/src/deidentify_dates.php
@@ -151,7 +151,7 @@ $recordTransformations = (new RecordTransformations())
 $deidentifyConfig = (new DeidentifyConfig())
     ->setRecordTransformations($recordTransformations);
 
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_dates.php
+++ b/dlp/src/deidentify_dates.php
@@ -151,7 +151,7 @@ $recordTransformations = (new RecordTransformations())
 $deidentifyConfig = (new DeidentifyConfig())
     ->setRecordTransformations($recordTransformations);
 
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_fpe.php
+++ b/dlp/src/deidentify_fpe.php
@@ -104,7 +104,7 @@ $deidentifyConfig = (new DeidentifyConfig())
 $content = (new ContentItem())
     ->setValue($string);
 
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_fpe.php
+++ b/dlp/src/deidentify_fpe.php
@@ -104,7 +104,7 @@ $deidentifyConfig = (new DeidentifyConfig())
 $content = (new ContentItem())
     ->setValue($string);
 
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_fpe.php
+++ b/dlp/src/deidentify_fpe.php
@@ -104,7 +104,7 @@ $deidentifyConfig = (new DeidentifyConfig())
 $content = (new ContentItem())
     ->setValue($string);
 
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_mask.php
+++ b/dlp/src/deidentify_mask.php
@@ -82,7 +82,7 @@ $deidentifyConfig = (new DeidentifyConfig())
 $item = (new ContentItem())
     ->setValue($string);
 
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_mask.php
+++ b/dlp/src/deidentify_mask.php
@@ -82,7 +82,7 @@ $deidentifyConfig = (new DeidentifyConfig())
 $item = (new ContentItem())
     ->setValue($string);
 
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/deidentify_mask.php
+++ b/dlp/src/deidentify_mask.php
@@ -82,7 +82,7 @@ $deidentifyConfig = (new DeidentifyConfig())
 $item = (new ContentItem())
     ->setValue($string);
 
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 
 // Run request
 $response = $dlp->deidentifyContent($parent, [

--- a/dlp/src/inspect_bigquery.php
+++ b/dlp/src/inspect_bigquery.php
@@ -114,7 +114,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_bigquery.php
+++ b/dlp/src/inspect_bigquery.php
@@ -114,7 +114,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_bigquery.php
+++ b/dlp/src/inspect_bigquery.php
@@ -114,7 +114,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_datastore.php
+++ b/dlp/src/inspect_datastore.php
@@ -118,7 +118,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_datastore.php
+++ b/dlp/src/inspect_datastore.php
@@ -118,7 +118,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_datastore.php
+++ b/dlp/src/inspect_datastore.php
@@ -118,7 +118,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_gcs.php
+++ b/dlp/src/inspect_gcs.php
@@ -114,7 +114,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_gcs.php
+++ b/dlp/src/inspect_gcs.php
@@ -123,7 +123,9 @@ $job = $dlp->createDlpJob($parent, [
 $backoff = new ExponentialBackoff(30);
 $backoff->execute(function () use ($subscription, $dlp, &$job) {
     printf('Waiting for job to complete' . PHP_EOL);
+    printf('CRWILSON_DEBUG0a: ' . $job->getName() . "\n");
     foreach ($subscription->pull() as $message) {
+      printf('CRWILSON_DEBUG0b: ' . $message->attributes()['DlpJobName'] . "\n");
         if (isset($message->attributes()['DlpJobName']) &&
             $message->attributes()['DlpJobName'] === $job->getName()) {
             $subscription->acknowledge($message);

--- a/dlp/src/inspect_gcs.php
+++ b/dlp/src/inspect_gcs.php
@@ -114,7 +114,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_gcs.php
+++ b/dlp/src/inspect_gcs.php
@@ -123,9 +123,7 @@ $job = $dlp->createDlpJob($parent, [
 $backoff = new ExponentialBackoff(30);
 $backoff->execute(function () use ($subscription, $dlp, &$job) {
     printf('Waiting for job to complete' . PHP_EOL);
-    printf('CRWILSON_DEBUG0a: ' . $job->getName() . "\n");
     foreach ($subscription->pull() as $message) {
-      printf('CRWILSON_DEBUG0b: ' . $message->attributes()['DlpJobName'] . "\n");
         if (isset($message->attributes()['DlpJobName']) &&
             $message->attributes()['DlpJobName'] === $job->getName()) {
             $subscription->acknowledge($message);

--- a/dlp/src/inspect_gcs.php
+++ b/dlp/src/inspect_gcs.php
@@ -114,7 +114,7 @@ $inspectJob = (new InspectJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'inspectJob' => $inspectJob
 ]);

--- a/dlp/src/inspect_image_file.php
+++ b/dlp/src/inspect_image_file.php
@@ -51,7 +51,7 @@ $fileBytes = (new ByteContentItem())
     ->setData(file_get_contents($filepath));
 
 // Construct request
-$parent = $dlp->projectName($projectId);
+$parent = $dlp->locationName($projectId, "global");
 $item = (new ContentItem())
     ->setByteItem($fileBytes);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_image_file.php
+++ b/dlp/src/inspect_image_file.php
@@ -51,7 +51,7 @@ $fileBytes = (new ByteContentItem())
     ->setData(file_get_contents($filepath));
 
 // Construct request
-$parent = "projects/$projectId/locations/global"
+$parent = "projects/$projectId/locations/global";
 $item = (new ContentItem())
     ->setByteItem($fileBytes);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_image_file.php
+++ b/dlp/src/inspect_image_file.php
@@ -51,7 +51,7 @@ $fileBytes = (new ByteContentItem())
     ->setData(file_get_contents($filepath));
 
 // Construct request
-$parent = $dlp->locationName($projectId, "global");
+$parent = "projects/$projectId/locations/global"
 $item = (new ContentItem())
     ->setByteItem($fileBytes);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_string.php
+++ b/dlp/src/inspect_string.php
@@ -44,7 +44,7 @@ use Google\Cloud\Dlp\V2\Likelihood;
 $dlp = new DlpServiceClient();
 
 // Construct request
-$parent = $dlp->projectName($projectId);
+$parent = $dlp->locationName($projectId, "global");
 $item = (new ContentItem())
     ->setValue($textToInspect);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_string.php
+++ b/dlp/src/inspect_string.php
@@ -44,7 +44,7 @@ use Google\Cloud\Dlp\V2\Likelihood;
 $dlp = new DlpServiceClient();
 
 // Construct request
-$parent = "projects/$projectId/locations/global"
+$parent = "projects/$projectId/locations/global";
 $item = (new ContentItem())
     ->setValue($textToInspect);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_string.php
+++ b/dlp/src/inspect_string.php
@@ -44,7 +44,7 @@ use Google\Cloud\Dlp\V2\Likelihood;
 $dlp = new DlpServiceClient();
 
 // Construct request
-$parent = $dlp->locationName($projectId, "global");
+$parent = "projects/$projectId/locations/global"
 $item = (new ContentItem())
     ->setValue($textToInspect);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_text_file.php
+++ b/dlp/src/inspect_text_file.php
@@ -51,7 +51,7 @@ $fileBytes = (new ByteContentItem())
     ->setData(file_get_contents($filepath));
 
 // Construct request
-$parent = $dlp->projectName($projectId);
+$parent = $dlp->locationName($projectId, "global");
 $item = (new ContentItem())
     ->setByteItem($fileBytes);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_text_file.php
+++ b/dlp/src/inspect_text_file.php
@@ -51,7 +51,7 @@ $fileBytes = (new ByteContentItem())
     ->setData(file_get_contents($filepath));
 
 // Construct request
-$parent = "projects/$projectId/locations/global"
+$parent = "projects/$projectId/locations/global";
 $item = (new ContentItem())
     ->setByteItem($fileBytes);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/inspect_text_file.php
+++ b/dlp/src/inspect_text_file.php
@@ -51,7 +51,7 @@ $fileBytes = (new ByteContentItem())
     ->setData(file_get_contents($filepath));
 
 // Construct request
-$parent = $dlp->locationName($projectId, "global");
+$parent = "projects/$projectId/locations/global"
 $item = (new ContentItem())
     ->setByteItem($fileBytes);
 $inspectConfig = (new InspectConfig())

--- a/dlp/src/k_anonymity.php
+++ b/dlp/src/k_anonymity.php
@@ -101,7 +101,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/k_anonymity.php
+++ b/dlp/src/k_anonymity.php
@@ -101,7 +101,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/k_anonymity.php
+++ b/dlp/src/k_anonymity.php
@@ -101,7 +101,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/k_map.php
+++ b/dlp/src/k_map.php
@@ -122,7 +122,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/k_map.php
+++ b/dlp/src/k_map.php
@@ -122,7 +122,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/k_map.php
+++ b/dlp/src/k_map.php
@@ -122,7 +122,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/l_diversity.php
+++ b/dlp/src/l_diversity.php
@@ -108,7 +108,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/l_diversity.php
+++ b/dlp/src/l_diversity.php
@@ -108,7 +108,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/l_diversity.php
+++ b/dlp/src/l_diversity.php
@@ -108,7 +108,7 @@ $riskJob = (new RiskAnalysisJobConfig())
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/list_inspect_templates.php
+++ b/dlp/src/list_inspect_templates.php
@@ -42,7 +42,7 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
 // Instantiate a client.
 $dlp = new DlpServiceClient();
 
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 
 // Run request
 $response = $dlp->listInspectTemplates($parent);

--- a/dlp/src/list_inspect_templates.php
+++ b/dlp/src/list_inspect_templates.php
@@ -42,7 +42,7 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
 // Instantiate a client.
 $dlp = new DlpServiceClient();
 
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 
 // Run request
 $response = $dlp->listInspectTemplates($parent);

--- a/dlp/src/list_inspect_templates.php
+++ b/dlp/src/list_inspect_templates.php
@@ -42,7 +42,7 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
 // Instantiate a client.
 $dlp = new DlpServiceClient();
 
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 
 // Run request
 $response = $dlp->listInspectTemplates($parent);

--- a/dlp/src/list_jobs.php
+++ b/dlp/src/list_jobs.php
@@ -51,7 +51,7 @@ $jobType = DlpJobType::INSPECT_JOB;
 // Run job-listing request
 // For more information and filter syntax,
 // @see https://cloud.google.com/dlp/docs/reference/rest/v2/projects.dlpJobs/list
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $response = $dlp->listDlpJobs($parent, [
   'filter' => $filter,
   'type' => $jobType

--- a/dlp/src/list_jobs.php
+++ b/dlp/src/list_jobs.php
@@ -51,7 +51,7 @@ $jobType = DlpJobType::INSPECT_JOB;
 // Run job-listing request
 // For more information and filter syntax,
 // @see https://cloud.google.com/dlp/docs/reference/rest/v2/projects.dlpJobs/list
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $response = $dlp->listDlpJobs($parent, [
   'filter' => $filter,
   'type' => $jobType

--- a/dlp/src/list_jobs.php
+++ b/dlp/src/list_jobs.php
@@ -51,7 +51,7 @@ $jobType = DlpJobType::INSPECT_JOB;
 // Run job-listing request
 // For more information and filter syntax,
 // @see https://cloud.google.com/dlp/docs/reference/rest/v2/projects.dlpJobs/list
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $response = $dlp->listDlpJobs($parent, [
   'filter' => $filter,
   'type' => $jobType

--- a/dlp/src/list_triggers.php
+++ b/dlp/src/list_triggers.php
@@ -42,7 +42,7 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
 // Instantiate a client.
 $dlp = new DlpServiceClient();
 
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 
 // Run request
 $response = $dlp->listJobTriggers($parent);

--- a/dlp/src/list_triggers.php
+++ b/dlp/src/list_triggers.php
@@ -42,7 +42,7 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
 // Instantiate a client.
 $dlp = new DlpServiceClient();
 
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 
 // Run request
 $response = $dlp->listJobTriggers($parent);

--- a/dlp/src/list_triggers.php
+++ b/dlp/src/list_triggers.php
@@ -42,7 +42,7 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
 // Instantiate a client.
 $dlp = new DlpServiceClient();
 
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 
 // Run request
 $response = $dlp->listJobTriggers($parent);

--- a/dlp/src/numerical_stats.php
+++ b/dlp/src/numerical_stats.php
@@ -99,7 +99,7 @@ $topic = $pubsub->topic($topicId);
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/numerical_stats.php
+++ b/dlp/src/numerical_stats.php
@@ -99,7 +99,7 @@ $topic = $pubsub->topic($topicId);
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/numerical_stats.php
+++ b/dlp/src/numerical_stats.php
@@ -99,7 +99,7 @@ $topic = $pubsub->topic($topicId);
 $subscription = $topic->subscription($subscriptionId);
 
 // Submit request
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 $job = $dlp->createDlpJob($parent, [
     'riskJob' => $riskJob
 ]);

--- a/dlp/src/redact_image.php
+++ b/dlp/src/redact_image.php
@@ -89,7 +89,7 @@ foreach ($infoTypes as $infoType) {
     $imageRedactionConfigs[] = $config;
 }
 
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 
 // Run request
 $response = $dlp->redactImage($parent, [

--- a/dlp/src/redact_image.php
+++ b/dlp/src/redact_image.php
@@ -89,7 +89,7 @@ foreach ($infoTypes as $infoType) {
     $imageRedactionConfigs[] = $config;
 }
 
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 
 // Run request
 $response = $dlp->redactImage($parent, [

--- a/dlp/src/redact_image.php
+++ b/dlp/src/redact_image.php
@@ -89,7 +89,7 @@ foreach ($infoTypes as $infoType) {
     $imageRedactionConfigs[] = $config;
 }
 
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 
 // Run request
 $response = $dlp->redactImage($parent, [

--- a/dlp/src/reidentify_fpe.php
+++ b/dlp/src/reidentify_fpe.php
@@ -113,7 +113,7 @@ $reidentifyConfig = (new DeidentifyConfig())
 $item = (new ContentItem())
     ->setValue($string);
 
-$parent = $dlp->locationName($callingProjectId, "global");
+$parent = "projects/$callingProjectId/locations/global"
 
 // Run request
 $response = $dlp->reidentifyContent($parent, [

--- a/dlp/src/reidentify_fpe.php
+++ b/dlp/src/reidentify_fpe.php
@@ -113,7 +113,7 @@ $reidentifyConfig = (new DeidentifyConfig())
 $item = (new ContentItem())
     ->setValue($string);
 
-$parent = $dlp->projectName($callingProjectId);
+$parent = $dlp->locationName($callingProjectId, "global");
 
 // Run request
 $response = $dlp->reidentifyContent($parent, [

--- a/dlp/src/reidentify_fpe.php
+++ b/dlp/src/reidentify_fpe.php
@@ -113,7 +113,7 @@ $reidentifyConfig = (new DeidentifyConfig())
 $item = (new ContentItem())
     ->setValue($string);
 
-$parent = "projects/$callingProjectId/locations/global"
+$parent = "projects/$callingProjectId/locations/global";
 
 // Run request
 $response = $dlp->reidentifyContent($parent, [

--- a/dlp/test/data/harmful.csv
+++ b/dlp/test/data/harmful.csv
@@ -1,0 +1,2 @@
+Name,Description
+John Doe,Name of a person

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -242,7 +242,7 @@ class dlpTest extends TestCase
             $scanPeriod,
             $autoPopulateTimespan,
         ]);
-        $fullTriggerId = sprintf('projects/%s/jobTriggers/%s', self::$projectId, $triggerId);
+        $fullTriggerId = sprintf('projects/%s/locations/global/jobTriggers/%s', self::$projectId, $triggerId);
         $this->assertContains('Successfully created trigger ' . $fullTriggerId, $output);
 
         $output = $this->runSnippet('list_triggers', [self::$projectId]);
@@ -263,7 +263,7 @@ class dlpTest extends TestCase
         $displayName = uniqid("My inspect template display name ");
         $description = uniqid("My inspect template description ");
         $templateId = uniqid('my-php-test-inspect-template-');
-        $fullTemplateId = sprintf('projects/%s/inspectTemplates/%s', self::$projectId, $templateId);
+        $fullTemplateId = sprintf('projects/%s/locations/global/inspectTemplates/%s', self::$projectId, $templateId);
 
         $output  = $this->runSnippet('create_inspect_template', [
             self::$projectId,


### PR DESCRIPTION
Update DLP samples to include `locations/global` in the parent field, so that the job name returned by the API matches what is used internally and what is used in the pubsub message being looked for.

See internal bug b/158100365

Also added a troubleshooting note to the DLP readme.

