### PR TITLE
chore: remove cloud run button from eventarc generic README

### DIFF
--- a/eventarc/generic/README.md
+++ b/eventarc/generic/README.md
@@ -2,8 +2,6 @@
 
 # Eventarc – Generic – PHP Sample
 
-[<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30"/>][run_button_generic]
-
 This directory contains a sample for receiving a generic event using Cloud Run
 and Eventarc with PHP. For testing purposes, we use Cloud Pub/Sub as an event
 source for our sample.


### PR DESCRIPTION
The cloud run button isn't given any context here, so it's better to just remove it or refactor the README to make it work (see #1227)