### PR TITLE
chore(Cloud SQL): upgrade PHP version from 7.2 to 7.4

### DIFF
--- a/cloud_sql/mysql/pdo/app.standard.yaml
+++ b/cloud_sql/mysql/pdo/app.standard.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: php72
+runtime: php74
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
 # something like https://cloud.google.com/secret-manager/ to help keep secrets secret.

--- a/cloud_sql/postgres/pdo/app.standard.yaml
+++ b/cloud_sql/postgres/pdo/app.standard.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: php72
+runtime: php74
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
 # something like https://cloud.google.com/secret-manager/ to help keep secrets secret.


### PR DESCRIPTION
Now that #1336 has landed (and #1242 has been obviated), I'm moving some `app.yaml` fixes from the latter to a separate PR.