### PR TITLE
docs: standardize region tagging

### DIFF
--- a/asset/src/search_all_iam_policies.php
+++ b/asset/src/search_all_iam_policies.php
@@ -26,6 +26,7 @@ $query = isset($argv[2]) ? $argv[2] : '';
 $pageSize = isset($argv[3]) ? (int) $argv[3] : 0;
 $pageToken = isset($argv[4]) ? $argv[4] : '';
 
+// [START asset_quickstart_search_all_iam_policies]
 // [START asset_search_all_iam_policies]
 use Google\Cloud\Asset\V1\AssetServiceClient;
 
@@ -50,3 +51,4 @@ foreach ($response->getPage() as $policy) {
     print($policy->getResource() . PHP_EOL);
 }
 // [END asset_search_all_iam_policies]
+// [END asset_quickstart_search_all_iam_policies]

--- a/asset/src/search_all_resources.php
+++ b/asset/src/search_all_resources.php
@@ -28,6 +28,7 @@ $pageSize = isset($argv[4]) ? (int) $argv[4] : 0;
 $pageToken = isset($argv[5]) ? $argv[5] : '';
 $orderBy = isset($argv[6]) ? $argv[6] : '';
 
+// [START asset_quickstart_search_all_resources]
 // [START asset_search_all_resources]
 use Google\Cloud\Asset\V1\AssetServiceClient;
 
@@ -56,3 +57,4 @@ foreach ($response->getPage() as $resource) {
     print($resource->getName() . PHP_EOL);
 }
 // [END asset_search_all_resources]
+// [END asset_quickstart_search_all_resources]


### PR DESCRIPTION
Standardizing some region tags. Will come back through and remove the 'inner' tags once docs are updated to represent the newly merged 'outer' tags.