### PR TITLE
Adding samples to demonstrate listing images and pagination

### DIFF
--- a/compute/cloud-client/instances/src/list_all_images.php
+++ b/compute/cloud-client/instances/src/list_all_images.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/compute/cloud-client/README.md
+ */
+
+namespace Google\Cloud\Samples\Compute;
+
+# [START compute_images_list]
+use Google\Cloud\Compute\V1\ImagesClient;
+
+/**
+ * List all images for a particular Cloud project.
+ * Example:
+ * ```
+ * list_all_images($projectId);
+ * ```
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ *
+ * @throws \Google\ApiCore\ApiException if the remote call fails.
+ */
+function list_all_images(string $projectId)
+{
+    $imagesClient = new ImagesClient();
+    // Listing only non-deprecated images to reduce the size of the reply.
+    $optionalArgs = array('filter' =>"deprecated.state != DEPRECATED");
+
+    // Iterate through all elements using ImagesClient
+    $pagedResponse = $imagesClient->list($projectId, $optionalArgs);
+    printf("=================== Flat list of images ===================" . PHP_EOL);
+    foreach ($pagedResponse->iterateAllElements() as $element) {
+        printf(' - %s' . PHP_EOL, $element->getName());
+    }
+}
+# [END compute_images_list]
+
+
+
+require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/compute/cloud-client/instances/src/list_images_by_page.php
+++ b/compute/cloud-client/instances/src/list_images_by_page.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/compute/cloud-client/README.md
+ */
+
+namespace Google\Cloud\Samples\Compute;
+
+# [START compute_images_list_page]
+use Google\Cloud\Compute\V1\ImagesClient;
+
+/**
+ * List all images for a particular Cloud project in pages.
+ * Example:
+ * ```
+ * list_images_by_page($projectId);
+ * ```
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ * @param int $page_size Size of the pages you want the API to return on each call.
+ * @throws \Google\ApiCore\ApiException if the remote call fails.
+ */
+function list_images_by_page(string $projectId, int $page_size = 10)
+{
+    $imagesClient = new ImagesClient();
+    $page_num = 1;
+    $optionalArgs = array( 'maxResults' => $page_size, 'filter' =>"deprecated.state != DEPRECATED");
+    // Iterate through elements by page using ImagesClient
+    $pagedResponse = $imagesClient->list($projectId, $optionalArgs);
+    printf("=================== Paginated list of images ===================" . PHP_EOL);
+    foreach ($pagedResponse->iteratePages() as $page) {
+        printf('Page ' . $page_num . ':' . PHP_EOL);
+        foreach ($page as $element) {
+            printf(' - %s' . PHP_EOL, $element->getName());
+            $page_num++;
+        }
+    }
+}
+# [END compute_images_list_page]
+
+
+
+require_once __DIR__ . '/../../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/compute/cloud-client/instances/test/instancesTest.php
+++ b/compute/cloud-client/instances/test/instancesTest.php
@@ -51,7 +51,6 @@ class instancesTest extends TestCase
         // Remove the bucket
         self::$bucket->delete();
     }
-
     public function testCreateInstance()
     {
         $output = $this->runFunctionSnippet('create_instance', [
@@ -169,5 +168,26 @@ class instancesTest extends TestCase
             'projectId' => self::$projectId,
         ]);
         $this->assertStringContainsString('project `' . self::$projectId . '` is disabled', $output);
+    }
+    public function testListAllImages()
+    {
+        $output = $this->runFunctionSnippet('list_all_images', [
+        'projectId' => 'windows-sql-cloud',
+    ]);
+
+        $this->assertStringContainsString('sql-2012-enterprise-windows', $output);
+        $arr = explode(PHP_EOL, $output);
+        $this->assertGreaterThanOrEqual(2, count($arr));
+    }
+    public function testListImagesByPage()
+    {
+        $output = $this->runFunctionSnippet('list_images_by_page', [
+            'projectId' => 'windows-sql-cloud',
+        ]);
+
+        $this->assertStringContainsString('sql-2012-enterprise-windows', $output);
+        $this->assertStringContainsString('Page 2', $output);
+        $arr = explode(PHP_EOL, $output);
+        $this->assertGreaterThanOrEqual(2, count($arr));
     }
 }


### PR DESCRIPTION
Listing all images available for a particular project ID, then separately a sample to organise the output into manageable pages