### PR TITLE
Update/Fix batch_predict.php

### DIFF
--- a/automl/src/batch_predict.php
+++ b/automl/src/batch_predict.php
@@ -48,11 +48,11 @@ try {
 
     // set the multiple GCS uri
     $gcsSource = (new GcsSource())
-        ->setInputUri($inputUri);
+        ->setInputUris($inputUri);
     $inputConfig = (new BatchPredictInputConfig())
         ->setGcsSource($gcsSource);
     $gcsDestination = (new GcsDestination())
-        ->setInputUri($outputUri);
+        ->setOutputUriPrefix($outputUri);
     $outputConfig = (new BatchPredictOutputConfig())
         ->setGcsDestination($gcsDestination);
     // params is additional domain-specific parameters


### PR DESCRIPTION
**Line 51 needs to have:** 
`->setInputUris($inputUri);`
This is because `->setInputUri($inputUri);` has never worked with the current version since June when we first tried to use the GCP documentation. 

**LINE 55 should have:** 
`->setOutputUriPrefix($outputUri);`
**instead of** 
`->setInputUri($outputUri);`

Both of these are shown on the GCP documentation page, and do not work.
https://cloud.google.com/vision/automl/docs/predict-batch


This fix was **WORKING** until recently, but now `$operationResponse->operationSucceeded()` _(line 71)_ returns false, and `$error->getMessage()` _(line 76)_ returns NULL. 

Either way, the documentation is broken until someone updates it further for us.