### PR TITLE
feat(spanner): add samples for custom timeout and retry settings

### DIFF
--- a/spanner/composer.json
+++ b/spanner/composer.json
@@ -64,7 +64,8 @@
             "src/list_backups.php",
             "src/list_database_operations.php",
             "src/restore_backup.php",
-            "src/update_backup.php"
+            "src/update_backup.php",
+            "src/set_custom_timeout_and_retry.php"
         ]
     }
 }

--- a/spanner/spanner.php
+++ b/spanner/spanner.php
@@ -387,6 +387,18 @@ $application->add((new Command('query-data-with-nested-struct-field'))
     })
 );
 
+// Set custom timeout and retry
+$application->add((new Command('set_custom_timeout_and_retry'))
+    ->setDefinition($inputDefinition)
+    ->setDescription('Sets custom timeout and retry settings.')
+    ->setCode(function ($input, $output) {
+        set_custom_timeout_and_retry(
+            $input->getArgument('instance_id'),
+            $input->getArgument('database_id')
+        );
+    })
+);
+
 // Insert data with DML
 $application->add((new Command('insert-data-with-dml'))
     ->setDefinition($inputDefinition)

--- a/spanner/spanner.php
+++ b/spanner/spanner.php
@@ -388,7 +388,7 @@ $application->add((new Command('query-data-with-nested-struct-field'))
 );
 
 // Set custom timeout and retry
-$application->add((new Command('set_custom_timeout_and_retry'))
+$application->add((new Command('set-custom-timeout-and-retry'))
     ->setDefinition($inputDefinition)
     ->setDescription('Sets custom timeout and retry settings.')
     ->setCode(function ($input, $output) {

--- a/spanner/src/set_custom_timeout_and_retry.php
+++ b/spanner/src/set_custom_timeout_and_retry.php
@@ -26,7 +26,7 @@ namespace Google\Cloud\Samples\Spanner;
 // [START spanner_set_custom_timeout_and_retry]
 use Google\ApiCore\ApiStatus;
 use Google\Cloud\Spanner\SpannerClient;
-use Google\Cloud\Spanner\Database;
+use Google\Cloud\Spanner\Transaction;
 
 /**
  * Set custom timeout and retry settings.

--- a/spanner/src/set_custom_timeout_and_retry.php
+++ b/spanner/src/set_custom_timeout_and_retry.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/spanner/README.md
+ */
+
+namespace Google\Cloud\Samples\Spanner;
+
+// [START spanner_set_custom_timeout_and_retry]
+use Google\ApiCore\RetrySettings;
+use Google\Cloud\Spanner\SpannerClient;
+use Google\Cloud\Spanner\Database;
+
+/**
+ * Set custom timeout and retry settings.
+ * Example:
+ * ```
+ * set_custom_timeout_and_retry($instanceId, $databaseId);
+ * ```
+ *
+ * @param string $instanceId The Spanner instance ID.
+ * @param string $databaseId The Spanner database ID.
+ */
+function set_custom_timeout_and_retry($instanceId, $databaseId)
+{
+    $spanner = new SpannerClient();
+    $instance = $spanner->instance($instanceId);
+    $database = $instance->database($databaseId);
+
+    $customTimeoutMillis = 60000;
+    $customRetrySettings = new RetrySettings([
+        'initialRetryDelayMillis' => 500,
+        'retryDelayMultiplier' => 1.5,
+        'maxRetryDelayMillis' => 64000,
+        'retryableCodes' => [ApiStatus::DEADLINE_EXCEEDED, ApiStatus::UNAVAILABLE],
+    ]);
+    $database->runTransaction(function (Transaction $t) use ($spanner) {
+        $rowCount = $t->executeUpdate(
+            "INSERT Singers (SingerId, FirstName, LastName) "
+            . " VALUES (10, 'Virginia', 'Watson')",
+            [
+                'retrySettings' => $customRetrySettings,
+                'timeoutMillis' => $timeoutMillis,
+            ]);
+        $t->commit();
+        printf('Inserted %d row(s).' . PHP_EOL, $rowCount);
+    });
+}
+// [END spanner_set_custom_timeout_and_retry]

--- a/spanner/src/set_custom_timeout_and_retry.php
+++ b/spanner/src/set_custom_timeout_and_retry.php
@@ -24,6 +24,7 @@
 namespace Google\Cloud\Samples\Spanner;
 
 // [START spanner_set_custom_timeout_and_retry]
+use Google\ApiCore\ApiStatus;
 use Google\ApiCore\RetrySettings;
 use Google\Cloud\Spanner\SpannerClient;
 use Google\Cloud\Spanner\Database;

--- a/spanner/src/set_custom_timeout_and_retry.php
+++ b/spanner/src/set_custom_timeout_and_retry.php
@@ -44,20 +44,18 @@ function set_custom_timeout_and_retry($instanceId, $databaseId)
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);
 
-    $customTimeoutMillis = 60000;
-    $customRetrySettings = [
-        'initialRetryDelayMillis' => 500,
-        'retryDelayMultiplier' => 1.5,
-        'maxRetryDelayMillis' => 64000,
-        'retryableCodes' => [ApiStatus::DEADLINE_EXCEEDED, ApiStatus::UNAVAILABLE],
-    ];
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
             "INSERT Singers (SingerId, FirstName, LastName) "
             . " VALUES (10, 'Virginia', 'Watson')",
             [
-                'retrySettings' => $customRetrySettings,
-                'timeoutMillis' => $timeoutMillis,
+                'retrySettings' => [
+                    'initialRetryDelayMillis' => 500,
+                    'retryDelayMultiplier' => 1.5,
+                    'maxRetryDelayMillis' => 64000,
+                    'retryableCodes' => [ApiStatus::DEADLINE_EXCEEDED, ApiStatus::UNAVAILABLE],
+                ],
+                'timeoutMillis' => 60000,
             ]);
         $t->commit();
         printf('Inserted %d row(s).' . PHP_EOL, $rowCount);

--- a/spanner/src/set_custom_timeout_and_retry.php
+++ b/spanner/src/set_custom_timeout_and_retry.php
@@ -25,7 +25,6 @@ namespace Google\Cloud\Samples\Spanner;
 
 // [START spanner_set_custom_timeout_and_retry]
 use Google\ApiCore\ApiStatus;
-use Google\ApiCore\RetrySettings;
 use Google\Cloud\Spanner\SpannerClient;
 use Google\Cloud\Spanner\Database;
 
@@ -46,12 +45,12 @@ function set_custom_timeout_and_retry($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $customTimeoutMillis = 60000;
-    $customRetrySettings = new RetrySettings([
+    $customRetrySettings = [
         'initialRetryDelayMillis' => 500,
         'retryDelayMultiplier' => 1.5,
         'maxRetryDelayMillis' => 64000,
         'retryableCodes' => [ApiStatus::DEADLINE_EXCEEDED, ApiStatus::UNAVAILABLE],
-    ]);
+    ];
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
             "INSERT Singers (SingerId, FirstName, LastName) "

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -165,6 +165,25 @@ class spannerTest extends TestCase
     /**
      * @depends testDeleteData
      */
+    public function testSetCustomTimeoutAndRetry()
+    {
+        $output = $this->runCommand('set-custom-timeout-and-retry');
+        $this->assertContains('Inserted 1 row(s)', $output);
+
+        // Clear database for other samples
+        $spanner = new SpannerClient();
+        $instance = $spanner->instance(spannerTest::$instanceId);
+        $database = $instance->database(spannerTest::$databaseId);
+
+        $remainingSingers = $spanner->keySet([
+            'all' => true
+        ]);
+        $database->delete('Singers', $remainingSingers);
+    }
+
+    /**
+     * @depends testSetCustomTimeoutAndRetry
+     */
     public function testAddColumn()
     {
         $output = $this->runCommand('add-column');
@@ -421,15 +440,6 @@ class spannerTest extends TestCase
         $output = $this->runCommand('delete-data-with-dml');
         self::$lastUpdateDataTimestamp = time();
         $this->assertContains('Deleted 1 row(s)', $output);
-    }
-
-    /**
-     * @depends testDeleteDataWithDml
-     */
-    public function testSetCustomTimeoutAndRetry()
-    {
-        $output = $this->runCommand('set-custom-timeout-and-retry');
-        $this->assertContains('Inserted 1 row(s)', $output);
     }
 
     /**

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -424,6 +424,15 @@ class spannerTest extends TestCase
     }
 
     /**
+     * @depends testDeleteDataWithDml
+     */
+    public function testSetCustomTimeoutAndRetry()
+    {
+        $output = $this->runCommand('set-custom-timeout-and-retry');
+        $this->assertContains('Inserted 1 row(s)', $output);
+    }
+
+    /**
      * @depends testInsertData
      */
     public function testUpdateDataWithDmlTimestamp()

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -176,7 +176,7 @@ class spannerTest extends TestCase
         $database = $instance->database(spannerTest::$databaseId);
 
         $remainingSingers = $spanner->keySet([
-            'all' => true
+            'keys' =>  [10],
         ]);
         $database->delete('Singers', $remainingSingers);
     }


### PR DESCRIPTION
This sample shows how to set custom timeout and retry settings on client calls.