### PR TITLE
fix: fixes AutoML Vision Object Detection prediction

### DIFF
--- a/automl/src/vision_object_detection_predict.php
+++ b/automl/src/vision_object_detection_predict.php
@@ -45,7 +45,7 @@ try {
     // read the file
     $content = file_get_contents($filePath);
     $image = (new Image())
-        ->setImageBytes($image);
+        ->setImageBytes($content);
     // create payload
     $payload = (new ExamplePayload())
         ->setImage($image);


### PR DESCRIPTION
Fixes AutoML Vision Object Detection prediction sample so that it passes image bytes to service.

Region tags affected:

- automl_vision_classification_predict