### PR TITLE
Update CODEOWNERS / Blunderbuss for SoDA teams

### DIFF
--- a/.github/.blunderbuss.yml
+++ b/.github/.blunderbuss.yml
@@ -1,0 +1,23 @@
+assign_issues_by:
+ - labels:
+  - 'api: bigtable'
+  - 'api: datastore'
+  - 'api: firestore'
+  to:
+  - GoogleCloudPlatform/cloud-native-db-dpes
+- labels:
+  - 'api: cloudsql'
+  to:
+  - GoogleCloudPlatform/infra-db-dpes
+
+assign_prs_by:
+ - labels:
+  - 'api: bigtable'
+  - 'api: datastore'
+  - 'api: firestore'
+  to:
+  - GoogleCloudPlatform/cloud-native-db-dpes
+- labels:
+  - 'api: cloudsql'
+  to:
+  - GoogleCloudPlatform/infra-db-dpes

--- a/.github/.blunderbuss.yml
+++ b/.github/.blunderbuss.yml
@@ -1,5 +1,5 @@
 assign_issues_by:
- - labels:
+- labels:
   - 'api: bigtable'
   - 'api: datastore'
   - 'api: firestore'
@@ -11,7 +11,7 @@ assign_issues_by:
   - GoogleCloudPlatform/infra-db-dpes
 
 assign_prs_by:
- - labels:
+- labels:
   - 'api: bigtable'
   - 'api: datastore'
   - 'api: firestore'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,10 +9,10 @@
 # explicitly taken by someone else.
 *                         @GoogleCloudPlatform/php-admins
 
-/bigtable/                @GoogleCloudPlatform/bigtable-dpe @GoogleCloudPlatform/php-admins
-/cloud_sql/               @GoogleCloudPlatform/cloud-sql-dpes @GoogleCloudPlatform/php-admins
-/datastore/               @GoogleCloudPlatform/firestore-dpe @GoogleCloudPlatform/php-admins
-/firestore/               @GoogleCloudPlatform/firestore-dpe @GoogleCloudPlatform/php-admins
+/bigtable/**/*.php        @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/php-admins
+/cloud_sql/**/*.php       @GoogleCloudPlatform/infra-db-dpes @GoogleCloudPlatform/php-admins
+/datastore/**/*.php       @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/php-admins
+/firestore/**/*.php       @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/php-admins
 /iot/                     @gcseh @GoogleCloudPlatform/api-iot @GoogleCloudPlatform/php-admins
 /storage/                 @GoogleCloudPlatform/storage-dpe @GoogleCloudPlatform/php-admins
 


### PR DESCRIPTION
Updates the CODEOWNERs file and Blunderbuss config for new teamsync managed groups

Before merging, please make sure the follow teams have write access for this repo:

- [ ] `@GoogleCloudPlatform/cloud-native-db-dpes`
- [ ] `@GoogleCloudPlatform/infra-db-dpes`
- [ ] verify blunderbuss is enabled for this repo