### PR TITLE
docs: cleanup README for eventarc

### DIFF
--- a/eventarc/generic/README.md
+++ b/eventarc/generic/README.md
@@ -83,20 +83,6 @@ source for our sample.
 
     *This will take a few minutes to build and deploy.*
 
-1. [Build the container using Cloud Build](https://cloud.google.com/run/docs/building/containers#builder)
-
-    ```sh
-    gcloud builds submit --tag gcr.io/$(gcloud config get-value project)/eventarc-generic-php
-    ```
-
-1. [Deploy the container](https://cloud.google.com/run/docs/deploying#service)
-
-    ```sh
-    gcloud run deploy eventarc-generic-php \
-      --image gcr.io/$(gcloud config get-value project)/eventarc-generic-php \
-      --allow-unauthenticated
-    ```
-
     The command line will display the service URL when deployment is complete.
 
 ### Create an Eventarc Trigger

--- a/eventarc/generic/README.md
+++ b/eventarc/generic/README.md
@@ -79,11 +79,11 @@ source for our sample.
 
 ## Run the sample on Cloud Run
 
-1. [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30"/>][run_button_generic]
+### Deploy to Cloud Run
 
-    *This will take a few minutes to build and deploy.*
+[<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30"/>][run_button_generic]
 
-    The command line will display the service URL when deployment is complete.
+*This will take a few minutes to build and deploy.*
 
 ### Create an Eventarc Trigger
 

--- a/eventarc/generic/README.md
+++ b/eventarc/generic/README.md
@@ -2,8 +2,6 @@
 
 # Eventarc – Generic – PHP Sample
 
-[<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30"/>][run_button_generic]
-
 This directory contains a sample for receiving a generic event using Cloud Run
 and Eventarc with PHP. For testing purposes, we use Cloud Pub/Sub as an event
 source for our sample.
@@ -80,6 +78,10 @@ source for our sample.
     Exit the container with `Ctrl-D`.
 
 ## Run the sample on Cloud Run
+
+1. [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30"/>][run_button_generic]
+
+    *This will take a few minutes to build and deploy.*
 
 1. [Build the container using Cloud Build](https://cloud.google.com/run/docs/building/containers#builder)
 


### PR DESCRIPTION
This replaces the manual steps to deploy to Cloud Run with the Cloud Run button