### PR TITLE
chore(functions): Update tests to use new php-tools extension methods

### DIFF
--- a/functions/concepts_filesystem/test/DeployTest.php
+++ b/functions/concepts_filesystem/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'listFiles';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'listFiles';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/concepts_filesystem/test/SystemTest.php
+++ b/functions/concepts_filesystem/test/SystemTest.php
@@ -31,7 +31,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'listFiles';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'listFiles';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/concepts_requests/test/DeployTest.php
+++ b/functions/concepts_requests/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'makeRequest';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'makeRequest';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/concepts_requests/test/SystemTest.php
+++ b/functions/concepts_requests/test/SystemTest.php
@@ -31,7 +31,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'makeRequest';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'makeRequest';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/env_vars/test/DeployTest.php
+++ b/functions/env_vars/test/DeployTest.php
@@ -44,8 +44,21 @@ class DeployTest extends TestCase
     }
 
     /**
-      * @dataProvider cases
-      */
+     * Deploy the Cloud Function, called from DeploymentTrait::deployApp().
+     *
+     * Overrides CloudFunctionDeploymentTrait::doDeploy().
+     */
+    private static function doDeploy()
+    {
+        self::$bucket = self::requireEnv('GOOGLE_STORAGE_BUCKET');
+        return self::$fn->deploy([
+            '--update-env-vars' => 'FOO=bar',
+        ]);
+    }
+
+    /**
+     * @dataProvider cases
+     */
     public function testFunction(
         $statusCode,
         $varName,
@@ -65,11 +78,5 @@ class DeployTest extends TestCase
         $actual = trim((string) $resp->getBody());
         // Failures often lead to a large HTML page in the response body.
         $this->assertEquals($expected, $actual);
-    }
-
-    protected static function deployFlags(array $flags = []): array
-    {
-        $flags['--update-env-vars'] = 'FOO=bar';
-        return $flags;
     }
 }

--- a/functions/env_vars/test/DeployTest.php
+++ b/functions/env_vars/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'envVar';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'envVar';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/env_vars/test/SystemTest.php
+++ b/functions/env_vars/test/SystemTest.php
@@ -31,7 +31,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'envVar';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'envVar';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/env_vars/test/SystemTest.php
+++ b/functions/env_vars/test/SystemTest.php
@@ -38,6 +38,14 @@ class SystemTest extends TestCase
     }
 
     /**
+     * Overrides CloudFunctionLocalTestTrait::doRun().
+     */
+    private static function doRun()
+    {
+        return self::$fn->run(['FOO' => 'bar']);
+    }
+
+    /**
       * @dataProvider cases
       */
     public function testFunction(
@@ -45,9 +53,6 @@ class SystemTest extends TestCase
         $varName,
         $varValue
     ): void {
-        // Check the target env variable
-        $this->requireEnv($varName);
-
         // Send a request to the function.
         $resp = $this->client->get('/');
 

--- a/functions/helloworld_get/test/DeployTest.php
+++ b/functions/helloworld_get/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloGet';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloGet';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/helloworld_get/test/SystemTest.php
+++ b/functions/helloworld_get/test/SystemTest.php
@@ -31,7 +31,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloGet';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloGet';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/helloworld_http/test/DeployTest.php
+++ b/functions/helloworld_http/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloHttp';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloHttp';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/helloworld_http/test/SampleUnitTest.php
+++ b/functions/helloworld_http/test/SampleUnitTest.php
@@ -29,6 +29,11 @@ use PHPUnit\Framework\TestCase;
  */
 class SampleUnitTest extends TestCase
 {
+    /**
+     * Include the Cloud Function code before running any tests.
+     *
+     * @see https://phpunit.readthedocs.io/en/latest/fixtures.html
+     */
     public static function setUpBeforeClass(): void
     {
         require_once __DIR__ . '/../index.php';

--- a/functions/helloworld_http/test/SystemTest.php
+++ b/functions/helloworld_http/test/SystemTest.php
@@ -32,7 +32,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloHttp';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloHttp';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/http_content_type/test/DeployTest.php
+++ b/functions/http_content_type/test/DeployTest.php
@@ -35,7 +35,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloContent';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloContent';
+        return $props;
+    }
 
     public function testFunction(): void
     {

--- a/functions/http_content_type/test/SystemTest.php
+++ b/functions/http_content_type/test/SystemTest.php
@@ -32,7 +32,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloContent';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloContent';
+        return $props;
+    }
 
     public function testFunction(): void
     {

--- a/functions/http_cors/test/DeployTest.php
+++ b/functions/http_cors/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'corsEnabledFunction';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'corsEnabledFunction';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/http_cors/test/SystemTest.php
+++ b/functions/http_cors/test/SystemTest.php
@@ -31,7 +31,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'corsEnabledFunction';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'corsEnabledFunction';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/http_form_data/test/DeployTest.php
+++ b/functions/http_form_data/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'uploadFile';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'uploadFile';
+        return $props;
+    }
 
     /**
      * @dataProvider cases

--- a/functions/http_form_data/test/SystemTest.php
+++ b/functions/http_form_data/test/SystemTest.php
@@ -32,7 +32,12 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'uploadFile';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'uploadFile';
+        return $props;
+    }
+
 
     /**
      * @dataProvider cases

--- a/functions/http_method/test/DeployTest.php
+++ b/functions/http_method/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'httpMethod';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'httpMethod';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/http_method/test/SystemTest.php
+++ b/functions/http_method/test/SystemTest.php
@@ -31,7 +31,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'httpMethod';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'httpMethod';
+        return $props;
+    }
 
     /**
       * @dataProvider cases

--- a/functions/log_helloworld/test/DeployTest.php
+++ b/functions/log_helloworld/test/DeployTest.php
@@ -37,7 +37,11 @@ class DeployTest extends TestCase
     use CloudFunctionDeploymentTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloLogging';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloHttp';
+        return $props;
+    }
 
     public function testFunction(): void
     {

--- a/functions/log_helloworld/test/SystemTest.php
+++ b/functions/log_helloworld/test/SystemTest.php
@@ -31,7 +31,11 @@ class SystemTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $name = 'helloLogging';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloHttp';
+        return $props;
+    }
 
     public function testFunction(): void
     {


### PR DESCRIPTION
Note I expect the `env_vars` System Test to fail unless the CI environment has a "FOO" variable set.

This is a pre-existing bug, and likewise a remaining gap in the php-tools implementation of `CloudFunction::run()`