### PR TITLE
samples(spanner): PITR samples backup fix

### DIFF
--- a/spanner/src/create_backup.php
+++ b/spanner/src/create_backup.php
@@ -44,7 +44,7 @@ function create_backup($instanceId, $databaseId, $backupId)
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);
 
-    $results = $database->execute("SELECT CURRENT_TIMESTAMP() as Timestamp");
+    $results = $database->execute("SELECT TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), MICROSECOND) as Timestamp");
     $row = $results->rows()->current();
 
     $expireTime = new \DateTime('+14 days');

--- a/spanner/src/create_backup.php
+++ b/spanner/src/create_backup.php
@@ -31,27 +31,24 @@ use Google\Cloud\Spanner\SpannerClient;
  * Create a backup.
  * Example:
  * ```
- * create_backup($instanceId, $databaseId, $backupId);
+ * create_backup($instanceId, $databaseId, $backupId, $versionTime);
  * ```
  *
  * @param string $instanceId The Spanner instance ID.
  * @param string $databaseId The Spanner database ID.
  * @param string $backupId The Spanner backup ID.
+ * @param string $versionTime The version of the database to backup.
  */
-function create_backup($instanceId, $databaseId, $backupId)
+function create_backup($instanceId, $databaseId, $backupId, $versionTime)
 {
     $spanner = new SpannerClient();
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);
 
-    $results = $database->execute("SELECT TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), MICROSECOND) as Timestamp");
-    $row = $results->rows()->current();
-
     $expireTime = new \DateTime('+14 days');
-    $versionTime = new \DateTime($row['Timestamp']);
     $backup = $instance->backup($backupId);
     $operation = $backup->create($database->name(), $expireTime, [
-        'versionTime' => $versionTime
+        'versionTime' => new \DateTime($versionTime)
     ]);
 
     print('Waiting for operation to complete...' . PHP_EOL);

--- a/spanner/src/create_backup.php
+++ b/spanner/src/create_backup.php
@@ -48,7 +48,7 @@ function create_backup($instanceId, $databaseId, $backupId)
     $row = $results->rows()->current();
 
     $expireTime = new \DateTime('+14 days');
-    $versionTime = $row['Timestamp'];
+    $versionTime = new \DateTime($row['Timestamp']);
     $backup = $instance->backup($backupId);
     $operation = $backup->create($database->name(), $expireTime, [
         'versionTime' => $versionTime

--- a/spanner/src/create_backup.php
+++ b/spanner/src/create_backup.php
@@ -48,7 +48,7 @@ function create_backup($instanceId, $databaseId, $backupId)
     $row = $results->rows()->current();
 
     $expireTime = new \DateTime('+14 days');
-    $versionTime = new \DateTime($row['Timestamp']);
+    $versionTime = $row['Timestamp'];
     $backup = $instance->backup($backupId);
     $operation = $backup->create($database->name(), $expireTime, [
         'versionTime' => $versionTime

--- a/spanner/src/create_backup.php
+++ b/spanner/src/create_backup.php
@@ -44,8 +44,11 @@ function create_backup($instanceId, $databaseId, $backupId)
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);
 
+    $results = $database->execute("SELECT CURRENT_TIMESTAMP() as Timestamp");
+    $row = $results->rows()->current();
+
     $expireTime = new \DateTime('+14 days');
-    $versionTime = new \DateTime($database->info()['earliestVersionTime']);
+    $versionTime = new \DateTime($row['Timestamp']);
     $backup = $instance->backup($backupId);
     $operation = $backup->create($database->name(), $expireTime, [
         'versionTime' => $versionTime

--- a/spanner/test/spannerBackupTest.php
+++ b/spanner/test/spannerBackupTest.php
@@ -56,6 +56,9 @@ class spannerBackupTest extends TestCase
     /** @var $instance Instance */
     protected static $instance;
 
+    /** @var string $versionTime */
+    protected static $versionTime;
+
     public static function setUpBeforeClass(): void
     {
         self::checkProjectEnvVars();
@@ -74,6 +77,11 @@ class spannerBackupTest extends TestCase
         self::$backupId = 'backup-' . self::$databaseId;
         self::$restoredDatabaseId = self::$databaseId . '-res';
         self::$instance = $spanner->instance(self::$instanceId);
+
+        $database = self::$instance->database($databaseId);
+        $results = $database->execute("SELECT TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), MICROSECOND) as Timestamp");
+        $row = $results->rows()->current();
+        self::$versionTime = $row['Timestamp'];
     }
 
     public function testCreateDatabaseWithVersionRetentionPeriod()
@@ -105,6 +113,7 @@ class spannerBackupTest extends TestCase
         $output = $this->runFunctionSnippet('create_backup', [
             self::$databaseId,
             self::$backupId,
+            self::$versionTime,
         ]);
         $this->assertStringContainsString(self::$backupId, $output);
     }


### PR DESCRIPTION
Instead of using the earliest version time of the database, uses the current time (from spanner). If we used the earliest version time of the database instead we would be creating an empty backup, since the database we are backing up is not 1 hour old (default version retention period).