### PR TITLE
feat(tests): use a single container with multiple php versions

### DIFF
--- a/.kokoro/php73.cfg
+++ b/.kokoro/php73.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php73"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php-multi-test"
 }
 
 # Give the docker image a unique project ID and credentials per PHP version

--- a/.kokoro/php74.cfg
+++ b/.kokoro/php74.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php74"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php-multi-test"
 }
 
 # Give the docker image a unique project ID and credentials per PHP version

--- a/.kokoro/php80.cfg
+++ b/.kokoro/php80.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php80"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php-multi-test"
 }
 
 # Give the docker image a unique project ID and credentials per PHP version

--- a/.kokoro/system_tests.sh
+++ b/.kokoro/system_tests.sh
@@ -50,10 +50,21 @@ mkdir -p build/logs
 
 export PULL_REQUEST_NUMBER=$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
+# decide which php version to use (this is for TESTING ONLY)
+if [ "3" -eq ${GOOGLE_ALT_PROJECT_ID: -1} ]; then
+  phpbrew switch "7.3.28"
+elif [ "1" -eq ${GOOGLE_ALT_PROJECT_ID: -1} ]; then
+  phpbrew switch "7.4.20"
+elif [ "2" -eq ${GOOGLE_ALT_PROJECT_ID: -1} ]; then
+  phpbrew switch "8.0.7"
+else
+  # By default use PHP 7.4
+  phpbrew switch "7.4.20"
+fi
+
 # If we are running REST tests, disable gRPC
 if [ "${RUN_REST_TESTS_ONLY}" = "true" ]; then
-  GRPC_INI=$(php -i | grep grpc.ini | sed 's/^Additional .ini files parsed => //g' | sed 's/,*$//g' )
-  mv $GRPC_INI "${GRPC_INI}.disabled"
+  phpbrew ext disable grpc
 fi
 
 # Install global test dependencies


### PR DESCRIPTION
The goal here is to eventually break the tests down by sample directory instead of by PHP version. This will greatly simplify the complexity of our testing and speed up test execution. 