### PR TITLE
Refactoring compute_instances_operation_check sample

### DIFF
--- a/compute/cloud-client/instances/composer.json
+++ b/compute/cloud-client/instances/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "google/cloud-compute": "^0.3.2",
+        "google/cloud-compute": "^0.4.0",
         "google/cloud-storage": "^1.23"
     }
 }

--- a/compute/cloud-client/instances/composer.json
+++ b/compute/cloud-client/instances/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "google/cloud-compute": "^0.3.1",
+        "google/cloud-compute": "^0.3.2",
         "google/cloud-storage": "^1.23"
     }
 }

--- a/compute/cloud-client/instances/src/create_instance.php
+++ b/compute/cloud-client/instances/src/create_instance.php
@@ -83,9 +83,10 @@ function create_instance(
     $instancesClient = new InstancesClient();
     $operation = $instancesClient->insert($instance, $projectId, $zone);
 
-    // Wait for the create operation to complete.
+    // Wait for the create operation to complete using a custom helper function.
+    // @see src/wait_for_operation.php
     $operation = wait_for_operation($operation, $projectId, $zone);
-    if (! $operation->getError()) {
+    if (empty($operation->getError())) {
         printf('Created instance %s' . PHP_EOL, $instanceName);
     } else {
         printf('Instance creation failed!' . PHP_EOL);

--- a/compute/cloud-client/instances/src/delete_instance.php
+++ b/compute/cloud-client/instances/src/delete_instance.php
@@ -50,8 +50,10 @@ function delete_instance(
     $instancesClient = new InstancesClient();
     $operation = $instancesClient->delete($instanceName, $projectId, $zone);
 
+    // Wait for the create operation to complete using a custom helper function.
+    // @see src/wait_for_operation.php
     $operation = wait_for_operation($operation, $projectId, $zone);
-    if (! $operation->getError()) {
+    if (empty($operation->getError())) {
         printf('Deleted instance %s' . PHP_EOL, $instanceName);
     } else {
         printf('Instance deletion failed!' . PHP_EOL);

--- a/compute/cloud-client/instances/src/wait_for_operation.php
+++ b/compute/cloud-client/instances/src/wait_for_operation.php
@@ -51,12 +51,12 @@ function wait_for_operation(
         $operation = $operationClient->wait($operation->getName(), $projectId, $zone);
 
         if ($operation->hasError()) {
-            printf("Operation failed with error(s): %s" . PHP_EOL, $operation->getError()->serializeToString());
+            printf('Operation failed with error(s): %s' . PHP_EOL, $operation->getError()->serializeToString());
             return $operation;
         }
     }
 
-    print("Operation successful" . PHP_EOL);
+    print('Operation successful' . PHP_EOL);
     return $operation;
 }
 # [END compute_instances_operation_check]

--- a/compute/cloud-client/instances/src/wait_for_operation.php
+++ b/compute/cloud-client/instances/src/wait_for_operation.php
@@ -23,41 +23,40 @@
 
 namespace Google\Cloud\Samples\Compute;
 
-include_once "wait_for_operation.php";
-
-# [START compute_instances_delete]
-use Google\Cloud\Compute\V1\InstancesClient;
+# [START compute_instances_operation_check]
+use Google\Cloud\Compute\V1\Operation;
+use Google\Cloud\Compute\V1\ZoneOperationsClient;
 
 /**
- * Delete an instance.
- * Example:
- * ```
- * delete_instance($projectId, $zone, $instanceName);
- * ```
+ * This method waits for an operation to be completed. Calling this function
+ * will block until the operation is finished.
  *
+ * @param Operation $operation The Operation object representing the operation you want to
+wait on.
  * @param string $projectId Your Google Cloud project ID.
  * @param string $zone Zone where the instance you want to delete is (like "us-central1-a").
- * @param string $instanceName Unique name for the Compute instance to delete.
  *
  * @throws \Google\ApiCore\ApiException if the remote call fails.
+ * @return Operation Finished Operation object.
  */
-function delete_instance(
+function wait_for_operation(
+    Operation $operation,
     string $projectId,
-    string $zone,
-    string $instanceName
-) {
-    // Delete the Compute Engine instance using InstancesClient.
-    $instancesClient = new InstancesClient();
-    $operation = $instancesClient->delete($instanceName, $projectId, $zone);
+    string $zone
+): Operation {
+    $operationClient = new ZoneOperationsClient();
 
-    $operation = wait_for_operation($operation, $projectId, $zone);
-    if (! $operation->getError()) {
-        printf('Deleted instance %s' . PHP_EOL, $instanceName);
-    } else {
-        printf('Instance deletion failed!' . PHP_EOL);
+    while ($operation->getStatus() != Operation\Status::DONE) {
+        // Wait for the operation to complete.
+        $operation = $operationClient->wait($operation->getName(), $projectId, $zone);
+
+        if ($operation->hasError()) {
+            printf("Operation failed with error(s): %s" . PHP_EOL, $operation->getError()->serializeToString());
+            return $operation;
+        }
     }
-}
-# [END compute_instances_delete]
 
-require_once __DIR__ . '/../../../../testing/sample_helpers.php';
-\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);
+    print("Operation successful" . PHP_EOL);
+    return $operation;
+}
+# [END compute_instances_operation_check]


### PR DESCRIPTION
Refactoring compute_instances_operation_check sample to repeat the wait operation if it hasn't finished yet. This change is made per recommendation from library team (AC Tools).

What has been done:
- moved wait_for_operation to a separate file
- added while loop around library wait call
- added autoDelete flag to disks created with the instance to make sure they are cleaned up after VM deletion


