### PR TITLE
fix: functions slack sample

### DIFF
--- a/functions/slack_slash_command/index.php
+++ b/functions/slack_slash_command/index.php
@@ -38,8 +38,8 @@ function isValidSlackWebhook(ServerRequestInterface $request): bool
     }
 
     // Compute signature
-    $plaintext = 'v0:' . $timestamp . ':' . (string) $request->getBody();
-    $hash = 'v0=' . hash_hmac('sha256', $plaintext, $SLACK_SECRET);
+    $plaintext = sprintf('v0:%s:%s', $timestamp, $request->getBody());
+    $hash = sprintf('v0=%s', hash_hmac('sha256', $plaintext, $SLACK_SECRET));
 
     return $hash === $signature;
 }
@@ -83,7 +83,7 @@ function formatSlackMessage(Google_Service_Kgsearch_SearchResponse $kgResponse, 
         ], $attachmentJson);
     }
 
-    if ($entity['image']) {
+    if (isset($entity['image'])) {
         $imageJson = $entity['image'];
         $attachmentJson['image_url'] = $imageJson['contentUrl'];
     }

--- a/functions/slack_slash_command/test/IntegrationTest.php
+++ b/functions/slack_slash_command/test/IntegrationTest.php
@@ -32,8 +32,6 @@ class IntegrationTest extends TestCase
     use CloudFunctionLocalTestTrait;
     use TestCasesTrait;
 
-    private static $entryPoint = 'receiveRequest';
-
     /**
      * Run the PHP server locally for the defined function.
      *
@@ -42,8 +40,8 @@ class IntegrationTest extends TestCase
     private static function doRun()
     {
         self::$fn->run([
-            'SLACK_SECRET' => self::requireEnv('SLACK_SECRET'),
-            'KG_API_KEY' => self::requireEnv('KG_API_KEY'),
+            'SLACK_SECRET' => self::$slackSecret,
+            'KG_API_KEY' => self::$kgApiKey,
         ]);
     }
 

--- a/functions/slack_slash_command/test/TestCasesTrait.php
+++ b/functions/slack_slash_command/test/TestCasesTrait.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 
 namespace Google\Cloud\Samples\Functions\SlackSlashCommand\Test;
 
-use Google\Cloud\TestUtils\CloudFunctionLocalTestTrait;
 use Google\Cloud\TestUtils\TestTrait;
 
 trait TestCasesTrait


### PR DESCRIPTION
- fix timestamp - it was evaluating as empty because it was set to the string `'0'`
- Wrote a unit test for debugging and figured we might as well keep it
- misc test / function cleanup