### PR TITLE
feat(functions): add functions_http_unit_test and functions_http_content

### DIFF
--- a/functions/helloworld_http/composer.json
+++ b/functions/helloworld_http/composer.json
@@ -1,10 +1,5 @@
 {
     "require": {
         "google/cloud-functions-framework": "^0.6"
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Google\\Cloud\\Samples\\Functions\\HelloworldHttp\\Test\\": "test"
-        }
     }
 }

--- a/functions/helloworld_http/test/DeployTest.php
+++ b/functions/helloworld_http/test/DeployTest.php
@@ -22,6 +22,8 @@ namespace Google\Cloud\Samples\Functions\HelloworldHttp\Test;
 use Google\Cloud\TestUtils\CloudFunctionDeploymentTrait;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/TestCasesTrait.php';
+
 /**
  * Class DeployTest.
  *
@@ -37,7 +39,7 @@ class DeployTest extends TestCase
 
     private static $name = 'helloHttp';
 
-    public function testFunction() : void
+    public function testFunction(): void
     {
         foreach (self::cases() as $test) {
             $body = json_encode($test['body']);

--- a/functions/helloworld_http/test/SampleUnitTest.php
+++ b/functions/helloworld_http/test/SampleUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START functions_http_unit_test]
+
+namespace Google\Cloud\Samples\Functions\HelloworldHttp\Test;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SampleUnitTest.
+ *
+ * Unit test for helloHttp.
+ */
+class SampleUnitTest extends TestCase
+{
+    public static function setUpBeforeClass() : void
+    {
+        require_once __DIR__ . '/../index.php';
+    }
+
+    public function testFunction() : void
+    {
+        $name = uniqid();
+        $request = new ServerRequest('POST', '/', [], json_encode(['name' => $name]));
+        $expected = sprintf('Hello, %s!', $name);
+        $actual = helloHttp($request);
+        $this->assertContains($expected, $actual);
+    }
+}
+
+// [END functions_http_unit_test]

--- a/functions/helloworld_http/test/SampleUnitTest.php
+++ b/functions/helloworld_http/test/SampleUnitTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SampleUnitTest extends TestCase
 {
-    public static function setUpBeforeClass() : void
+    public static function setUpBeforeClass(): void
     {
         require_once __DIR__ . '/../index.php';
     }

--- a/functions/helloworld_http/test/SystemTest.php
+++ b/functions/helloworld_http/test/SystemTest.php
@@ -22,6 +22,8 @@ namespace Google\Cloud\Samples\Functions\HelloworldHttp\Test;
 use PHPUnit\Framework\TestCase;
 use Google\Cloud\TestUtils\CloudFunctionLocalTestTrait;
 
+require_once __DIR__ . '/TestCasesTrait.php';
+
 /**
  * Class SystemTest.
  */
@@ -32,7 +34,7 @@ class SystemTest extends TestCase
 
     private static $name = 'helloHttp';
 
-    public function testFunction() : void
+    public function testFunction(): void
     {
         foreach (self::cases() as $test) {
             $body = json_encode($test['body']);

--- a/functions/helloworld_http/test/TestCasesTrait.php
+++ b/functions/helloworld_http/test/TestCasesTrait.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Samples\Functions\HelloworldHttp\Test;
 
 trait TestCasesTrait
 {
-    public static function cases() : array
+    public static function cases(): array
     {
         return [
             [

--- a/functions/helloworld_http/test/UnitTest.php
+++ b/functions/helloworld_http/test/UnitTest.php
@@ -31,12 +31,12 @@ class UnitTest extends TestCase
 
     private static $name = 'helloHttp';
 
-    public static function setUpBeforeClass() : void
+    public static function setUpBeforeClass(): void
     {
         require_once __DIR__ . '/../index.php';
     }
 
-    public function testFunction() : void
+    public function testFunction(): void
     {
         foreach (self::cases() as $test) {
             $body = json_encode($test['body']);

--- a/functions/http_content_type/composer.json
+++ b/functions/http_content_type/composer.json
@@ -1,10 +1,5 @@
 {
     "require": {
         "google/cloud-functions-framework": "^0.6"
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Google\\Cloud\\Samples\\Functions\\HttpContentType\\Test\\": "test"
-        }
     }
 }

--- a/functions/http_content_type/composer.json
+++ b/functions/http_content_type/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "google/cloud-functions-framework": "^0.6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Google\\Cloud\\Samples\\Functions\\HttpContentType\\Test\\": "test"
+        }
+    }
+}

--- a/functions/http_content_type/index.php
+++ b/functions/http_content_type/index.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START functions_http_content]
+
+use Psr\Http\Message\ServerRequestInterface;
+
+function helloContent(ServerRequestInterface $request): string
+{
+    $name = 'World';
+    $body = $request->getBody()->getContents();
+    switch ($request->getHeader('content-type')[0]) {
+        // '{"name":"John"}'
+        case 'application/json':
+          if (!empty($body)) {
+              $json = json_decode($body, true);
+              if (json_last_error() != JSON_ERROR_NONE) {
+                  throw new RuntimeException(sprintf(
+                    'Could not parse body: %s', json_last_error_msg()
+                ));
+              }
+              $name = $json['name'] ?? $name;
+          }
+          break;
+        // 'John', stored in a stream
+        case 'application/octet-stream':
+          $name = $body;
+          break;
+        // 'John'
+        case 'text/plain':
+          $name = $body;
+          break;
+        // 'name=John' in the body of a POST request (not the URL)
+        case 'application/x-www-form-urlencoded':
+          parse_str($body, $data);
+          $name = $data['name'] ?? $name;
+          break;
+    }
+
+    return sprintf('Hello %s!', htmlspecialchars($name));
+}
+
+// [END functions_http_content]

--- a/functions/http_content_type/phpunit.xml.dist
+++ b/functions/http_content_type/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2018 Google LLC
+  Copyright 2020 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/functions/http_content_type/phpunit.xml.dist
+++ b/functions/http_content_type/phpunit.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2018 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
+    <testsuites>
+        <testsuite name="Cloud Functions Hello World HTTP Test Suite">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+            <exclude>
+              <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/functions/http_content_type/test/DeployTest.php
+++ b/functions/http_content_type/test/DeployTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Samples\Functions\HttpContentType\Test;
+
+use Google\Cloud\TestUtils\CloudFunctionDeploymentTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class DeployTest.
+ *
+ * This test is not run by the CI system.
+ *
+ * To skip deployment of a new function, run with "GOOGLE_SKIP_DEPLOYMENT=true".
+ * To skip deletion of the tested function, run with "GOOGLE_KEEP_DEPLOYMENT=true".
+ */
+class DeployTest extends TestCase
+{
+    use CloudFunctionDeploymentTrait;
+    use TestCasesTrait;
+
+    private static $name = 'helloContent';
+
+    public function testFunction() : void
+    {
+        foreach (self::cases() as $test) {
+            $resp = $this->client->post('', [
+                'headers' => ['content-type' => $test['content-type']],
+                'body' => $test['body'],
+                // Uncomment and CURLOPT_VERBOSE debug content will be sent to stdout.
+                // 'debug' => true,
+            ]);
+
+            $actual = trim((string) $resp->getBody());
+
+            $this->assertEquals($test['code'], $resp->getStatusCode(), $test['content-type'] . ':');
+            // Failures often lead to a large HTML page in the response body.
+            $this->assertContains($test['expected'], $actual, $test['content-type'] . ':');
+        }
+    }
+}

--- a/functions/http_content_type/test/DeployTest.php
+++ b/functions/http_content_type/test/DeployTest.php
@@ -20,6 +20,8 @@ namespace Google\Cloud\Samples\Functions\HttpContentType\Test;
 use Google\Cloud\TestUtils\CloudFunctionDeploymentTrait;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/TestCasesTrait.php';
+
 /**
  * Class DeployTest.
  *
@@ -35,7 +37,7 @@ class DeployTest extends TestCase
 
     private static $name = 'helloContent';
 
-    public function testFunction() : void
+    public function testFunction(): void
     {
         foreach (self::cases() as $test) {
             $resp = $this->client->post('', [

--- a/functions/http_content_type/test/SystemTest.php
+++ b/functions/http_content_type/test/SystemTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\Functions\HttpContentType\Test;
+
+use PHPUnit\Framework\TestCase;
+use Google\Cloud\TestUtils\CloudFunctionLocalTestTrait;
+
+/**
+ * Class SystemTest.
+ */
+class SystemTest extends TestCase
+{
+    use CloudFunctionLocalTestTrait;
+    use TestCasesTrait;
+
+    private static $name = 'helloContent';
+
+    public function testFunction() : void
+    {
+        foreach (self::cases() as $test) {
+            $resp = $resp = $this->client->post('/', [
+                'headers' => ['content-type' => $test['content-type']],
+                'body' => $test['body'],
+            ]);
+            $actual = trim((string) $resp->getBody());
+
+            $this->assertEquals($test['code'], $resp->getStatusCode(), $test['content-type'] . ':');
+            // Failures often lead to a large HTML page in the response body.
+            $this->assertContains($test['expected'], $actual, $test['content-type'] . ':');
+        }
+    }
+}

--- a/functions/http_content_type/test/SystemTest.php
+++ b/functions/http_content_type/test/SystemTest.php
@@ -22,6 +22,8 @@ namespace Google\Cloud\Samples\Functions\HttpContentType\Test;
 use PHPUnit\Framework\TestCase;
 use Google\Cloud\TestUtils\CloudFunctionLocalTestTrait;
 
+require_once __DIR__ . '/TestCasesTrait.php';
+
 /**
  * Class SystemTest.
  */
@@ -32,7 +34,7 @@ class SystemTest extends TestCase
 
     private static $name = 'helloContent';
 
-    public function testFunction() : void
+    public function testFunction(): void
     {
         foreach (self::cases() as $test) {
             $resp = $resp = $this->client->post('/', [

--- a/functions/http_content_type/test/TestCasesTrait.php
+++ b/functions/http_content_type/test/TestCasesTrait.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\Functions\HttpContentType\Test;
+
+trait TestCasesTrait
+{
+    public static function cases() : array
+    {
+        return [
+            [
+                'content-type' => 'text/plain',
+                'body' => 'John',
+                'code' => '200',
+                'expected' => 'Hello John!',
+            ],
+            [
+                'content-type' => 'application/json',
+                'body' => json_encode(['name' => 'John']),
+                'code' => '200',
+                'expected' => 'Hello John!',
+            ],
+            [
+                'content-type' => 'application/octet-stream',
+                'body' => 'John',
+                'code' => '200',
+                'expected' => 'Hello John!',
+            ],
+            [
+                'content-type' => 'application/x-www-form-urlencoded',
+                'body' => 'name=John',
+                'code' => '200',
+                'expected' => 'Hello John!',
+            ],
+        ];
+    }
+}

--- a/functions/http_content_type/test/UnitTest.php
+++ b/functions/http_content_type/test/UnitTest.php
@@ -22,6 +22,8 @@ namespace Google\Cloud\Samples\Functions\HttpContentType\Test;
 use GuzzleHttp\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/TestCasesTrait.php';
+
 /**
  * Unit tests for the Cloud Function.
  */
@@ -36,7 +38,7 @@ class UnitTest extends TestCase
         require_once __DIR__ . '/../index.php';
     }
 
-    public function testFunction() : void
+    public function testFunction(): void
     {
         foreach (self::cases() as $test) {
             $request = new ServerRequest('POST', '/', ['content-type' => $test['content-type']], $test['body']);
@@ -45,7 +47,7 @@ class UnitTest extends TestCase
         }
     }
 
-    private static function runFunction($functionName, array $params = [])
+    private static function runFunction($functionName, array $params = []): string
     {
         return call_user_func_array($functionName, $params);
     }

--- a/functions/http_content_type/test/UnitTest.php
+++ b/functions/http_content_type/test/UnitTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\Functions\HttpContentType\Test;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the Cloud Function.
+ */
+class UnitTest extends TestCase
+{
+    use TestCasesTrait;
+
+    private static $name = 'helloContent';
+
+    public static function setUpBeforeClass()
+    {
+        require_once __DIR__ . '/../index.php';
+    }
+
+    public function testFunction() : void
+    {
+        foreach (self::cases() as $test) {
+            $request = new ServerRequest('POST', '/', ['content-type' => $test['content-type']], $test['body']);
+            $actual = $this->runFunction(self::$name, [$request]);
+            $this->assertContains($test['expected'], $actual, $test['content-type'] . ':');
+        }
+    }
+
+    private static function runFunction($functionName, array $params = [])
+    {
+        return call_user_func_array($functionName, $params);
+    }
+}


### PR DESCRIPTION
This PR adds two additional samples.

* functions_http_content is a new function sample that demonstrates handling different content types.
* functions_http_unit_test shows how to write a unit test for a Cloud Function. The existing UnitTest is not a good fit for use as a sample, and rather than refactor it I decided to keep both as a cross-check that the unit test sample for developers and our own (more thorough) testing stay in alignment.