### PR TITLE
Refactoring set, get and disable usage export bucket samples

### DIFF
--- a/compute/cloud-client/instances/README.md
+++ b/compute/cloud-client/instances/README.md
@@ -101,6 +101,24 @@ $ php src/delete_instance.php $YOUR_PROJECT_ID "us-central1-a" "my-new-instance-
 Deleted instance my-new-instance-name
 ```
 
+### Set usage export bucket
+
+```
+$ php src/set_usage_export_bucket.php $YOUR_PROJECT_ID "my-gcs-bucket-name" "my-report-name-prefix"
+```
+
+### Get usage export bucket
+
+```
+$ php src/get_usage_export_bucket.php $YOUR_PROJECT_ID
+```
+
+### Disable usage export bucket
+
+```
+$ php src/disable_usage_export_bucket.php $YOUR_PROJECT_ID
+```
+
 ## Troubleshooting
 
 If you get the following error, set the environment variable `GCLOUD_PROJECT` to your project ID:

--- a/compute/cloud-client/instances/src/disable_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/disable_usage_export_bucket.php
@@ -25,7 +25,6 @@ namespace Google\Cloud\Samples\Compute;
 
 # [START compute_usage_report_disable]
 use Google\Cloud\Compute\V1\ProjectsClient;
-use Google\Cloud\Compute\V1\UsageExportLocation;
 
 /**
  * Disable Compute Engine usage export bucket for the Cloud Project.

--- a/compute/cloud-client/instances/src/disable_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/disable_usage_export_bucket.php
@@ -25,6 +25,8 @@ namespace Google\Cloud\Samples\Compute;
 
 # [START compute_usage_report_disable]
 use Google\Cloud\Compute\V1\ProjectsClient;
+use Google\Cloud\Compute\V1\GlobalOperationsClient;
+use Google\Cloud\Compute\V1\Operation;
 
 /**
  * Disable Compute Engine usage export bucket for the Cloud Project.
@@ -35,20 +37,23 @@ use Google\Cloud\Compute\V1\ProjectsClient;
  *
  * @param string $projectId Your Google Cloud project ID.
  *
- * @return \Google\Cloud\Compute\V1\Operation
- *
  * @throws \Google\ApiCore\ApiException if the remote call fails.
  */
 function disable_usage_export_bucket(string $projectId)
 {
     // Disable the usage export location by sending null as usageExportLocationResource.
     $projectsClient = new ProjectsClient();
-    return $projectsClient->setUsageExportBucket($projectId, null);
+    $operation = $projectsClient->setUsageExportBucket($projectId, null);
+
+    // Wait for the set operation to complete.
+    if ($operation->getStatus() === Operation\Status::RUNNING) {
+        $operationClient = new GlobalOperationsClient();
+        $operationClient->wait($operation->getName(), $projectId);
+    }
+
+    printf("Compute Engine usage export bucket for project `%s` disabled.", $projectId);
 }
 # [END compute_usage_report_disable]
 
-// Run the sample only if called directly
-if (__FILE__ == get_included_files()[0]) {
-    require_once __DIR__ . '/../../../../testing/sample_helpers.php';
-    \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
-}
+require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/compute/cloud-client/instances/src/disable_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/disable_usage_export_bucket.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/compute/cloud-client/README.md
+ */
+
+namespace Google\Cloud\Samples\Compute;
+
+# [START compute_usage_report_disable]
+use Google\Cloud\Compute\V1\ProjectsClient;
+use Google\Cloud\Compute\V1\UsageExportLocation;
+
+/**
+ * Disable Compute Engine usage export bucket for the Cloud Project.
+ * Example:
+ * ```
+ * disable_usage_export_bucket($projectId);
+ * ```
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ *
+ * @return \Google\Cloud\Compute\V1\Operation
+ *
+ * @throws \Google\ApiCore\ApiException if the remote call fails.
+ */
+function disable_usage_export_bucket(string $projectId)
+{
+    // Disable the usage export location by sending null as usageExportLocationResource.
+    $projectsClient = new ProjectsClient();
+    return $projectsClient->setUsageExportBucket($projectId, null);
+}
+# [END compute_usage_report_disable]
+
+// Run the sample only if called directly
+if (__FILE__ == get_included_files()[0]) {
+    require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+    \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
+}

--- a/compute/cloud-client/instances/src/get_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/get_usage_export_bucket.php
@@ -25,7 +25,6 @@ namespace Google\Cloud\Samples\Compute;
 
 # [START compute_usage_report_get]
 use Google\Cloud\Compute\V1\ProjectsClient;
-use Google\Cloud\Compute\V1\UsageExportLocation;
 
 /**
  * Retrieve Compute Engine usage export bucket for the Cloud project.
@@ -63,7 +62,7 @@ function get_usage_export_bucket(string $projectId)
 
         printf(
             "Compute Engine usage export bucket for project `%s` is bucket_name = `%s` with " .
-            "report_name_prefix = `%s`.". PHP_EOL,
+            "report_name_prefix = `%s`." . PHP_EOL,
             $projectId,
             $responseUsageExportLocation->getBucketName(),
             $responseUsageExportLocation->getReportNamePrefix()

--- a/compute/cloud-client/instances/src/get_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/get_usage_export_bucket.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/compute/cloud-client/README.md
+ */
+
+namespace Google\Cloud\Samples\Compute;
+
+# [START compute_usage_report_get]
+use Google\Cloud\Compute\V1\ProjectsClient;
+use Google\Cloud\Compute\V1\UsageExportLocation;
+
+/**
+ * Retrieve Compute Engine usage export bucket for the Cloud project.
+ * Replaces the empty value returned by the API with the default value used
+ * to generate report file names.
+ * Example:
+ * ```
+ * get_usage_export_bucket($projectId);
+ * ```
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ * @return UsageExportLocation|null UsageExportLocation object describing the current usage
+ * export settings for project $projectId.
+ *
+ * @throws \Google\ApiCore\ApiException if the remote call fails.
+ */
+function get_usage_export_bucket(string $projectId)
+{
+    // Get the usage export location for the project from the server.
+    $projectsClient = new ProjectsClient();
+    $projectResponse = $projectsClient->get($projectId);
+
+    // Replace the empty value returned by the API with the default value used to generate report file names.
+    if ($projectResponse->hasUsageExportLocation()) {
+        $responseUsageExportLocation = $projectResponse->getUsageExportLocation();
+
+        // Verify that the server explicitly sent the optional field.
+        if ($responseUsageExportLocation->hasReportNamePrefix()) {
+            if ($responseUsageExportLocation->getReportNamePrefix() == '') {
+                // Although the server explicitly sent the empty string value, the next usage
+                // report generated with these settings still has the default prefix value "usage_gce".
+                // See https://cloud.google.com/compute/docs/reference/rest/v1/projects/get
+                print("Report name prefix not set, replacing with default value of `usage_gce`.");
+                $responseUsageExportLocation->setReportNamePrefix('usage_gce');
+            }
+        }
+
+        return $responseUsageExportLocation;
+    } else {
+        // The usage reports are disabled.
+        return null;
+    }
+}
+# [END compute_usage_report_get]
+
+// Run the sample only if called directly
+if (__FILE__ == get_included_files()[0]) {
+    require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+    \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
+}

--- a/compute/cloud-client/instances/src/get_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/get_usage_export_bucket.php
@@ -37,8 +37,6 @@ use Google\Cloud\Compute\V1\UsageExportLocation;
  * ```
  *
  * @param string $projectId Your Google Cloud project ID.
- * @return UsageExportLocation|null UsageExportLocation object describing the current usage
- * export settings for project $projectId.
  *
  * @throws \Google\ApiCore\ApiException if the remote call fails.
  */
@@ -58,21 +56,24 @@ function get_usage_export_bucket(string $projectId)
                 // Although the server explicitly sent the empty string value, the next usage
                 // report generated with these settings still has the default prefix value "usage_gce".
                 // See https://cloud.google.com/compute/docs/reference/rest/v1/projects/get
-                print("Report name prefix not set, replacing with default value of `usage_gce`.");
+                print("Report name prefix not set, replacing with default value of `usage_gce`." . PHP_EOL);
                 $responseUsageExportLocation->setReportNamePrefix('usage_gce');
             }
         }
 
-        return $responseUsageExportLocation;
+        printf(
+            "Compute Engine usage export bucket for project `%s` is bucket_name = `%s` with " .
+            "report_name_prefix = `%s`.". PHP_EOL,
+            $projectId,
+            $responseUsageExportLocation->getBucketName(),
+            $responseUsageExportLocation->getReportNamePrefix()
+        );
     } else {
         // The usage reports are disabled.
-        return null;
+        printf("Compute Engine usage export bucket for project `%s` is disabled.", $projectId);
     }
 }
 # [END compute_usage_report_get]
 
-// Run the sample only if called directly
-if (__FILE__ == get_included_files()[0]) {
-    require_once __DIR__ . '/../../../../testing/sample_helpers.php';
-    \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
-}
+require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/compute/cloud-client/instances/src/set_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/set_usage_export_bucket.php
@@ -76,7 +76,7 @@ function set_usage_export_bucket(
 
     printf(
         "Compute Engine usage export bucket for project `%s` set to bucket_name = `%s` with " .
-        "report_name_prefix = `%s`.". PHP_EOL,
+        "report_name_prefix = `%s`." . PHP_EOL,
         $projectId,
         $usageExportLocation->getBucketName(),
         (strlen($reportNamePrefix) == 0) ? 'usage_gce' : $usageExportLocation->getReportNamePrefix()

--- a/compute/cloud-client/instances/src/set_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/set_usage_export_bucket.php
@@ -75,4 +75,3 @@ if (__FILE__ == get_included_files()[0]) {
     require_once __DIR__ . '/../../../../testing/sample_helpers.php';
     \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
 }
-

--- a/compute/cloud-client/instances/src/set_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/set_usage_export_bucket.php
@@ -23,18 +23,10 @@
 
 namespace Google\Cloud\Samples\Compute;
 
-# [START compute_instances_verify_default_value]
 # [START compute_usage_report_set]
-# [START compute_usage_report_get]
-# [START compute_usage_report_disable]
 use Google\Cloud\Compute\V1\ProjectsClient;
 use Google\Cloud\Compute\V1\UsageExportLocation;
 
-# [END compute_usage_report_disable]
-# [END compute_usage_report_get]
-# [END compute_usage_report_set]
-
-# [START compute_usage_report_set]
 /**
  * Set Compute Engine usage export bucket for the Cloud project.
  * This sample presents how to interpret the default value for the report name prefix parameter.
@@ -78,73 +70,9 @@ function set_usage_export_bucket(
 }
 # [END compute_usage_report_set]
 
-# [START compute_usage_report_get]
-/**
- * Retrieve Compute Engine usage export bucket for the Cloud project.
- * Replaces the empty value returned by the API with the default value used
- * to generate report file names.
- * Example:
- * ```
- * get_usage_export_bucket($projectId);
- * ```
- *
- * @param string $projectId Your Google Cloud project ID.
- * @return UsageExportLocation|null UsageExportLocation object describing the current usage
- * export settings for project $projectId.
- *
- * @throws \Google\ApiCore\ApiException if the remote call fails.
- */
-function get_usage_export_bucket(string $projectId)
-{
-    // Get the usage export location for the project from the server.
-    $projectsClient = new ProjectsClient();
-    $projectResponse = $projectsClient->get($projectId);
-
-    // Replace the empty value returned by the API with the default value used to generate report file names.
-    if ($projectResponse->hasUsageExportLocation()) {
-        $responseUsageExportLocation = $projectResponse->getUsageExportLocation();
-
-        // Verify that the server explicitly sent the optional field.
-        if ($responseUsageExportLocation->hasReportNamePrefix()) {
-            if ($responseUsageExportLocation->getReportNamePrefix() == '') {
-                // Although the server explicitly sent the empty string value, the next usage
-                // report generated with these settings still has the default prefix value "usage_gce".
-                // See https://cloud.google.com/compute/docs/reference/rest/v1/projects/get
-                print("Report name prefix not set, replacing with default value of `usage_gce`.");
-                $responseUsageExportLocation->setReportNamePrefix('usage_gce');
-            }
-        }
-
-        return $responseUsageExportLocation;
-    } else {
-        // The usage reports are disabled.
-        return null;
-    }
+// Run the sample only if called directly
+if (__FILE__ == get_included_files()[0]) {
+    require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+    \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
 }
-# [END compute_usage_report_get]
-# [END compute_instances_verify_default_value]
 
-# [START compute_usage_report_disable]
-/**
- * Disable Compute Engine usage export bucket for the Cloud Project.
- * Example:
- * ```
- * disable_usage_export_bucket($projectId);
- * ```
- *
- * @param string $projectId Your Google Cloud project ID.
- *
- * @return \Google\Cloud\Compute\V1\Operation
- *
- * @throws \Google\ApiCore\ApiException if the remote call fails.
- */
-function disable_usage_export_bucket(string $projectId)
-{
-    // Disable the usage export location by sending null as usageExportLocationResource.
-    $projectsClient = new ProjectsClient();
-    return $projectsClient->setUsageExportBucket($projectId, null);
-}
-# [END compute_usage_report_disable]
-
-require_once __DIR__ . '/../../../../testing/sample_helpers.php';
-\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/compute/cloud-client/instances/src/set_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/set_usage_export_bucket.php
@@ -26,6 +26,8 @@ namespace Google\Cloud\Samples\Compute;
 # [START compute_usage_report_set]
 use Google\Cloud\Compute\V1\ProjectsClient;
 use Google\Cloud\Compute\V1\UsageExportLocation;
+use Google\Cloud\Compute\V1\Operation;
+use Google\Cloud\Compute\V1\GlobalOperationsClient;
 
 /**
  * Set Compute Engine usage export bucket for the Cloud project.
@@ -40,8 +42,6 @@ use Google\Cloud\Compute\V1\UsageExportLocation;
  * An existing Google Cloud Storage bucket is required.
  * @param string $reportNamePrefix Prefix of the usage report name which defaults to an empty string
  * to showcase default values behavior.
- *
- * @return \Google\Cloud\Compute\V1\Operation
  *
  * @throws \Google\ApiCore\ApiException if the remote call fails.
  */
@@ -61,17 +61,28 @@ function set_usage_export_bucket(
         // being generated with the default prefix value "usage_gce".
         // See https://cloud.google.com/compute/docs/reference/rest/v1/projects/setUsageExportBucket
         print("Setting report_name_prefix to empty value causes the " .
-            "report to have the default value of `usage_gce`.");
+            "report to have the default value of `usage_gce`." . PHP_EOL);
     }
 
     // Set the usage export location.
     $projectsClient = new ProjectsClient();
-    return $projectsClient->setUsageExportBucket($projectId, $usageExportLocation);
+    $operation = $projectsClient->setUsageExportBucket($projectId, $usageExportLocation);
+
+    // Wait for the set operation to complete.
+    if ($operation->getStatus() === Operation\Status::RUNNING) {
+        $operationClient = new GlobalOperationsClient();
+        $operationClient->wait($operation->getName(), $projectId);
+    }
+
+    printf(
+        "Compute Engine usage export bucket for project `%s` set to bucket_name = `%s` with " .
+        "report_name_prefix = `%s`.". PHP_EOL,
+        $projectId,
+        $usageExportLocation->getBucketName(),
+        (strlen($reportNamePrefix) == 0) ? 'usage_gce' : $usageExportLocation->getReportNamePrefix()
+    );
 }
 # [END compute_usage_report_set]
 
-// Run the sample only if called directly
-if (__FILE__ == get_included_files()[0]) {
-    require_once __DIR__ . '/../../../../testing/sample_helpers.php';
-    \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
-}
+require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/compute/cloud-client/instances/test/instancesTest.php
+++ b/compute/cloud-client/instances/test/instancesTest.php
@@ -108,8 +108,8 @@ class instancesTest extends TestCase
         ]);
 
         $this->assertStringContainsString('default value of `usage_gce`', $output);
-        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
-        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '`', $output);
+        $this->assertStringContainsString('bucket_name = `' . self::$bucketName . '`', $output);
         $this->assertStringContainsString('report_name_prefix = `usage_gce`', $output);
 
         // Check default value behaviour for getter
@@ -117,20 +117,20 @@ class instancesTest extends TestCase
             'projectId' => self::$projectId
         ]);
         $this->assertStringContainsString('default value of `usage_gce`', $output);
-        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
-        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '`', $output);
+        $this->assertStringContainsString('bucket_name = `' . self::$bucketName . '`', $output);
         $this->assertStringContainsString('report_name_prefix = `usage_gce`', $output);
 
         // Disable usage exports
         $output = $this->runFunctionSnippet('disable_usage_export_bucket', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertStringContainsString('project `'. self::$projectId .'` disabled', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '` disabled', $output);
 
         $output = $this->runFunctionSnippet('get_usage_export_bucket', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertStringContainsString('project `'. self::$projectId .'` is disabled', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '` is disabled', $output);
     }
 
     public function testSetUsageExportBucketCustomPrefix()
@@ -146,28 +146,28 @@ class instancesTest extends TestCase
         ]);
 
         $this->assertStringNotContainsString('default value of `usage_gce`', $output);
-        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
-        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
-        $this->assertStringContainsString('report_name_prefix = `'. $customPrefix .'`', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '`', $output);
+        $this->assertStringContainsString('bucket_name = `' . self::$bucketName . '`', $output);
+        $this->assertStringContainsString('report_name_prefix = `' . $customPrefix . '`', $output);
 
         // Check user value behaviour for getter
         $output = $this->runFunctionSnippet('get_usage_export_bucket', [
             'projectId' => self::$projectId,
         ]);
         $this->assertStringNotContainsString('default value of `usage_gce`', $output);
-        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
-        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
-        $this->assertStringContainsString('report_name_prefix = `'. $customPrefix .'`', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '`', $output);
+        $this->assertStringContainsString('bucket_name = `' . self::$bucketName . '`', $output);
+        $this->assertStringContainsString('report_name_prefix = `' . $customPrefix . '`', $output);
 
         // Disable usage exports
         $output = $this->runFunctionSnippet('disable_usage_export_bucket', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertStringContainsString('project `'. self::$projectId .'` disabled', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '` disabled', $output);
 
         $output = $this->runFunctionSnippet('get_usage_export_bucket', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertStringContainsString('project `'. self::$projectId .'` is disabled', $output);
+        $this->assertStringContainsString('project `' . self::$projectId . '` is disabled', $output);
     }
 }

--- a/compute/cloud-client/instances/test/instancesTest.php
+++ b/compute/cloud-client/instances/test/instancesTest.php
@@ -17,8 +17,6 @@
 
 namespace Google\Cloud\Samples\Compute;
 
-use Google\Cloud\Compute\V1\Operation;
-use Google\Cloud\Compute\V1\GlobalOperationsClient;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
@@ -103,86 +101,73 @@ class instancesTest extends TestCase
 
     public function testSetUsageExportBucketDefaultPrefix()
     {
-        // We include files directly as we need access to returned objects
-        require_once "src/set_usage_export_bucket.php";
-        require_once "src/get_usage_export_bucket.php";
-        require_once "src/disable_usage_export_bucket.php";
-
         // Check default value behaviour for setter
-        ob_start();
-        $operation = set_usage_export_bucket(self::$projectId, self::$bucketName);
-        $this->assertStringContainsString('default value of `usage_gce`', ob_get_clean());
+        $output = $this->runFunctionSnippet('set_usage_export_bucket', [
+            'projectId' => self::$projectId,
+            'bucketName' => self::$bucketName
+        ]);
 
-        // Wait for the settings to take place
-        if ($operation->getStatus() === Operation\Status::RUNNING) {
-            // Wait until operation completes
-            $operationClient = new GlobalOperationsClient();
-            $operationClient->wait($operation->getName(), self::$projectId);
-        }
+        $this->assertStringContainsString('default value of `usage_gce`', $output);
+        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
+        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
+        $this->assertStringContainsString('report_name_prefix = `usage_gce`', $output);
 
         // Check default value behaviour for getter
-        ob_start();
-        $usageExportLocation = get_usage_export_bucket(self::$projectId);
-        $this->assertStringContainsString('default value of `usage_gce`', ob_get_clean());
-        $this->assertEquals($usageExportLocation->getBucketName(), self::$bucketName);
-        $this->assertEquals($usageExportLocation->getReportNamePrefix(), 'usage_gce');
+        $output = $this->runFunctionSnippet('get_usage_export_bucket', [
+            'projectId' => self::$projectId
+        ]);
+        $this->assertStringContainsString('default value of `usage_gce`', $output);
+        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
+        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
+        $this->assertStringContainsString('report_name_prefix = `usage_gce`', $output);
 
         // Disable usage exports
-        $operation = disable_usage_export_bucket(self::$projectId);
+        $output = $this->runFunctionSnippet('disable_usage_export_bucket', [
+            'projectId' => self::$projectId,
+        ]);
+        $this->assertStringContainsString('project `'. self::$projectId .'` disabled', $output);
 
-        // Wait for the settings to take place
-        if ($operation->getStatus() === Operation\Status::RUNNING) {
-            // Wait until operation completes
-            $operationClient = new GlobalOperationsClient();
-            $operationClient->wait($operation->getName(), self::$projectId);
-        }
-
-        // Make sure the export bucket was properly disabled
-        $usageExportLocation = get_usage_export_bucket(self::$projectId);
-        $this->assertNull($usageExportLocation);
+        $output = $this->runFunctionSnippet('get_usage_export_bucket', [
+            'projectId' => self::$projectId,
+        ]);
+        $this->assertStringContainsString('project `'. self::$projectId .'` is disabled', $output);
     }
 
     public function testSetUsageExportBucketCustomPrefix()
     {
-        // We include files directly as we need access to returned objects
-        require_once "src/set_usage_export_bucket.php";
-        require_once "src/get_usage_export_bucket.php";
-        require_once "src/disable_usage_export_bucket.php";
-
         // Set custom prefix
         $customPrefix = "my-custom-prefix";
 
         // Check user value behaviour for setter
-        ob_start();
-        $operation = set_usage_export_bucket(self::$projectId, self::$bucketName, $customPrefix);
-        $this->assertStringNotContainsString('default value of `usage_gce`', ob_get_clean());
+        $output = $this->runFunctionSnippet('set_usage_export_bucket', [
+            'projectId' => self::$projectId,
+            'bucketName' => self::$bucketName,
+            'reportNamePrefix' => $customPrefix
+        ]);
 
-        // Wait for the settings to take place
-        if ($operation->getStatus() === Operation\Status::RUNNING) {
-            // Wait until operation completes
-            $operationClient = new GlobalOperationsClient();
-            $operationClient->wait($operation->getName(), self::$projectId);
-        }
+        $this->assertStringNotContainsString('default value of `usage_gce`', $output);
+        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
+        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
+        $this->assertStringContainsString('report_name_prefix = `'. $customPrefix .'`', $output);
 
         // Check user value behaviour for getter
-        ob_start();
-        $usageExportLocation = get_usage_export_bucket(self::$projectId);
-        $this->assertStringNotContainsString('default value of `usage_gce`', ob_get_clean());
-        $this->assertEquals($usageExportLocation->getBucketName(), self::$bucketName);
-        $this->assertEquals($usageExportLocation->getReportNamePrefix(), $customPrefix);
+        $output = $this->runFunctionSnippet('get_usage_export_bucket', [
+            'projectId' => self::$projectId,
+        ]);
+        $this->assertStringNotContainsString('default value of `usage_gce`', $output);
+        $this->assertStringContainsString('project `'. self::$projectId .'`', $output);
+        $this->assertStringContainsString('bucket_name = `'. self::$bucketName .'`', $output);
+        $this->assertStringContainsString('report_name_prefix = `'. $customPrefix .'`', $output);
 
         // Disable usage exports
-        $operation = disable_usage_export_bucket(self::$projectId);
+        $output = $this->runFunctionSnippet('disable_usage_export_bucket', [
+            'projectId' => self::$projectId,
+        ]);
+        $this->assertStringContainsString('project `'. self::$projectId .'` disabled', $output);
 
-        // Wait for the settings to take place
-        if ($operation->getStatus() === Operation\Status::RUNNING) {
-            // Wait until operation completes
-            $operationClient = new GlobalOperationsClient();
-            $operationClient->wait($operation->getName(), self::$projectId);
-        }
-
-        // Make sure the export bucket was properly disabled
-        $usageExportLocation = get_usage_export_bucket(self::$projectId);
-        $this->assertNull($usageExportLocation);
+        $output = $this->runFunctionSnippet('get_usage_export_bucket', [
+            'projectId' => self::$projectId,
+        ]);
+        $this->assertStringContainsString('project `'. self::$projectId .'` is disabled', $output);
     }
 }

--- a/compute/cloud-client/instances/test/instancesTest.php
+++ b/compute/cloud-client/instances/test/instancesTest.php
@@ -103,10 +103,12 @@ class instancesTest extends TestCase
 
     public function testSetUsageExportBucketDefaultPrefix()
     {
-        $output = $this->runFunctionSnippet('set_usage_export_bucket', [
-            'projectId' => self::$projectId,
-            'bucketName' => self::$bucketName
-        ]);
+        // We include files directly as we need access to returned objects
+        require_once "src/set_usage_export_bucket.php";
+        require_once "src/get_usage_export_bucket.php";
+        require_once "src/disable_usage_export_bucket.php";
+
+        // Check default value behaviour for setter
         ob_start();
         $operation = set_usage_export_bucket(self::$projectId, self::$bucketName);
         $this->assertStringContainsString('default value of `usage_gce`', ob_get_clean());
@@ -118,6 +120,7 @@ class instancesTest extends TestCase
             $operationClient->wait($operation->getName(), self::$projectId);
         }
 
+        // Check default value behaviour for getter
         ob_start();
         $usageExportLocation = get_usage_export_bucket(self::$projectId);
         $this->assertStringContainsString('default value of `usage_gce`', ob_get_clean());
@@ -134,15 +137,22 @@ class instancesTest extends TestCase
             $operationClient->wait($operation->getName(), self::$projectId);
         }
 
+        // Make sure the export bucket was properly disabled
         $usageExportLocation = get_usage_export_bucket(self::$projectId);
         $this->assertNull($usageExportLocation);
     }
 
     public function testSetUsageExportBucketCustomPrefix()
     {
+        // We include files directly as we need access to returned objects
+        require_once "src/set_usage_export_bucket.php";
+        require_once "src/get_usage_export_bucket.php";
+        require_once "src/disable_usage_export_bucket.php";
+
         // Set custom prefix
         $customPrefix = "my-custom-prefix";
 
+        // Check user value behaviour for setter
         ob_start();
         $operation = set_usage_export_bucket(self::$projectId, self::$bucketName, $customPrefix);
         $this->assertStringNotContainsString('default value of `usage_gce`', ob_get_clean());
@@ -154,6 +164,7 @@ class instancesTest extends TestCase
             $operationClient->wait($operation->getName(), self::$projectId);
         }
 
+        // Check user value behaviour for getter
         ob_start();
         $usageExportLocation = get_usage_export_bucket(self::$projectId);
         $this->assertStringNotContainsString('default value of `usage_gce`', ob_get_clean());
@@ -170,6 +181,7 @@ class instancesTest extends TestCase
             $operationClient->wait($operation->getName(), self::$projectId);
         }
 
+        // Make sure the export bucket was properly disabled
         $usageExportLocation = get_usage_export_bucket(self::$projectId);
         $this->assertNull($usageExportLocation);
     }


### PR DESCRIPTION
Refactoring set, get and disable usage export bucket samples by putting them in separate files. Removal of compute_instances_verify_default_value region tag as we decided not to use it.