### PR TITLE
fix: helloworld pubsub sample

### DIFF
--- a/functions/helloworld_pubsub/index.php
+++ b/functions/helloworld_pubsub/index.php
@@ -24,8 +24,10 @@ function helloworldPubsub(CloudEvent $event): void
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
 
     $cloudEventData = $event->getData();
-    if (isset($cloudEventData['data'])) {
-        $name = htmlspecialchars(base64_decode($cloudEventData['data']));
+    $pubSubData = $cloudEventData['message']['data'];
+
+    if ($pubSubData) {
+        $name = htmlspecialchars(base64_decode($pubSubData));
     } else {
         $name = 'World';
     }

--- a/functions/helloworld_pubsub/index.php
+++ b/functions/helloworld_pubsub/index.php
@@ -24,10 +24,10 @@ function helloworldPubsub(CloudEvent $event): void
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
 
     $cloudEventData = $event->getData();
-    $pubSubData = $cloudEventData['message']['data'];
+    $pubSubData = base64_decode($cloudEventData['message']['data']);
 
     if ($pubSubData) {
-        $name = htmlspecialchars(base64_decode($pubSubData));
+        $name = htmlspecialchars($pubSubData);
     } else {
         $name = 'World';
     }

--- a/functions/helloworld_pubsub/test/DeployTest.php
+++ b/functions/helloworld_pubsub/test/DeployTest.php
@@ -72,10 +72,6 @@ class DeployTest extends TestCase
         // Send Pub/Sub message.
         $this->publishMessage($name);
 
-        // Give event and log systems a head start.
-        // If log retrieval fails to find logs for our function within retry limit, increase sleep time.
-        sleep(60);
-
         $fiveMinAgo = date(\DateTime::RFC3339, strtotime('-5 minutes'));
         $this->processFunctionLogs($fiveMinAgo, function (\Iterator $logs) use ($name, $expected, $label) {
             // Concatenate all relevant log messages.

--- a/functions/helloworld_pubsub/test/IntegrationTest.php
+++ b/functions/helloworld_pubsub/test/IntegrationTest.php
@@ -60,7 +60,9 @@ class IntegrationTest extends TestCase
                     'type' => 'google.cloud.pubsub.topic.v1.messagePublished',
                 ],
                 'data' => [
-                    'data' => base64_encode('John')
+                    'message' => [
+                        'data' => base64_encode('John')
+                    ]
                 ],
                 'statusCode' => 200,
                 'expected' => 'Hello, John!',


### PR DESCRIPTION
- Fixes how pubsub message data is handled in the sample
- Removes `sleep` from test, since this is handled by retrying in `processFunctionsLogs`