### PR TITLE
chore(functions): add missing HTTP test snippet

### DIFF
--- a/functions/helloworld_http/test/SystemTest.php
+++ b/functions/helloworld_http/test/SystemTest.php
@@ -17,6 +17,7 @@
 
 declare(strict_types=1);
 
+// [START functions_http_integration_test]
 namespace Google\Cloud\Samples\Functions\HelloworldHttp\Test;
 
 use PHPUnit\Framework\TestCase;
@@ -54,3 +55,4 @@ class SystemTest extends TestCase
         $this->assertContains($expected, $actual, $label . ':');
     }
 }
+// [END functions_http_integration_test]


### PR DESCRIPTION
**Note:** this snippet would refer to some of our testing infrastructure (namely `CloudFunctionLocalTestTrait`) publicly. We may want to consider using something else in this sample if we don't want to suggest that to customers.