### PR TITLE
chore(GAE logging): fix slow tests

### DIFF
--- a/appengine/standard/logging/test/DeployTest.php
+++ b/appengine/standard/logging/test/DeployTest.php
@@ -41,17 +41,22 @@ class DeployTest extends TestCase
             $response->getBody()->getContents()
         );
 
-        $this->verifyLog('This will show up as log level INFO', 'info');
+        $this->verifyLog('This will show up as log level INFO', 'info', 3);
+
+        // These need fewer retries than the above call,
+        // they should succeed if the above call has too.
         $this->verifyLog('This will show up as log level WARNING', 'warning');
         $this->verifyLog('This will show up as log level ERROR', 'error');
     }
 
-    private function verifyLog($message, $level, $retryCount = 5)
+    private function verifyLog($message, $level, $retryCount = 1)
     {
+        $fiveMinAgo = date(\DateTime::RFC3339, strtotime('-5 minutes'));
         $filter = sprintf(
-            'resource.type = "gae_app" AND severity = "%s" AND logName = "%s"',
+            'resource.type="gae_app" severity="%s" logName="%s" timestamp>="%s"',
             strtoupper($level),
-            sprintf('projects/%s/logs/app', self::$projectId)
+            sprintf('projects/%s/logs/app', self::$projectId),
+            $fiveMinAgo
         );
         $logOptions = [
             'pageSize' => 20,

--- a/appengine/standard/logging/test/DeployTest.php
+++ b/appengine/standard/logging/test/DeployTest.php
@@ -43,13 +43,13 @@ class DeployTest extends TestCase
 
         $this->verifyLog('This will show up as log level INFO', 'info', 3);
 
-        // These need fewer retries than the above call,
-        // they should succeed if the above call has too.
+        // These should succeed if the above call has too.
+        // Thus, they need fewer retries!
         $this->verifyLog('This will show up as log level WARNING', 'warning');
         $this->verifyLog('This will show up as log level ERROR', 'error');
     }
 
-    private function verifyLog($message, $level, $retryCount = 1)
+    private function verifyLog($message, $level, $retryCount = 2)
     {
         $fiveMinAgo = date(\DateTime::RFC3339, strtotime('-5 minutes'));
         $filter = sprintf(


### PR DESCRIPTION
40 minutes -> 4 minutes. 😉 

(The secret was to add a time limit filter to the logs calls!)