### PR TITLE
Feat: Added new rules in .php-cs-fixer.dist.php

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,6 +16,22 @@ $config
         'return_type_declaration' => [
             'space_before' => 'none'
         ],
+        // only converts simple strings in double quotes to single quotes
+        // ignores strings using variables, escape characters or single quotes inside
+        'single_quote' => true,
+        // there should be a single space b/w the cast and it's operand
+        'cast_spaces' => ['space' => 'single'],
+        // there shouldn't be any trailing whitespace at the end of a non-blank line
+        'no_trailing_whitespace' => true,
+        // there shouldn't be any trailing whitespace at the end of a blank line
+        'no_whitespace_in_blank_line' => true,
+        // there should be a space around binary operators like (=, => etc)
+        'binary_operator_spaces' => ['default' => 'single_space'],
+        // deals with rogue empty blank lines
+        'no_extra_blank_lines' => ['tokens' => ['extra']],
+        // reduces multi blank lines b/w phpdoc description and @param to a single line
+        // NOTE: Doesn't add a blank line if none exist
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/analyticsdata/quickstart_json_credentials.php
+++ b/analyticsdata/quickstart_json_credentials.php
@@ -43,7 +43,6 @@ use Google\Analytics\Data\V1beta\Metric;
  */
 $property_id = 'YOUR-GA4-PROPERTY-ID';
 
-
 // [START analyticsdata_json_credentials_initialize]
 /* TODO(developer): Replace this variable with a valid path to the
  *  credentials.json file for your service account downloaded from the

--- a/appengine/flexible/datastore/app.php
+++ b/appengine/flexible/datastore/app.php
@@ -72,7 +72,7 @@ $app->get('/', function (Request $request, Response $response) {
             $entity['user_ip']);
     }
     # [END gae_flex_datastore_query]
-    array_unshift($visits, "Last 10 visits:");
+    array_unshift($visits, 'Last 10 visits:');
     $response->getBody()->write(implode("\n", $visits));
 
     return $response

--- a/appengine/flexible/datastore/test/DeployTest.php
+++ b/appengine/flexible/datastore/test/DeployTest.php
@@ -30,6 +30,6 @@ class DeployTest extends TestCase
         $this->assertEquals('200', $resp->getStatusCode(),
             'top page status code');
 
-        $this->assertStringContainsString("Last 10 visits:", (string) $resp->getBody());
+        $this->assertStringContainsString('Last 10 visits:', (string) $resp->getBody());
     }
 }

--- a/appengine/flexible/datastore/test/LocalTest.php
+++ b/appengine/flexible/datastore/test/LocalTest.php
@@ -33,6 +33,6 @@ class LocalTest extends TestCase
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
         $text = (string) $response->getBody();
-        $this->assertStringContainsString("Last 10 visits:", $text);
+        $this->assertStringContainsString('Last 10 visits:', $text);
     }
 }

--- a/appengine/flexible/logging/test/DeployTest.php
+++ b/appengine/flexible/logging/test/DeployTest.php
@@ -41,7 +41,7 @@ class DeployTest extends TestCase
         $this->assertEquals('200', $resp->getStatusCode(),
             'top page status code');
 
-        $this->assertStringContainsString("Logs:", (string) $resp->getBody());
+        $this->assertStringContainsString('Logs:', (string) $resp->getBody());
     }
     public function testAsyncLog()
     {

--- a/appengine/flexible/logging/test/LocalTest.php
+++ b/appengine/flexible/logging/test/LocalTest.php
@@ -33,7 +33,7 @@ class LocalTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
         $text = (string) $response->getBody();
-        $this->assertStringContainsString("Logs:", $text);
+        $this->assertStringContainsString('Logs:', $text);
     }
 
     public function testAsyncLog()

--- a/appengine/flexible/memcache/test/DeployTest.php
+++ b/appengine/flexible/memcache/test/DeployTest.php
@@ -50,10 +50,10 @@ class DeployTest extends TestCase
         $key = rand(0, 1000);
 
         // Test the /memcached REST API.
-        $this->put("/memcached/test$key", "sour");
-        $this->assertEquals("sour", $this->get("/memcached/test$key"));
-        $this->put("/memcached/test$key", "sweet");
-        $this->assertEquals("sweet", $this->get("/memcached/test$key"));
+        $this->put("/memcached/test$key", 'sour');
+        $this->assertEquals('sour', $this->get("/memcached/test$key"));
+        $this->put("/memcached/test$key", 'sweet');
+        $this->assertEquals('sweet', $this->get("/memcached/test$key"));
 
         // Make sure it handles a POST request too, which will increment the
         // counter.

--- a/appengine/flexible/memcache/test/LocalTest.php
+++ b/appengine/flexible/memcache/test/LocalTest.php
@@ -62,26 +62,26 @@ class LocalTest extends TestCase
         // Use a random key to avoid colliding with simultaneous tests.
 
         // Test the /memcached REST API.
-        $request1 = (new RequestFactory)->createRequest('PUT', "/memcached/testkey1");
+        $request1 = (new RequestFactory)->createRequest('PUT', '/memcached/testkey1');
         $request1->getBody()->write('sour');
         $response1 = $app->handle($request1);
         $this->assertEquals(200, (string) $response1->getStatusCode());
 
         // Check that the key was written as expected
-        $request2 = (new RequestFactory)->createRequest('GET', "/memcached/testkey1");
+        $request2 = (new RequestFactory)->createRequest('GET', '/memcached/testkey1');
         $response2 = $app->handle($request2);
-        $this->assertEquals("sour", (string) $response2->getBody());
+        $this->assertEquals('sour', (string) $response2->getBody());
 
         // Test the /memcached REST API with a new value.
-        $request3 = (new RequestFactory)->createRequest('PUT', "/memcached/testkey2");
+        $request3 = (new RequestFactory)->createRequest('PUT', '/memcached/testkey2');
         $request3->getBody()->write('sweet');
         $response3 = $app->handle($request3);
         $this->assertEquals(200, (string) $response3->getStatusCode());
 
         // Check that the key was written as expected
-        $request4 = (new RequestFactory)->createRequest('GET', "/memcached/testkey2");
+        $request4 = (new RequestFactory)->createRequest('GET', '/memcached/testkey2');
         $response4 = $app->handle($request4);
-        $this->assertEquals("sweet", (string) $response4->getBody());
+        $this->assertEquals('sweet', (string) $response4->getBody());
     }
 }
 

--- a/appengine/flexible/twilio/app.php
+++ b/appengine/flexible/twilio/app.php
@@ -28,7 +28,7 @@ $app = AppFactory::create();
 $app->addErrorMiddleware(true, true, true);
 
 $twilioAccountSid = getenv('TWILIO_ACCOUNT_SID');
-$twilioAuthToken  = getenv('TWILIO_AUTH_TOKEN');
+$twilioAuthToken = getenv('TWILIO_AUTH_TOKEN');
 $twilioNumber = getenv('TWILIO_FROM_NUMBER');
 
 # [START gae_flex_twilio_receive_call]

--- a/appengine/flexible/websockets/socket-demo.php
+++ b/appengine/flexible/websockets/socket-demo.php
@@ -42,7 +42,7 @@ class SocketDemo implements MessageComponentInterface
 
     public function onMessage(ConnectionInterface $from, $msg)
     {
-        $output = "Message received: " . $msg . "\n";
+        $output = 'Message received: ' . $msg . "\n";
         echo $output;
         foreach ($this->clients as $client) {
             $client->send($output);
@@ -59,7 +59,7 @@ class SocketDemo implements MessageComponentInterface
     public function onError(ConnectionInterface $conn, \Exception $e)
     {
         $conn->close();
-        echo "Connection closed due to error: " . $e->getMessage() . "\n";
+        echo 'Connection closed due to error: ' . $e->getMessage() . "\n";
         echo "\t" . $this->clients->count() . " connection(s) active.\n";
     }
 }

--- a/appengine/flexible/websockets/test/LocalTest.php
+++ b/appengine/flexible/websockets/test/LocalTest.php
@@ -54,14 +54,14 @@ class LocalTest extends TestCase
                 return $endPromise;
             })
             ->otherwise(function ($e) {
-                echo "Error: " . $e->getMessage() . "\n";
+                echo 'Error: ' . $e->getMessage() . "\n";
                 throw $e;
             });
 
         $this->loop->run();
         $resolvedMsg = Block\await($basePromise, $this->loop);
         $this->assertStringContainsString(
-            "Message received: Hello World!",
+            'Message received: Hello World!',
             strval($resolvedMsg)
         );
     }

--- a/appengine/flexible/wordpress/files/wp-config.php
+++ b/appengine/flexible/wordpress/files/wp-config.php
@@ -97,7 +97,7 @@ define('NONCE_SALT',       'YOUR_NONCE_SALT');
  * You can have multiple installations in one database if you give each
  * a unique prefix. Only numbers, letters, and underscores please!
  */
-$table_prefix  = 'wp_';
+$table_prefix = 'wp_';
 
 /**
  * For developers: WordPress debugging mode.

--- a/appengine/standard/errorreporting/index.php
+++ b/appengine/standard/errorreporting/index.php
@@ -43,7 +43,7 @@ if (isset($_GET['type'])) {
             print('Triggering a PHP Fatal Error by including a file with a syntax error.');
             print($linkText);
             $filename = tempnam(sys_get_temp_dir(), 'php_syntax_error');
-            file_put_contents($filename, "<?php syntax-error");
+            file_put_contents($filename, '<?php syntax-error');
             require($filename);
             break;
         default:

--- a/appengine/standard/getting-started/test/CloudSqlTest.php
+++ b/appengine/standard/getting-started/test/CloudSqlTest.php
@@ -144,11 +144,11 @@ class CloudSqlTest extends TestCase
 
         // Clean up.
         $result = $model->delete($breakfastId);
-        $this->assertTrue((bool)$result);
+        $this->assertTrue((bool) $result);
         $this->assertFalse($model->read($breakfastId));
-        $this->assertTrue((bool)$model->read($bellId));
+        $this->assertTrue((bool) $model->read($bellId));
         $result = $model->delete($bellId);
-        $this->assertTrue((bool)$result);
+        $this->assertTrue((bool) $result);
         $this->assertFalse($model->read($bellId));
     }
 }

--- a/appengine/standard/grpc/monitoring.php
+++ b/appengine/standard/grpc/monitoring.php
@@ -41,7 +41,7 @@ $m->setType('custom.googleapis.com/my_metric');
 $r = new MonitoredResource();
 $r->setType('gce_instance');
 $r->setLabels([
-    'instance_id' =>$instanceId,
+    'instance_id' => $instanceId,
     'zone' => 'us-central1-f',
 ]);
 

--- a/appengine/standard/grpc/speech.php
+++ b/appengine/standard/grpc/speech.php
@@ -47,7 +47,7 @@ $strm = $speechClient->streamingRecognize();
 $strm->write($strmReq);
 
 $strmReq = new StreamingRecognizeRequest();
-$f = fopen($audioFile, "rb");
+$f = fopen($audioFile, 'rb');
 $fsize = filesize($audioFile);
 $bytes = fread($f, $fsize);
 $strmReq->setAudioContent($bytes);

--- a/appengine/standard/helloworld/index.php
+++ b/appengine/standard/helloworld/index.php
@@ -1,3 +1,3 @@
 <?php
 
-echo "hello world!";
+echo 'hello world!';

--- a/bigquery/api/src/browse_table.php
+++ b/bigquery/api/src/browse_table.php
@@ -30,7 +30,6 @@ if (count($argv) < 4 || count($argv) > 5) {
 list($_, $projectId, $datasetId, $tableId) = $argv;
 $startIndex = isset($argv[4]) ? $argv[4] : 0;
 
-
 # [START bigquery_browse_table]
 use Google\Cloud\BigQuery\BigQueryClient;
 

--- a/bigquery/api/src/stream_row.php
+++ b/bigquery/api/src/stream_row.php
@@ -30,7 +30,7 @@ if (count($argv) < 4 || count($argv) > 5) {
     return printf("Usage: php %s PROJECT_ID DATASET_ID TABLE_ID [DATA]\n", __FILE__);
 }
 list($_, $projectId, $datasetId, $tableId) = $argv;
-$data = isset($argv[4]) ? json_decode($argv[4], true) : ["field1" => "value1"];
+$data = isset($argv[4]) ? json_decode($argv[4], true) : ['field1' => 'value1'];
 
 # [START bigquery_table_insert_rows]
 use Google\Cloud\BigQuery\BigQueryClient;

--- a/bigtable/src/create_cluster.php
+++ b/bigtable/src/create_cluster.php
@@ -48,18 +48,18 @@ function create_cluster(
     $instanceName = $instanceAdminClient->instanceName($projectId, $instanceId);
     $clusterName = $instanceAdminClient->clusterName($projectId, $instanceId, $clusterId);
 
-    printf("Adding Cluster to Instance %s" . PHP_EOL, $instanceId);
+    printf('Adding Cluster to Instance %s' . PHP_EOL, $instanceId);
     try {
         $instanceAdminClient->getInstance($instanceName);
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {
-            printf("Instance %s does not exists." . PHP_EOL, $instanceId);
+            printf('Instance %s does not exists.' . PHP_EOL, $instanceId);
             return;
         } else {
             throw $e;
         }
     }
-    printf("Listing Clusters:" . PHP_EOL);
+    printf('Listing Clusters:' . PHP_EOL);
 
     $storage_type = StorageType::SSD;
     $serve_nodes = 3;
@@ -81,7 +81,7 @@ function create_cluster(
     );
     try {
         $instanceAdminClient->getCluster($clusterName);
-        printf("Cluster %s already exists, aborting...", $clusterId);
+        printf('Cluster %s already exists, aborting...', $clusterId);
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {
             $operationResponse = $instanceAdminClient->createCluster($instanceName, $clusterId, $cluster);
@@ -89,10 +89,10 @@ function create_cluster(
             $operationResponse->pollUntilComplete();
             if ($operationResponse->operationSucceeded()) {
                 $result = $operationResponse->getResult();
-                printf("Cluster created: %s", $clusterId);
+                printf('Cluster created: %s', $clusterId);
             } else {
                 $error = $operationResponse->getError();
-                printf("Cluster not created: %s", $error);
+                printf('Cluster not created: %s', $error);
             }
         } else {
             throw $e;

--- a/bigtable/src/create_dev_instance.php
+++ b/bigtable/src/create_dev_instance.php
@@ -50,7 +50,7 @@ function create_dev_instance(
     $projectName = $instanceAdminClient->projectName($projectId);
     $instanceName = $instanceAdminClient->instanceName($projectId, $instanceId);
 
-    printf("Creating a DEVELOPMENT Instance" . PHP_EOL);
+    printf('Creating a DEVELOPMENT Instance' . PHP_EOL);
     // Set options to create an Instance
 
     $storageType = StorageType::HDD;
@@ -78,10 +78,10 @@ function create_dev_instance(
     // Create development instance with given options
     try {
         $instanceAdminClient->getInstance($instanceName);
-        printf("Instance %s already exists." . PHP_EOL, $instanceId);
+        printf('Instance %s already exists.' . PHP_EOL, $instanceId);
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {
-            printf("Creating a development Instance: %s" . PHP_EOL, $instanceId);
+            printf('Creating a development Instance: %s' . PHP_EOL, $instanceId);
             $operationResponse = $instanceAdminClient->createInstance(
                 $projectName,
                 $instanceId,
@@ -92,7 +92,7 @@ function create_dev_instance(
             if (!$operationResponse->operationSucceeded()) {
                 print('Error: ' . $operationResponse->getError()->getMessage());
             } else {
-                printf("Instance %s created." . PHP_EOL, $instanceId);
+                printf('Instance %s created.' . PHP_EOL, $instanceId);
             }
         } else {
             throw $e;

--- a/bigtable/src/create_production_instance.php
+++ b/bigtable/src/create_production_instance.php
@@ -71,11 +71,11 @@ function create_production_instance(
     ];
     try {
         $instanceAdminClient->getInstance($instanceName);
-        printf("Instance %s already exists." . PHP_EOL, $instanceId);
-        throw new Exception(sprintf("Instance %s already exists." . PHP_EOL, $instanceId));
+        printf('Instance %s already exists.' . PHP_EOL, $instanceId);
+        throw new Exception(sprintf('Instance %s already exists.' . PHP_EOL, $instanceId));
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {
-            printf("Creating an Instance: %s" . PHP_EOL, $instanceId);
+            printf('Creating an Instance: %s' . PHP_EOL, $instanceId);
             $operationResponse = $instanceAdminClient->createInstance(
                 $projectName,
                 $instanceId,
@@ -86,7 +86,7 @@ function create_production_instance(
             if (!$operationResponse->operationSucceeded()) {
                 print('Error: ' . $operationResponse->getError()->getMessage());
             } else {
-                printf("Instance %s created.", $instanceId);
+                printf('Instance %s created.', $instanceId);
             }
         } else {
             throw $e;

--- a/bigtable/src/delete_cluster.php
+++ b/bigtable/src/delete_cluster.php
@@ -42,13 +42,13 @@ function delete_cluster(
     $instanceAdminClient = new BigtableInstanceAdminClient();
     $clusterName = $instanceAdminClient->clusterName($projectId, $instanceId, $clusterId);
 
-    printf("Deleting Cluster" . PHP_EOL);
+    printf('Deleting Cluster' . PHP_EOL);
     try {
         $instanceAdminClient->deleteCluster($clusterName);
-        printf("Cluster %s deleted." . PHP_EOL, $clusterId);
+        printf('Cluster %s deleted.' . PHP_EOL, $clusterId);
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {
-            printf("Cluster %s does not exist." . PHP_EOL, $clusterId);
+            printf('Cluster %s does not exist.' . PHP_EOL, $clusterId);
         } else {
             throw $e;
         }

--- a/bigtable/src/delete_instance.php
+++ b/bigtable/src/delete_instance.php
@@ -40,13 +40,13 @@ function delete_instance(
     $instanceAdminClient = new BigtableInstanceAdminClient();
     $instanceName = $instanceAdminClient->instanceName($projectId, $instanceId);
 
-    printf("Deleting Instance" . PHP_EOL);
+    printf('Deleting Instance' . PHP_EOL);
     try {
         $instanceAdminClient->deleteInstance($instanceName);
-        printf("Deleted Instance: %s." . PHP_EOL, $instanceId);
+        printf('Deleted Instance: %s.' . PHP_EOL, $instanceId);
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {
-            printf("Instance %s does not exists." . PHP_EOL, $instanceId);
+            printf('Instance %s does not exists.' . PHP_EOL, $instanceId);
         } else {
             throw $e;
         }

--- a/bigtable/src/filter_composing_chain.php
+++ b/bigtable/src/filter_composing_chain.php
@@ -47,7 +47,7 @@ function filter_composing_chain(
 
     $filter = Filter::chain()
         ->addFilter(Filter::limit()->cellsPerColumn(1))
-        ->addFilter(Filter::family()->exactMatch("cell_plan"));
+        ->addFilter(Filter::family()->exactMatch('cell_plan'));
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -64,7 +64,7 @@ function filter_composing_chain(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -73,7 +73,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_composing_condition.php
+++ b/bigtable/src/filter_composing_condition.php
@@ -48,10 +48,10 @@ function filter_composing_condition(
     $filter = Filter::condition(
         Filter::chain()
             ->addFilter(Filter::value()->exactMatch(unpack('C*', 1)))
-            ->addFilter(Filter::qualifier()->exactMatch("data_plan_10gb"))
+            ->addFilter(Filter::qualifier()->exactMatch('data_plan_10gb'))
     )
-        ->then(Filter::label("passed-filter"))
-        ->otherwise(Filter::label("filtered-out"));
+        ->then(Filter::label('passed-filter'))
+        ->otherwise(Filter::label('filtered-out'));
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -68,7 +68,7 @@ function filter_composing_condition(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -77,7 +77,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_composing_interleave.php
+++ b/bigtable/src/filter_composing_interleave.php
@@ -47,7 +47,7 @@ function filter_composing_interleave(
 
     $filter = Filter::interleave()
         ->addFilter(Filter::value()->exactMatch(unpack('C*', 1)))
-        ->addFilter(Filter::qualifier()->exactMatch("os_build"));
+        ->addFilter(Filter::qualifier()->exactMatch('os_build'));
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -64,7 +64,7 @@ function filter_composing_interleave(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -73,7 +73,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_block_all.php
+++ b/bigtable/src/filter_limit_block_all.php
@@ -62,7 +62,7 @@ function filter_limit_block_all(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_cells_per_col.php
+++ b/bigtable/src/filter_limit_cells_per_col.php
@@ -62,7 +62,7 @@ function filter_limit_cells_per_col(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_cells_per_row.php
+++ b/bigtable/src/filter_limit_cells_per_row.php
@@ -62,7 +62,7 @@ function filter_limit_cells_per_row(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_cells_per_row_offset.php
+++ b/bigtable/src/filter_limit_cells_per_row_offset.php
@@ -62,7 +62,7 @@ function filter_limit_cells_per_row_offset(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_col_family_regex.php
+++ b/bigtable/src/filter_limit_col_family_regex.php
@@ -45,7 +45,7 @@ function filter_limit_col_family_regex(
     ]);
     $table = $dataClient->table($instanceId, $tableId);
 
-    $filter = Filter::family()->regex("stats_.*$");
+    $filter = Filter::family()->regex('stats_.*$');
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -62,7 +62,7 @@ function filter_limit_col_family_regex(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_col_qualifier_regex.php
+++ b/bigtable/src/filter_limit_col_qualifier_regex.php
@@ -45,7 +45,7 @@ function filter_limit_col_qualifier_regex(
     ]);
     $table = $dataClient->table($instanceId, $tableId);
 
-    $filter = Filter::qualifier()->regex("connected_.*$");
+    $filter = Filter::qualifier()->regex('connected_.*$');
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -62,7 +62,7 @@ function filter_limit_col_qualifier_regex(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_col_range.php
+++ b/bigtable/src/filter_limit_col_range.php
@@ -46,9 +46,9 @@ function filter_limit_col_range(
     $table = $dataClient->table($instanceId, $tableId);
 
     $filter = Filter::qualifier()
-        ->rangeWithinFamily("cell_plan")
-        ->startClosed("data_plan_01gb")
-        ->endOpen("data_plan_10gb");
+        ->rangeWithinFamily('cell_plan')
+        ->startClosed('data_plan_01gb')
+        ->endOpen('data_plan_10gb');
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -65,7 +65,7 @@ function filter_limit_col_range(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -74,7 +74,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_pass_all.php
+++ b/bigtable/src/filter_limit_pass_all.php
@@ -62,7 +62,7 @@ function filter_limit_pass_all(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_row_regex.php
+++ b/bigtable/src/filter_limit_row_regex.php
@@ -45,7 +45,7 @@ function filter_limit_row_regex(
     ]);
     $table = $dataClient->table($instanceId, $tableId);
 
-    $filter = Filter::key()->regex(".*#20190501$");
+    $filter = Filter::key()->regex('.*#20190501$');
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -62,7 +62,7 @@ function filter_limit_row_regex(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_row_sample.php
+++ b/bigtable/src/filter_limit_row_sample.php
@@ -62,7 +62,7 @@ function filter_limit_row_sample(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_timestamp_range.php
+++ b/bigtable/src/filter_limit_timestamp_range.php
@@ -69,7 +69,7 @@ function filter_limit_timestamp_range(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -78,7 +78,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_value_range.php
+++ b/bigtable/src/filter_limit_value_range.php
@@ -47,8 +47,8 @@ function filter_limit_value_range(
 
     $filter = Filter::value()
         ->range()
-        ->startClosed("PQ2A.190405")
-        ->endOpen("PQ2A.190406");
+        ->startClosed('PQ2A.190405')
+        ->endOpen('PQ2A.190406');
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -65,7 +65,7 @@ function filter_limit_value_range(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -74,7 +74,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_limit_value_regex.php
+++ b/bigtable/src/filter_limit_value_regex.php
@@ -45,7 +45,7 @@ function filter_limit_value_regex(
     ]);
     $table = $dataClient->table($instanceId, $tableId);
 
-    $filter = Filter::value()->regex("PQ2A.*$");
+    $filter = Filter::value()->regex('PQ2A.*$');
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -62,7 +62,7 @@ function filter_limit_value_regex(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_modify_apply_label.php
+++ b/bigtable/src/filter_modify_apply_label.php
@@ -45,7 +45,7 @@ function filter_modify_apply_label(
     ]);
     $table = $dataClient->table($instanceId, $tableId);
 
-    $filter = Filter::label("labelled");
+    $filter = Filter::label('labelled');
 
     $rows = $table->readRows([
         'filter' => $filter
@@ -62,7 +62,7 @@ function filter_modify_apply_label(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/filter_modify_strip_value.php
+++ b/bigtable/src/filter_modify_strip_value.php
@@ -62,7 +62,7 @@ function filter_modify_strip_value(
 function print_row($key, $row)
 {
     printf('Reading data for row %s' . PHP_EOL, $key);
-    foreach ((array)$row as $family => $cols) {
+    foreach ((array) $row as $family => $cols) {
         printf('Column Family %s' . PHP_EOL, $family);
         foreach ($cols as $col => $data) {
             for ($i = 0; $i < count($data); $i++) {
@@ -71,7 +71,7 @@ function print_row($key, $row)
                     $col,
                     $data[$i]['value'],
                     $data[$i]['timeStamp'],
-                    $data[$i]['labels'] ? sprintf(" [%s]", $data[$i]['labels']) : ''
+                    $data[$i]['labels'] ? sprintf(' [%s]', $data[$i]['labels']) : ''
                 );
             }
         }

--- a/bigtable/src/get_cluster.php
+++ b/bigtable/src/get_cluster.php
@@ -63,7 +63,7 @@ function get_cluster(
     printf('State: ' . State::name($cluster->getState()) . PHP_EOL);
     printf('Default Storage Type: ' . StorageType::name($cluster->getDefaultStorageType()) . PHP_EOL);
     printf('Nodes: ' . $cluster->getServeNodes() . PHP_EOL);
-    printf('Encryption Config: ' . ($cluster->hasEncryptionConfig() ? $cluster->getEncryptionConfig()->getKmsKeyName() : "N/A") . PHP_EOL);
+    printf('Encryption Config: ' . ($cluster->hasEncryptionConfig() ? $cluster->getEncryptionConfig()->getKmsKeyName() : 'N/A') . PHP_EOL);
 }
 // [END bigtable_get_cluster]
 

--- a/bigtable/src/hello_world.php
+++ b/bigtable/src/hello_world.php
@@ -26,7 +26,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 if (count($argv) != 4) {
-    return printf("Usage: php %s PROJECT_ID INSTANCE_ID TABLE_ID" . PHP_EOL, __FILE__);
+    return printf('Usage: php %s PROJECT_ID INSTANCE_ID TABLE_ID' . PHP_EOL, __FILE__);
 }
 list($_, $projectId, $instanceId, $tableId) = $argv;
 

--- a/bigtable/src/insert_update_rows.php
+++ b/bigtable/src/insert_update_rows.php
@@ -91,7 +91,7 @@ function insert_update_rows(
         'rk5' => [
             'cf1' => [
                 'cq5' => [
-                    'value' => "Value5",
+                    'value' => 'Value5',
                     'timeStamp' => time_in_microseconds()
                 ]
             ]

--- a/bigtable/src/list_instance.php
+++ b/bigtable/src/list_instance.php
@@ -37,7 +37,7 @@ function list_instance(string $projectId): void
 
     $projectName = $instanceAdminClient->projectName($projectId);
 
-    printf("Listing Instances:" . PHP_EOL);
+    printf('Listing Instances:' . PHP_EOL);
 
     $getInstances = $instanceAdminClient->listInstances($projectName)->getInstances();
     $instances = $getInstances->getIterator();

--- a/bigtable/src/list_instance_clusters.php
+++ b/bigtable/src/list_instance_clusters.php
@@ -41,7 +41,7 @@ function list_instance_clusters(
     $projectName = $instanceAdminClient->projectName($projectId);
     $instanceName = $instanceAdminClient->instanceName($projectId, $instanceId);
 
-    printf("Listing Clusters:" . PHP_EOL);
+    printf('Listing Clusters:' . PHP_EOL);
     $getClusters = $instanceAdminClient->listClusters($instanceName)->getClusters();
     $clusters = $getClusters->getIterator();
 

--- a/bigtable/src/list_tables.php
+++ b/bigtable/src/list_tables.php
@@ -42,7 +42,7 @@ function list_tables(
 
     $instanceName = $instanceAdminClient->instanceName($projectId, $instanceId);
 
-    printf("Listing Tables:" . PHP_EOL);
+    printf('Listing Tables:' . PHP_EOL);
     $tables = $tableAdminClient->listTables($instanceName)->iterateAllElements();
     if (empty($tables)) {
         print('No table exists.' . PHP_EOL);

--- a/bigtable/src/quickstart.php
+++ b/bigtable/src/quickstart.php
@@ -26,7 +26,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 if (count($argv) < 3 || count($argv) > 5) {
-    return printf("Usage: php %s PROJECT_ID INSTANCE_ID TABLE_ID [LOCATION_ID]" . PHP_EOL, __FILE__);
+    return printf('Usage: php %s PROJECT_ID INSTANCE_ID TABLE_ID [LOCATION_ID]' . PHP_EOL, __FILE__);
 }
 list($_, $projectId, $instanceId, $tableId) = $argv;
 $locationId = isset($argv[5]) ? $argv[5] : 'us-east1-b';

--- a/bigtable/src/set_iam_policy.php
+++ b/bigtable/src/set_iam_policy.php
@@ -48,10 +48,10 @@ function set_iam_policy(
 
     try {
         $policy = new Policy([
-            'bindings'=>[
+            'bindings' => [
                 new Binding([
-                    'role'=>$role,
-                    'members'=>[$email]
+                    'role' => $role,
+                    'members' => [$email]
                 ])
             ]
         ]);

--- a/bigtable/src/update_instance.php
+++ b/bigtable/src/update_instance.php
@@ -47,19 +47,19 @@ function update_instance(
 
     $newType = InstanceType::PRODUCTION;
     $newLabels = [
-        'new-label-key'=>'label-val'
+        'new-label-key' => 'label-val'
     ];
 
     $instance = new Instance([
-        'name'=>$instanceName,
-        'display_name'=>$newDisplayName,
-        'labels'=>$newLabels,
-        'type'=>$newType
+        'name' => $instanceName,
+        'display_name' => $newDisplayName,
+        'labels' => $newLabels,
+        'type' => $newType
     ]);
 
     // This specifies the fields that need to be updated from $instance
     $updateMask = new FieldMask([
-        'paths'=>['labels', 'type', 'display_name']
+        'paths' => ['labels', 'type', 'display_name']
     ]);
 
     try {

--- a/bigtable/src/write_batch.php
+++ b/bigtable/src/write_batch.php
@@ -49,15 +49,15 @@ function write_batch(
     $columnFamilyId = 'stats_summary';
     $mutations = [
         (new Mutations())
-            ->upsert($columnFamilyId, "connected_wifi", 1, $timestampMicros)
-            ->upsert($columnFamilyId, "os_build", "12155.0.0-rc1", $timestampMicros),
+            ->upsert($columnFamilyId, 'connected_wifi', 1, $timestampMicros)
+            ->upsert($columnFamilyId, 'os_build', '12155.0.0-rc1', $timestampMicros),
         (new Mutations())
-            ->upsert($columnFamilyId, "connected_wifi", 1, $timestampMicros)
-            ->upsert($columnFamilyId, "os_build", "12145.0.0-rc6", $timestampMicros)];
+            ->upsert($columnFamilyId, 'connected_wifi', 1, $timestampMicros)
+            ->upsert($columnFamilyId, 'os_build', '12145.0.0-rc6', $timestampMicros)];
 
     $table->mutateRows([
-        "tablet#a0b81f74#20190501" => $mutations[0],
-        "tablet#a0b81f74#20190502" => $mutations[1]
+        'tablet#a0b81f74#20190501' => $mutations[0],
+        'tablet#a0b81f74#20190502' => $mutations[1]
     ]);
 
     printf('Successfully wrote 2 rows.' . PHP_EOL);

--- a/bigtable/src/write_conditionally.php
+++ b/bigtable/src/write_conditionally.php
@@ -49,14 +49,14 @@ function write_conditionally(
     $timestampMicros = time() * 1000 * 1000;
     $columnFamilyId = 'stats_summary';
 
-    $mutations = (new Mutations())->upsert($columnFamilyId, "os_name", "android", $timestampMicros);
+    $mutations = (new Mutations())->upsert($columnFamilyId, 'os_name', 'android', $timestampMicros);
     $predicateFilter = Filter::chain()
     ->addFilter(Filter::family()->exactMatch($columnFamilyId))
     ->addFilter(Filter::qualifier()->exactMatch('os_build'))
     ->addFilter(Filter::value()->regex('PQ2A.*'));
     $options = ['predicateFilter' => $predicateFilter, 'trueMutations' => $mutations];
 
-    $table->checkAndMutateRow("phone#4c410523#20190501", $options);
+    $table->checkAndMutateRow('phone#4c410523#20190501', $options);
 
     printf('Successfully updated row\'s os_name' . PHP_EOL);
 }

--- a/bigtable/src/write_simple.php
+++ b/bigtable/src/write_simple.php
@@ -49,11 +49,11 @@ function write_simple(
     $timestampMicros = time() * 1000 * 1000;
     $columnFamilyId = 'stats_summary';
     $mutations = (new Mutations())
-    ->upsert($columnFamilyId, "connected_cell", 1, $timestampMicros)
-    ->upsert($columnFamilyId, "connected_wifi", DataUtil::intToByteString(1), $timestampMicros)
-    ->upsert($columnFamilyId, "os_build", "PQ2A.190405.003", $timestampMicros);
+    ->upsert($columnFamilyId, 'connected_cell', 1, $timestampMicros)
+    ->upsert($columnFamilyId, 'connected_wifi', DataUtil::intToByteString(1), $timestampMicros)
+    ->upsert($columnFamilyId, 'os_build', 'PQ2A.190405.003', $timestampMicros);
 
-    $table->mutateRow("phone#4c410523#20190501", $mutations);
+    $table->mutateRow('phone#4c410523#20190501', $mutations);
 
     printf('Successfully wrote row.' . PHP_EOL);
 }

--- a/bigtable/test/bigtableTest.php
+++ b/bigtable/test/bigtableTest.php
@@ -83,7 +83,7 @@ final class BigtableTest extends TestCase
 
         $this->assertSame($expectedResponse, $content);
     }
-  
+
     /**
      * @depends testCreateProductionInstance
      */
@@ -616,7 +616,7 @@ final class BigtableTest extends TestCase
         self::$serviceAccountEmail = $this->createServiceAccount(self::$serviceAccountId);
 
         $user = 'serviceAccount:' . self::$serviceAccountEmail;
-        $content=self::runFunctionSnippet('set_iam_policy', [
+        $content = self::runFunctionSnippet('set_iam_policy', [
             self::$projectId,
             self::$instanceId,
             $user,
@@ -635,7 +635,7 @@ final class BigtableTest extends TestCase
     {
         $user = 'serviceAccount:' . self::$serviceAccountEmail;
 
-        $content=self::runFunctionSnippet('get_iam_policy', [
+        $content = self::runFunctionSnippet('get_iam_policy', [
             self::$projectId,
             self::$instanceId
         ]);

--- a/bigtable/test/filterTest.php
+++ b/bigtable/test/filterTest.php
@@ -49,33 +49,33 @@ final class FilterTest extends TestCase
         self::$timestampMicros = time() * 1000 * 1000;
         self::$timestampMicrosMinusHr = (time() - 60 * 60) * 1000 * 1000;
         self::$bigtableClient->table(self::$instanceId, self::$tableId)->mutateRows([
-            "phone#4c410523#20190501" => (new Mutations())
-                ->upsert('cell_plan', "data_plan_01gb", true, self::$timestampMicrosMinusHr)
-                ->upsert('cell_plan', "data_plan_01gb", false, self::$timestampMicros)
-                ->upsert('cell_plan', "data_plan_05gb", true, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190405.003", self::$timestampMicros),
-            "phone#4c410523#20190502" => (new Mutations())
-                ->upsert('cell_plan', "data_plan_05gb", true, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190405.004", self::$timestampMicros),
-            "phone#4c410523#20190505" => (new Mutations())
-                ->upsert('cell_plan', "data_plan_05gb", true, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_cell", 0, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190406.000", self::$timestampMicros),
-            "phone#5c10102#20190501" => (new Mutations())
-                ->upsert('cell_plan', "data_plan_10gb", true, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190401.002", self::$timestampMicros),
-            "phone#5c10102#20190502" => (new Mutations())
-                ->upsert('cell_plan', "data_plan_10gb", true, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 0, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190406.000", self::$timestampMicros)
+            'phone#4c410523#20190501' => (new Mutations())
+                ->upsert('cell_plan', 'data_plan_01gb', true, self::$timestampMicrosMinusHr)
+                ->upsert('cell_plan', 'data_plan_01gb', false, self::$timestampMicros)
+                ->upsert('cell_plan', 'data_plan_05gb', true, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190405.003', self::$timestampMicros),
+            'phone#4c410523#20190502' => (new Mutations())
+                ->upsert('cell_plan', 'data_plan_05gb', true, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190405.004', self::$timestampMicros),
+            'phone#4c410523#20190505' => (new Mutations())
+                ->upsert('cell_plan', 'data_plan_05gb', true, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_cell', 0, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190406.000', self::$timestampMicros),
+            'phone#5c10102#20190501' => (new Mutations())
+                ->upsert('cell_plan', 'data_plan_10gb', true, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190401.002', self::$timestampMicros),
+            'phone#5c10102#20190502' => (new Mutations())
+                ->upsert('cell_plan', 'data_plan_10gb', true, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 0, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190406.000', self::$timestampMicros)
         ]);
     }
 
@@ -100,7 +100,7 @@ final class FilterTest extends TestCase
             self::$instanceId,
             self::$tableId
         ]);
-        $result = "Reading data for row ";
+        $result = 'Reading data for row ';
         $this->assertStringContainsString($result, trim($output));
     }
 
@@ -421,7 +421,7 @@ Column Family stats_summary
     {
         // since we select the endTime as an open ended timestamp, we add a buffer to our expected timestamp
         // we add 1000 since bigtable has a 1000 microseconds(1ms) granularity
-        $endTime = self::$timestampMicrosMinusHr+1000;
+        $endTime = self::$timestampMicrosMinusHr + 1000;
         $output = self::runFunctionSnippet('filter_limit_timestamp_range', [
             self::$projectId,
             self::$instanceId,
@@ -444,7 +444,7 @@ Column Family cell_plan
             self::$tableId
         ]);
 
-        $result = "";
+        $result = '';
 
         $this->assertEquals($result, trim($output));
     }

--- a/bigtable/test/readTest.php
+++ b/bigtable/test/readTest.php
@@ -42,26 +42,26 @@ final class ReadTest extends TestCase
 
         self::$timestampMicros = time() * 1000 * 1000;
         self::$bigtableClient->table(self::$instanceId, self::$tableId)->mutateRows([
-            "phone#4c410523#20190501" => (new Mutations())
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190405.003", self::$timestampMicros),
-            "phone#4c410523#20190502" => (new Mutations())
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190405.004", self::$timestampMicros),
-            "phone#4c410523#20190505" => (new Mutations())
-                ->upsert('stats_summary', "connected_cell", 0, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190406.000", self::$timestampMicros),
-            "phone#5c10102#20190501" => (new Mutations())
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190401.002", self::$timestampMicros),
-            "phone#5c10102#20190502" => (new Mutations())
-                ->upsert('stats_summary', "connected_cell", 1, self::$timestampMicros)
-                ->upsert('stats_summary', "connected_wifi", 0, self::$timestampMicros)
-                ->upsert('stats_summary', "os_build", "PQ2A.190406.000", self::$timestampMicros)
+            'phone#4c410523#20190501' => (new Mutations())
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190405.003', self::$timestampMicros),
+            'phone#4c410523#20190502' => (new Mutations())
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190405.004', self::$timestampMicros),
+            'phone#4c410523#20190505' => (new Mutations())
+                ->upsert('stats_summary', 'connected_cell', 0, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190406.000', self::$timestampMicros),
+            'phone#5c10102#20190501' => (new Mutations())
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190401.002', self::$timestampMicros),
+            'phone#5c10102#20190502' => (new Mutations())
+                ->upsert('stats_summary', 'connected_cell', 1, self::$timestampMicros)
+                ->upsert('stats_summary', 'connected_wifi', 0, self::$timestampMicros)
+                ->upsert('stats_summary', 'os_build', 'PQ2A.190406.000', self::$timestampMicros)
         ]);
     }
 

--- a/cdn/test/signUrlTest.php
+++ b/cdn/test/signUrlTest.php
@@ -17,41 +17,41 @@
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . "/../signUrl.php";
+require_once __DIR__ . '/../signUrl.php';
 
 class signUrlTest extends TestCase
 {
     public function testBase64UrlEncode()
     {
-        $this->assertEquals(base64url_encode(hex2bin("9d9b51a2174d17d9b770a336e0870ae3")), "nZtRohdNF9m3cKM24IcK4w==");
+        $this->assertEquals(base64url_encode(hex2bin('9d9b51a2174d17d9b770a336e0870ae3')), 'nZtRohdNF9m3cKM24IcK4w==');
     }
 
     public function testBase64UrlEncodeWithoutPadding()
     {
-        $this->assertEquals(base64url_encode(hex2bin("9d9b51a2174d17d9b770a336e0870ae3"), false), "nZtRohdNF9m3cKM24IcK4w");
+        $this->assertEquals(base64url_encode(hex2bin('9d9b51a2174d17d9b770a336e0870ae3'), false), 'nZtRohdNF9m3cKM24IcK4w');
     }
 
     public function testBase64UrlDecode()
     {
-        $this->assertEquals(hex2bin("9d9b51a2174d17d9b770a336e0870ae3"), base64url_decode("nZtRohdNF9m3cKM24IcK4w=="));
+        $this->assertEquals(hex2bin('9d9b51a2174d17d9b770a336e0870ae3'), base64url_decode('nZtRohdNF9m3cKM24IcK4w=='));
     }
 
     public function testBase64UrlDecodeWithoutPadding()
     {
-        $this->assertEquals(hex2bin("9d9b51a2174d17d9b770a336e0870ae3"), base64url_decode("nZtRohdNF9m3cKM24IcK4w"));
+        $this->assertEquals(hex2bin('9d9b51a2174d17d9b770a336e0870ae3'), base64url_decode('nZtRohdNF9m3cKM24IcK4w'));
     }
 
     public function testSignUrl()
     {
-        $encoded_key="nZtRohdNF9m3cKM24IcK4w=="; // base64url encoded key
+        $encoded_key = 'nZtRohdNF9m3cKM24IcK4w=='; // base64url encoded key
 
         $cases = array(
-            array("http://35.186.234.33/index.html", "my-key", 1558131350,
-                  "http://35.186.234.33/index.html?Expires=1558131350&KeyName=my-key&Signature=fm6JZSmKNsB5sys8VGr-JE4LiiE="),
-            array("https://www.google.com/", "my-key", 1549751401,
-                  "https://www.google.com/?Expires=1549751401&KeyName=my-key&Signature=M_QO7BGHi2sGqrJO-MDr0uhDFuc="),
-            array("https://www.example.com/some/path?some=query&another=param", "my-key", 1549751461,
-                  "https://www.example.com/some/path?some=query&another=param&Expires=1549751461&KeyName=my-key&Signature=sTqqGX5hUJmlRJ84koAIhWW_c3M="),
+            array('http://35.186.234.33/index.html', 'my-key', 1558131350,
+                  'http://35.186.234.33/index.html?Expires=1558131350&KeyName=my-key&Signature=fm6JZSmKNsB5sys8VGr-JE4LiiE='),
+            array('https://www.google.com/', 'my-key', 1549751401,
+                  'https://www.google.com/?Expires=1549751401&KeyName=my-key&Signature=M_QO7BGHi2sGqrJO-MDr0uhDFuc='),
+            array('https://www.example.com/some/path?some=query&another=param', 'my-key', 1549751461,
+                  'https://www.example.com/some/path?some=query&another=param&Expires=1549751461&KeyName=my-key&Signature=sTqqGX5hUJmlRJ84koAIhWW_c3M='),
         );
 
         foreach ($cases as $c) {

--- a/cloud_sql/mysql/pdo/src/Votes.php
+++ b/cloud_sql/mysql/pdo/src/Votes.php
@@ -52,12 +52,12 @@ class Votes
             $stmt = $this->connection->prepare('SELECT 1 FROM votes');
             $stmt->execute();
         } catch (PDOException $e) {
-            $sql = "CREATE TABLE votes (
+            $sql = 'CREATE TABLE votes (
                 vote_id INT NOT NULL AUTO_INCREMENT,
                 time_cast DATETIME NOT NULL,
                 candidate VARCHAR(6) NOT NULL,
                 PRIMARY KEY (vote_id)
-            );";
+            );';
 
             $this->connection->exec($sql);
         }
@@ -70,7 +70,7 @@ class Votes
      */
     public function listVotes(): array
     {
-        $sql = "SELECT candidate, time_cast FROM votes ORDER BY time_cast DESC LIMIT 5";
+        $sql = 'SELECT candidate, time_cast FROM votes ORDER BY time_cast DESC LIMIT 5';
         $statement = $this->connection->prepare($sql);
         $statement->execute();
         return $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -84,7 +84,7 @@ class Votes
      */
     public function getCountByValue(string $value): int
     {
-        $sql = "SELECT COUNT(vote_id) as voteCount FROM votes WHERE candidate = ?";
+        $sql = 'SELECT COUNT(vote_id) as voteCount FROM votes WHERE candidate = ?';
 
         $statement = $this->connection->prepare($sql);
         $statement->execute([$value]);
@@ -105,7 +105,7 @@ class Votes
 
         # [START cloud_sql_mysql_pdo_connection]
         // Use prepared statements to guard against SQL injection.
-        $sql = "INSERT INTO votes (time_cast, candidate) VALUES (NOW(), :voteValue)";
+        $sql = 'INSERT INTO votes (time_cast, candidate) VALUES (NOW(), :voteValue)';
 
         try {
             $statement = $conn->prepare($sql);
@@ -114,7 +114,7 @@ class Votes
             $res = $statement->execute();
         } catch (PDOException $e) {
             throw new RuntimeException(
-                "Could not insert vote into database. The PDO exception was " .
+                'Could not insert vote into database. The PDO exception was ' .
                 $e->getMessage(),
                 $e->getCode(),
                 $e

--- a/cloud_sql/postgres/pdo/src/Votes.php
+++ b/cloud_sql/postgres/pdo/src/Votes.php
@@ -52,12 +52,12 @@ class Votes
             $stmt = $this->connection->prepare('SELECT 1 FROM votes');
             $stmt->execute();
         } catch (PDOException $e) {
-            $sql = "CREATE TABLE votes (
+            $sql = 'CREATE TABLE votes (
                 vote_id SERIAL NOT NULL,
                 time_cast TIMESTAMP NOT NULL,
                 candidate VARCHAR(6) NOT NULL,
                 PRIMARY KEY (vote_id)
-            );";
+            );';
 
             $this->connection->exec($sql);
         }
@@ -70,7 +70,7 @@ class Votes
      */
     public function listVotes(): array
     {
-        $sql = "SELECT candidate, time_cast FROM votes ORDER BY time_cast DESC LIMIT 5";
+        $sql = 'SELECT candidate, time_cast FROM votes ORDER BY time_cast DESC LIMIT 5';
         $statement = $this->connection->prepare($sql);
         $statement->execute();
         return $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -84,7 +84,7 @@ class Votes
      */
     public function getCountByValue(string $value): int
     {
-        $sql = "SELECT COUNT(vote_id) as voteCount FROM votes WHERE candidate = ?";
+        $sql = 'SELECT COUNT(vote_id) as voteCount FROM votes WHERE candidate = ?';
 
         $statement = $this->connection->prepare($sql);
         $statement->execute([$value]);
@@ -105,7 +105,7 @@ class Votes
 
         # [START cloud_sql_postgres_pdo_connection]
         // Use prepared statements to guard against SQL injection.
-        $sql = "INSERT INTO votes (time_cast, candidate) VALUES (NOW(), :voteValue)";
+        $sql = 'INSERT INTO votes (time_cast, candidate) VALUES (NOW(), :voteValue)';
 
         try {
             $statement = $conn->prepare($sql);
@@ -114,7 +114,7 @@ class Votes
             $res = $statement->execute();
         } catch (PDOException $e) {
             throw new RuntimeException(
-                "Could not insert vote into database. The PDO exception was " .
+                'Could not insert vote into database. The PDO exception was ' .
                 $e->getMessage(),
                 $e->getCode(),
                 $e

--- a/cloud_sql/postgres/pdo/src/app.php
+++ b/cloud_sql/postgres/pdo/src/app.php
@@ -81,7 +81,6 @@ $container['db'] = function () {
     }
 };
 
-
 // Configure the templating engine.
 $container['view'] = function () {
     return Twig::create(__DIR__ . '/../views');

--- a/cloud_sql/sqlserver/pdo/src/Votes.php
+++ b/cloud_sql/sqlserver/pdo/src/Votes.php
@@ -48,8 +48,8 @@ class Votes
      */
     public function createTableIfNotExists()
     {
-        $existsStmt = "SELECT * FROM INFORMATION_SCHEMA.TABLES
-            WHERE TABLE_NAME = ?";
+        $existsStmt = 'SELECT * FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_NAME = ?';
 
         $stmt = $this->connection->prepare($existsStmt);
         $stmt->execute(['votes']);
@@ -58,12 +58,12 @@ class Votes
 
         // If the table does not exist, create it.
         if (!$row) {
-            $sql = "CREATE TABLE votes (
+            $sql = 'CREATE TABLE votes (
                 vote_id INT NOT NULL IDENTITY,
                 time_cast DATETIME NOT NULL,
                 candidate VARCHAR(6) NOT NULL,
                 PRIMARY KEY (vote_id)
-            );";
+            );';
 
             $this->connection->exec($sql);
         }
@@ -76,7 +76,7 @@ class Votes
      */
     public function listVotes(): array
     {
-        $sql = "SELECT TOP 5 candidate, time_cast FROM votes ORDER BY time_cast DESC";
+        $sql = 'SELECT TOP 5 candidate, time_cast FROM votes ORDER BY time_cast DESC';
         $statement = $this->connection->prepare($sql);
         $statement->execute();
         return $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -90,7 +90,7 @@ class Votes
      */
     public function getCountByValue(string $value): int
     {
-        $sql = "SELECT COUNT(vote_id) as voteCount FROM votes WHERE candidate = ?";
+        $sql = 'SELECT COUNT(vote_id) as voteCount FROM votes WHERE candidate = ?';
 
         $statement = $this->connection->prepare($sql);
         $statement->execute([$value]);
@@ -111,7 +111,7 @@ class Votes
 
         # [START cloud_sql_sqlserver_pdo_connection]
         // Use prepared statements to guard against SQL injection.
-        $sql = "INSERT INTO votes (time_cast, candidate) VALUES (GETDATE(), :voteValue)";
+        $sql = 'INSERT INTO votes (time_cast, candidate) VALUES (GETDATE(), :voteValue)';
 
         try {
             $statement = $conn->prepare($sql);
@@ -120,7 +120,7 @@ class Votes
             $res = $statement->execute();
         } catch (PDOException $e) {
             throw new RuntimeException(
-                "Could not insert vote into database. The PDO exception was " .
+                'Could not insert vote into database. The PDO exception was ' .
                 $e->getMessage(),
                 $e->getCode(),
                 $e

--- a/compute/api-client/helloworld/app.php
+++ b/compute/api-client/helloworld/app.php
@@ -31,7 +31,7 @@ session_start();
  * oauth2_redirect_uri.
  */
 $client = new Google_Client();
-$client->setApplicationName("Google Compute Engine PHP Starter Application");
+$client->setApplicationName('Google Compute Engine PHP Starter Application');
 $client->setClientId('YOUR_CLIENT_ID');
 $client->setClientSecret('YOUR_CLIENT_SECRET');
 $client->setRedirectUri('YOUR_REDIRECT_URI');
@@ -70,17 +70,17 @@ define('DEFAULT_NETWORK', BASE_URL . DEFAULT_PROJECT .
 function generateMarkup($apiRequestName, $apiResponse)
 {
     $apiRequestMarkup = '';
-    $apiRequestMarkup .= "<header><h2>" . $apiRequestName . "</h2></header>";
+    $apiRequestMarkup .= '<header><h2>' . $apiRequestName . '</h2></header>';
 
     if ($apiResponse['items'] == '') {
-        $apiRequestMarkup .= "<pre>";
+        $apiRequestMarkup .= '<pre>';
         $apiRequestMarkup .= print_r(json_decode(json_encode($apiResponse), true), true);
-        $apiRequestMarkup .= "</pre>";
+        $apiRequestMarkup .= '</pre>';
     } else {
         foreach ($apiResponse['items'] as $response) {
-            $apiRequestMarkup .= "<pre>";
+            $apiRequestMarkup .= '<pre>';
             $apiRequestMarkup .= print_r(json_decode(json_encode($response), true), true);
-            $apiRequestMarkup .= "</pre>";
+            $apiRequestMarkup .= '</pre>';
         }
     }
 

--- a/compute/cloud-client/instances/src/disable_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/disable_usage_export_bucket.php
@@ -51,7 +51,7 @@ function disable_usage_export_bucket(string $projectId)
         $operationClient->wait($operation->getName(), $projectId);
     }
 
-    printf("Compute Engine usage export bucket for project `%s` disabled.", $projectId);
+    printf('Compute Engine usage export bucket for project `%s` disabled.', $projectId);
 }
 # [END compute_usage_report_disable]
 

--- a/compute/cloud-client/instances/src/get_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/get_usage_export_bucket.php
@@ -55,21 +55,21 @@ function get_usage_export_bucket(string $projectId)
                 // Although the server explicitly sent the empty string value, the next usage
                 // report generated with these settings still has the default prefix value "usage_gce".
                 // See https://cloud.google.com/compute/docs/reference/rest/v1/projects/get
-                print("Report name prefix not set, replacing with default value of `usage_gce`." . PHP_EOL);
+                print('Report name prefix not set, replacing with default value of `usage_gce`.' . PHP_EOL);
                 $responseUsageExportLocation->setReportNamePrefix('usage_gce');
             }
         }
 
         printf(
-            "Compute Engine usage export bucket for project `%s` is bucket_name = `%s` with " .
-            "report_name_prefix = `%s`." . PHP_EOL,
+            'Compute Engine usage export bucket for project `%s` is bucket_name = `%s` with ' .
+            'report_name_prefix = `%s`.' . PHP_EOL,
             $projectId,
             $responseUsageExportLocation->getBucketName(),
             $responseUsageExportLocation->getReportNamePrefix()
         );
     } else {
         // The usage reports are disabled.
-        printf("Compute Engine usage export bucket for project `%s` is disabled.", $projectId);
+        printf('Compute Engine usage export bucket for project `%s` is disabled.', $projectId);
     }
 }
 # [END compute_usage_report_get]

--- a/compute/cloud-client/instances/src/list_all_images.php
+++ b/compute/cloud-client/instances/src/list_all_images.php
@@ -49,7 +49,7 @@ function list_all_images(string $projectId)
      * so you can simply iterate over all the images.
      */
     $pagedResponse = $imagesClient->list($projectId, $optionalArgs);
-    print("=================== Flat list of images ===================" . PHP_EOL);
+    print('=================== Flat list of images ===================' . PHP_EOL);
     foreach ($pagedResponse->iterateAllElements() as $element) {
         printf(' - %s' . PHP_EOL, $element->getName());
     }

--- a/compute/cloud-client/instances/src/list_images_by_page.php
+++ b/compute/cloud-client/instances/src/list_images_by_page.php
@@ -52,7 +52,7 @@ function list_images_by_page(string $projectId, int $pageSize = 10)
      * that page from the API.
      */
     $pagedResponse = $imagesClient->list($projectId, $optionalArgs);
-    print("=================== Paginated list of images ===================" . PHP_EOL);
+    print('=================== Paginated list of images ===================' . PHP_EOL);
     foreach ($pagedResponse->iteratePages() as $page) {
         printf('Page %s:' . PHP_EOL, $pageNum);
         foreach ($page as $element) {

--- a/compute/cloud-client/instances/src/set_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/set_usage_export_bucket.php
@@ -52,16 +52,16 @@ function set_usage_export_bucket(
 ) {
     // Initialize UsageExportLocation object with provided bucket name and no report name prefix.
     $usageExportLocation = new UsageExportLocation(array(
-        "bucket_name" => $bucketName,
-        "report_name_prefix" => $reportNamePrefix
+        'bucket_name' => $bucketName,
+        'report_name_prefix' => $reportNamePrefix
     ));
 
     if (strlen($reportNamePrefix) == 0) {
         // Sending empty value for report_name_prefix results in the next usage report
         // being generated with the default prefix value "usage_gce".
         // See https://cloud.google.com/compute/docs/reference/rest/v1/projects/setUsageExportBucket
-        print("Setting report_name_prefix to empty value causes the " .
-            "report to have the default value of `usage_gce`." . PHP_EOL);
+        print('Setting report_name_prefix to empty value causes the ' .
+            'report to have the default value of `usage_gce`.' . PHP_EOL);
     }
 
     // Set the usage export location.
@@ -75,8 +75,8 @@ function set_usage_export_bucket(
     }
 
     printf(
-        "Compute Engine usage export bucket for project `%s` set to bucket_name = `%s` with " .
-        "report_name_prefix = `%s`." . PHP_EOL,
+        'Compute Engine usage export bucket for project `%s` set to bucket_name = `%s` with ' .
+        'report_name_prefix = `%s`.' . PHP_EOL,
         $projectId,
         $usageExportLocation->getBucketName(),
         (strlen($reportNamePrefix) == 0) ? 'usage_gce' : $usageExportLocation->getReportNamePrefix()

--- a/compute/cloud-client/instances/test/instancesTest.php
+++ b/compute/cloud-client/instances/test/instancesTest.php
@@ -136,7 +136,7 @@ class instancesTest extends TestCase
     public function testSetUsageExportBucketCustomPrefix()
     {
         // Set custom prefix
-        $customPrefix = "my-custom-prefix";
+        $customPrefix = 'my-custom-prefix';
 
         // Check user value behaviour for setter
         $output = $this->runFunctionSnippet('set_usage_export_bucket', [

--- a/dialogflow/src/detect_intent_audio.php
+++ b/dialogflow/src/detect_intent_audio.php
@@ -58,7 +58,7 @@ function detect_intent_audio($projectId, $path, $sessionId, $languageCode = 'en-
     $fulfilmentText = $queryResult->getFulfillmentText();
 
     // output relevant info
-    print(str_repeat("=", 20) . PHP_EOL);
+    print(str_repeat('=', 20) . PHP_EOL);
     printf('Query text: %s' . PHP_EOL, $queryText);
     printf('Detected intent: %s (confidence: %f)' . PHP_EOL, $displayName,
         $confidence);

--- a/dialogflow/src/detect_intent_stream.php
+++ b/dialogflow/src/detect_intent_stream.php
@@ -73,7 +73,7 @@ function detect_intent_stream($projectId, $path, $sessionId, $languageCode = 'en
     }
 
     // intermediate transcript info
-    print(PHP_EOL . str_repeat("=", 20) . PHP_EOL);
+    print(PHP_EOL . str_repeat('=', 20) . PHP_EOL);
     $stream = $sessionsClient->streamingDetectIntent();
     foreach ($requests as $request) {
         $stream->write($request);
@@ -88,7 +88,7 @@ function detect_intent_stream($projectId, $path, $sessionId, $languageCode = 'en
 
     // get final response and relevant info
     if ($response) {
-        print(str_repeat("=", 20) . PHP_EOL);
+        print(str_repeat('=', 20) . PHP_EOL);
         $queryResult = $response->getQueryResult();
         $queryText = $queryResult->getQueryText();
         $intent = $queryResult->getIntent();

--- a/dialogflow/src/detect_intent_texts.php
+++ b/dialogflow/src/detect_intent_texts.php
@@ -55,7 +55,7 @@ function detect_intent_texts($projectId, $texts, $sessionId, $languageCode = 'en
         $fulfilmentText = $queryResult->getFulfillmentText();
 
         // output relevant info
-        print(str_repeat("=", 20) . PHP_EOL);
+        print(str_repeat('=', 20) . PHP_EOL);
         printf('Query text: %s' . PHP_EOL, $queryText);
         printf('Detected intent: %s (confidence: %f)' . PHP_EOL, $displayName,
             $confidence);

--- a/dialogflow/src/intent_list.php
+++ b/dialogflow/src/intent_list.php
@@ -29,7 +29,7 @@ function intent_list($projectId)
 
     foreach ($intents->iterateAllElements() as $intent) {
         // print relevant info
-        print(str_repeat("=", 20) . PHP_EOL);
+        print(str_repeat('=', 20) . PHP_EOL);
         printf('Intent name: %s' . PHP_EOL, $intent->getName());
         printf('Intent display name: %s' . PHP_EOL, $intent->getDisplayName());
         printf('Action: %s' . PHP_EOL, $intent->getAction());

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -53,7 +53,7 @@ class dlpTest extends TestCase
     {
         $output = $this->runSnippet('inspect_string', [
             self::$projectId,
-            "My name is Gary Smith and my email is gary@example.com"
+            'My name is Gary Smith and my email is gary@example.com'
         ]);
 
         $this->assertStringContainsString('Info type: EMAIL_ADDRESS', $output);
@@ -173,8 +173,8 @@ class dlpTest extends TestCase
         // on a nonexistant bucket.
         $bucketName .= '-dlp-triggers';
 
-        $displayName = uniqid("My trigger display name ");
-        $description = uniqid("My trigger description ");
+        $displayName = uniqid('My trigger display name ');
+        $description = uniqid('My trigger description ');
         $triggerId = uniqid('my-php-test-trigger-');
         $scanPeriod = 1;
         $autoPopulateTimespan = true;
@@ -206,12 +206,12 @@ class dlpTest extends TestCase
 
     public function testInspectTemplates()
     {
-        $displayName = uniqid("My inspect template display name ");
-        $description = uniqid("My inspect template description ");
+        $displayName = uniqid('My inspect template display name ');
+        $description = uniqid('My inspect template description ');
         $templateId = uniqid('my-php-test-inspect-template-');
         $fullTemplateId = sprintf('projects/%s/locations/global/inspectTemplates/%s', self::$projectId, $templateId);
 
-        $output  = $this->runSnippet('create_inspect_template', [
+        $output = $this->runSnippet('create_inspect_template', [
             self::$projectId,
             $templateId,
             $displayName,

--- a/endpoints/getting-started/EndpointsCommand.php
+++ b/endpoints/getting-started/EndpointsCommand.php
@@ -77,9 +77,9 @@ class EndpointsCommand extends Command
             }
 
             $oauth = new OAuth2([
-                'issuer'    => 'jwt-client.endpoints.sample.google.com',
-                'audience'  => 'echo.endpoints.sample.google.com',
-                'scope'     => 'email',
+                'issuer' => 'jwt-client.endpoints.sample.google.com',
+                'audience' => 'echo.endpoints.sample.google.com',
+                'scope' => 'email',
                 'authorizationUri' => 'https://accounts.google.com/o/oauth2/auth',
                 'tokenCredentialUri' => 'https://www.googleapis.com/oauth2/v4/token',
             ]);
@@ -105,7 +105,7 @@ class EndpointsCommand extends Command
                 $oauth->setClientId($config['installed']['client_id']);
                 $oauth->setClientSecret($config['installed']['client_secret']);
                 $oauth->setRedirectUri('urn:ietf:wg:oauth:2.0:oob');
-                $authUrl = $oauth->buildFullAuthorizationUri(['access_type'  => 'offline']);
+                $authUrl = $oauth->buildFullAuthorizationUri(['access_type' => 'offline']);
                 `open '$authUrl'`;
 
                 // prompt for the auth code
@@ -116,7 +116,7 @@ class EndpointsCommand extends Command
 
                 $token = $oauth->fetchAuthToken();
                 if (empty($token['id_token'])) {
-                    return $output->writeln("<error>unable to retrieve ID token</error>");
+                    return $output->writeln('<error>unable to retrieve ID token</error>');
                 }
                 $headers['Authorization'] = sprintf('Bearer %s', $token['id_token']);
             }
@@ -132,7 +132,7 @@ class EndpointsCommand extends Command
 
         $response = $http->request($method, $path, [
             'query' => ['key' => $api_key],
-            'body'  => $body,
+            'body' => $body,
             'headers' => $headers
         ]);
 

--- a/endpoints/getting-started/app.php
+++ b/endpoints/getting-started/app.php
@@ -63,7 +63,6 @@ $app->get('/auth/info/googlejwt', function (Request $request, Response $response
         ->withHeader('Content-Type', 'application/json');
 });
 
-
 $app->get('/auth/info/googleidtoken', function (Request $request, Response $response) {
     // Auth info with Google ID token.
     $userInfo = get_user_info($request);

--- a/error_reporting/quickstart.php
+++ b/error_reporting/quickstart.php
@@ -29,6 +29,6 @@ $psrLogger = $logging->psrLogger('error-log', [
 // exception hander. This will ensure all exceptions are logged to Stackdriver.
 Bootstrap::init($psrLogger);
 
-print("Throwing a test exception. You can view the message at https://console.cloud.google.com/errors." . PHP_EOL);
+print('Throwing a test exception. You can view the message at https://console.cloud.google.com/errors.' . PHP_EOL);
 throw new Exception('quickstart.php test exception');
 # [END error_reporting_quickstart]

--- a/firestore/src/query_filter_not_in.php
+++ b/firestore/src/query_filter_not_in.php
@@ -41,7 +41,7 @@ function query_filter_not_in(string $projectId): void
     $stateQuery = $citiesRef->where(
         'country',
         \Google\Cloud\Firestore\V1\StructuredQuery\FieldFilter\Operator::NOT_IN,
-        ["USA", "Japan"]
+        ['USA', 'Japan']
     );
     # [END firestore_query_filter_not_in]
     foreach ($stateQuery->documents() as $document) {

--- a/firestore/src/solution_sharded_counter_increment.php
+++ b/firestore/src/solution_sharded_counter_increment.php
@@ -46,7 +46,7 @@ function solution_sharded_counter_increment(string $projectId): void
     foreach ($docCollection as $doc) {
         $numShards++;
     }
-    $shardIdx = random_int(0, $numShards-1);
+    $shardIdx = random_int(0, $numShards - 1);
     $doc = $ref->document($shardIdx);
     $doc->update([
         ['path' => 'Cnt', 'value' => FieldValue::increment(1)]

--- a/firestore/test/firestoreTest.php
+++ b/firestore/test/firestoreTest.php
@@ -205,7 +205,6 @@ class firestoreTest extends TestCase
         $this->assertStringContainsString('Document SF returned by query regions array-contains west_coast', $output);
     }
 
-
     /**
      * @depends testQueryCreateExamples
      */
@@ -245,11 +244,11 @@ class firestoreTest extends TestCase
     public function testNotEqQuery()
     {
         $output = $this->runFirestoreSnippet('query_filter_not_eq');
-        $this->assertStringContainsString("Document BJ returned by query state!=false.", $output);
-        $this->assertStringContainsString("Document TOK returned by query state!=false.", $output);
-        $this->assertStringContainsString("Document DC returned by query state!=false.", $output);
-        $this->assertStringNotContainsString("Document LA returned by query state!=false.", $output);
-        $this->assertStringNotContainsString("Document SF returned by query state!=false.", $output);
+        $this->assertStringContainsString('Document BJ returned by query state!=false.', $output);
+        $this->assertStringContainsString('Document TOK returned by query state!=false.', $output);
+        $this->assertStringContainsString('Document DC returned by query state!=false.', $output);
+        $this->assertStringNotContainsString('Document LA returned by query state!=false.', $output);
+        $this->assertStringNotContainsString('Document SF returned by query state!=false.', $output);
     }
 
     /**
@@ -283,7 +282,7 @@ class firestoreTest extends TestCase
             $output = $this->runFirestoreSnippet('query_filter_compound_multi_eq_lt');
             $this->assertStringContainsString('Document SF returned by query state=CA and population<1000000', $output);
         } catch (FailedPreconditionException $e) {
-            $this->markTestSkipped("test requires manual creation of index. message: " . $e->getMessage());
+            $this->markTestSkipped('test requires manual creation of index. message: ' . $e->getMessage());
         }
     }
 
@@ -318,7 +317,7 @@ class firestoreTest extends TestCase
             $output = $this->runFirestoreSnippet('query_collection_group_dataset');
             $this->assertStringContainsString('Added example landmarks collections to the cities collection.', $output);
         } catch (FailedPreconditionException $e) {
-            $this->markTestSkipped("test requires manual creation of index. message: " . $e->getMessage());
+            $this->markTestSkipped('test requires manual creation of index. message: ' . $e->getMessage());
         }
     }
 
@@ -467,7 +466,7 @@ class firestoreTest extends TestCase
             $this->assertStringContainsString('Document DC returned by order by state and descending population query', $output);
             $this->assertStringContainsString('Document TOK returned by order by state and descending population query', $output);
         } catch (FailedPreconditionException $e) {
-            $this->markTestSkipped("test requires manual creation of index. message: " . $e->getMessage());
+            $this->markTestSkipped('test requires manual creation of index. message: ' . $e->getMessage());
         }
     }
 
@@ -650,7 +649,7 @@ class firestoreTest extends TestCase
             $output = $this->runFirestoreSnippet('query_cursor_start_at_field_value_multi');
             $this->assertStringContainsString('Document TOK returned by start at ', $output);
         } catch (FailedPreconditionException $e) {
-            $this->markTestSkipped("test requires manual creation of index. message: " . $e->getMessage());
+            $this->markTestSkipped('test requires manual creation of index. message: ' . $e->getMessage());
         }
     }
 

--- a/functions/concepts_filesystem/index.php
+++ b/functions/concepts_filesystem/index.php
@@ -23,7 +23,7 @@ function listFiles(ServerRequestInterface $request): string
 {
     $contents = scandir(__DIR__);
 
-    $output = "Files:" . PHP_EOL;
+    $output = 'Files:' . PHP_EOL;
 
     foreach ($contents as $file) {
         $output .= "\t" . $file . PHP_EOL;

--- a/functions/env_vars/test/DeployTest.php
+++ b/functions/env_vars/test/DeployTest.php
@@ -49,7 +49,7 @@ class DeployTest extends TestCase
     {
         // Use the first test case as the source of the deployed environment variable.
         $cases = self::cases();
-        $env = sprintf("%s=%s", $cases[0]['varName'], $cases[0]['varValue']);
+        $env = sprintf('%s=%s', $cases[0]['varName'], $cases[0]['varValue']);
         self::$fn->deploy(['--update-env-vars' => $env]);
     }
 

--- a/functions/firebase_analytics/index.php
+++ b/functions/firebase_analytics/index.php
@@ -22,7 +22,7 @@ use Google\CloudFunctions\CloudEvent;
 function firebaseAnalytics(CloudEvent $cloudevent): void
 {
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
-    
+
     $data = $cloudevent->getData();
 
     fwrite($log, 'Function triggered by the following event:' . $data['resource'] . PHP_EOL);

--- a/functions/firebase_firestore/index.php
+++ b/functions/firebase_firestore/index.php
@@ -22,9 +22,9 @@ use Google\CloudFunctions\CloudEvent;
 function firebaseFirestore(CloudEvent $cloudevent)
 {
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
-    
-    fwrite($log, "Event: " . $cloudevent->getId() . PHP_EOL);
-    fwrite($log, "Event Type: " . $cloudevent->getType() . PHP_EOL);
+
+    fwrite($log, 'Event: ' . $cloudevent->getId() . PHP_EOL);
+    fwrite($log, 'Event Type: ' . $cloudevent->getType() . PHP_EOL);
 
     $data = $cloudevent->getData();
 

--- a/functions/firebase_firestore_reactive/test/IntegrationTest.php
+++ b/functions/firebase_firestore_reactive/test/IntegrationTest.php
@@ -54,7 +54,7 @@ class IntegrationTest extends TestCase
                         'value' => [
                             'fields' => [
                                 'original' => [
-                                    'stringValue'=> self::$value
+                                    'stringValue' => self::$value
                                 ]
                             ],
                             'name' => '/documents/some_collection/blah',

--- a/functions/firebase_remote_config/index.php
+++ b/functions/firebase_remote_config/index.php
@@ -22,7 +22,7 @@ use Google\CloudFunctions\CloudEvent;
 function firebaseRemoteConfig(CloudEvent $cloudevent)
 {
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
-    
+
     $data = $cloudevent->getData();
 
     fwrite($log, 'Update type: ' . $data['updateType'] . PHP_EOL);

--- a/functions/firebase_rtdb/index.php
+++ b/functions/firebase_rtdb/index.php
@@ -22,8 +22,8 @@ use Google\CloudFunctions\CloudEvent;
 function firebaseRTDB(CloudEvent $cloudevent)
 {
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
-    
-    fwrite($log, "Event: " . $cloudevent->getId() . PHP_EOL);
+
+    fwrite($log, 'Event: ' . $cloudevent->getId() . PHP_EOL);
 
     $data = $cloudevent->getData();
     $resource = $data['resource'] ?? '<null>';

--- a/functions/helloworld_log/index.php
+++ b/functions/helloworld_log/index.php
@@ -36,14 +36,14 @@ function helloLogging(ServerRequestInterface $request): string
 
     // This doesn't log anything
     error_log('error_log does not log in Cloud Functions!');
-    
+
     // This will log an error message and immediately terminate the function execution
     // trigger_error('fatal errors are logged!');
-    
+
     // For HTTP functions, this is added to the HTTP response
     // For CloudEvent functions, this does nothing
     var_dump('var_dump goes to HTTP response for HTTP functions');
-    
+
     // You can also dump variables using var_export() and forward
     // the resulting string to Cloud Logging via an fwrite() call.
     $entry = var_export('var_export output can be captured.', true);

--- a/functions/helloworld_storage/index.php
+++ b/functions/helloworld_storage/index.php
@@ -23,13 +23,13 @@ function helloGCS(CloudEvent $cloudevent)
 {
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
     $data = $cloudevent->getData();
-    fwrite($log, "Event: " . $cloudevent->getId() . PHP_EOL);
-    fwrite($log, "Event Type: " . $cloudevent->getType() . PHP_EOL);
-    fwrite($log, "Bucket: " . $data['bucket'] . PHP_EOL);
-    fwrite($log, "File: " . $data['name'] . PHP_EOL);
-    fwrite($log, "Metageneration: " . $data['metageneration'] . PHP_EOL);
-    fwrite($log, "Created: " . $data['timeCreated'] . PHP_EOL);
-    fwrite($log, "Updated: " . $data['updated'] . PHP_EOL);
+    fwrite($log, 'Event: ' . $cloudevent->getId() . PHP_EOL);
+    fwrite($log, 'Event Type: ' . $cloudevent->getType() . PHP_EOL);
+    fwrite($log, 'Bucket: ' . $data['bucket'] . PHP_EOL);
+    fwrite($log, 'File: ' . $data['name'] . PHP_EOL);
+    fwrite($log, 'Metageneration: ' . $data['metageneration'] . PHP_EOL);
+    fwrite($log, 'Created: ' . $data['timeCreated'] . PHP_EOL);
+    fwrite($log, 'Updated: ' . $data['updated'] . PHP_EOL);
 }
 
 // [END functions_helloworld_storage]

--- a/functions/http_form_data/index.php
+++ b/functions/http_form_data/index.php
@@ -59,14 +59,14 @@ function uploadFile(ServerRequestInterface $request): ResponseInterface
 function errorLog($msg): void
 {
     $stream = fopen('php://stderr', 'wb');
-    $entry = json_encode(['msg' => $msg, 'severity' => 'error'], JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
+    $entry = json_encode(['msg' => $msg, 'severity' => 'error'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     fwrite($stream, $entry . PHP_EOL);
 }
 
 function infoLog($msg): void
 {
     $stream = fopen('php://stderr', 'wb');
-    $entry = json_encode(['message' => $msg, 'severity' => 'info'], JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
+    $entry = json_encode(['message' => $msg, 'severity' => 'info'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     fwrite($stream, $entry . PHP_EOL);
 }
 

--- a/functions/slack_slash_command/index.php
+++ b/functions/slack_slash_command/index.php
@@ -100,7 +100,7 @@ function formatSlackMessage(Google_Service_Kgsearch_SearchResponse $kgResponse, 
  */
 function searchKnowledgeGraph(string $query): Google_Service_Kgsearch_SearchResponse
 {
-    $API_KEY = getenv("KG_API_KEY");
+    $API_KEY = getenv('KG_API_KEY');
 
     $apiClient = new Google\Client();
     $apiClient->setDeveloperKey($API_KEY);

--- a/functions/slack_slash_command/test/IntegrationTest.php
+++ b/functions/slack_slash_command/test/IntegrationTest.php
@@ -64,7 +64,7 @@ class IntegrationTest extends TestCase
         $this->assertEquals(
             $statusCode,
             $response->getStatusCode(),
-            $label . ": status code"
+            $label . ': status code'
         );
 
         if ($expected !== null) {

--- a/functions/slack_slash_command/test/UnitTest.php
+++ b/functions/slack_slash_command/test/UnitTest.php
@@ -52,7 +52,7 @@ class UnitTest extends TestCase
         $this->assertEquals(
             $statusCode,
             $response->getStatusCode(),
-            $label . ": status code"
+            $label . ': status code'
         );
 
         if ($expected !== null) {

--- a/functions/tips_infinite_retries/test/IntegrationTest.php
+++ b/functions/tips_infinite_retries/test/IntegrationTest.php
@@ -37,7 +37,6 @@ class IntegrationTest extends TestCase
     /** @var string */
     private static $functionSignatureType = 'cloudevent';
 
-
     public function dataProvider()
     {
         return [

--- a/functions/tips_phpinfo/index.php
+++ b/functions/tips_phpinfo/index.php
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 // [START functions_tips_phpinfo]
 
 use Psr\Http\Message\ServerRequestInterface;

--- a/functions/tips_retry/index.php
+++ b/functions/tips_retry/index.php
@@ -44,6 +44,6 @@ function tipsRetry(CloudEvent $event): void
      * failure, it should return *without* throwing an exception.
      */
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
-    fwrite($log, "Not retrying" . PHP_EOL);
+    fwrite($log, 'Not retrying' . PHP_EOL);
 }
 // [END functions_tips_retry]

--- a/functions/tips_retry/test/IntegrationTest.php
+++ b/functions/tips_retry/test/IntegrationTest.php
@@ -38,7 +38,6 @@ class IntegrationTest extends TestCase
     /** @var string */
     private static $functionSignatureType = 'cloudevent';
 
-
     private static function makeData(array $jsonArray)
     {
         return [

--- a/functions/tips_scopes/index.php
+++ b/functions/tips_scopes/index.php
@@ -44,7 +44,7 @@ function scopeDemo(ServerRequestInterface $request): string
     if (file_exists($cachePath)) {
         // Read cached value from file, using file locking to prevent race
         // conditions between function executions.
-        $response .= "Reading cached value." . PHP_EOL;
+        $response .= 'Reading cached value.' . PHP_EOL;
         $fh = fopen($cachePath, 'r');
         flock($fh, LOCK_EX);
         $instanceVar = stream_get_contents($fh);
@@ -52,7 +52,7 @@ function scopeDemo(ServerRequestInterface $request): string
     } else {
         // Compute cached value + write to file, using file locking to prevent
         // race conditions between function executions.
-        $response .= "Cache empty, computing value." . PHP_EOL;
+        $response .= 'Cache empty, computing value.' . PHP_EOL;
         $instanceVar = _heavyComputation();
         file_put_contents($cachePath, $instanceVar, LOCK_EX);
     }

--- a/iap/src/validate_jwt.php
+++ b/iap/src/validate_jwt.php
@@ -92,7 +92,6 @@ function validate_jwt($iapJwt, $expectedAudience)
     assert($jwt['iss'] == 'https://cloud.google.com/iap');
     assert($jwt['aud'] == $expectedAudience);
 
-
     print('Printing user identity information from ID token payload:');
     printf('sub: %s', $jwt['sub']);
     printf('email: %s', $jwt['email']);

--- a/kms/src/create_key_asymmetric_decrypt.php
+++ b/kms/src/create_key_asymmetric_decrypt.php
@@ -46,7 +46,7 @@ function create_key_asymmetric_decrypt_sample(
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24*60*60)
+            ->setSeconds(24 * 60 * 60)
         );
 
     // Call the API.
@@ -55,7 +55,6 @@ function create_key_asymmetric_decrypt_sample(
     return $createdKey;
 }
 // [END kms_create_key_asymmetric_decrypt]
-
 
 if (isset($argv)) {
     if (count($argv) === 0) {

--- a/kms/src/create_key_asymmetric_sign.php
+++ b/kms/src/create_key_asymmetric_sign.php
@@ -46,7 +46,7 @@ function create_key_asymmetric_sign_sample(
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24*60*60)
+            ->setSeconds(24 * 60 * 60)
         );
 
     // Call the API.
@@ -55,7 +55,6 @@ function create_key_asymmetric_sign_sample(
     return $createdKey;
 }
 // [END kms_create_key_asymmetric_sign]
-
 
 if (isset($argv)) {
     if (count($argv) === 0) {

--- a/kms/src/create_key_hsm.php
+++ b/kms/src/create_key_hsm.php
@@ -48,7 +48,7 @@ function create_key_hsm_sample(
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24*60*60)
+            ->setSeconds(24 * 60 * 60)
         );
 
     // Call the API.

--- a/kms/src/create_key_mac.php
+++ b/kms/src/create_key_mac.php
@@ -46,7 +46,7 @@ function create_key_mac_sample(
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24*60*60)
+            ->setSeconds(24 * 60 * 60)
         );
 
     // Call the API.

--- a/kms/src/create_key_rotation_schedule.php
+++ b/kms/src/create_key_rotation_schedule.php
@@ -46,12 +46,12 @@ function create_key_rotation_schedule_sample(
 
         // Rotate the key every 30 days.
         ->setRotationPeriod((new Duration())
-            ->setSeconds(60*60*24*30)
+            ->setSeconds(60 * 60 * 24 * 30)
         )
 
         // Start the first rotation in 24 hours.
         ->setNextRotationTime((new Timestamp())
-            ->setSeconds(time() + 60*60*24)
+            ->setSeconds(time() + 60 * 60 * 24)
         );
 
     // Call the API.

--- a/kms/src/update_key_add_rotation.php
+++ b/kms/src/update_key_add_rotation.php
@@ -42,12 +42,12 @@ function update_key_add_rotation_sample(
 
         // Rotate the key every 30 days.
         ->setRotationPeriod((new Duration())
-            ->setSeconds(60*60*24*30)
+            ->setSeconds(60 * 60 * 24 * 30)
         )
 
         // Start the first rotation in 24 hours.
         ->setNextRotationTime((new Timestamp())
-            ->setSeconds(time() + 60*60*24)
+            ->setSeconds(time() + 60 * 60 * 24)
         );
 
     // Create the field mask.

--- a/kms/test/kmsTest.php
+++ b/kms/test/kmsTest.php
@@ -440,7 +440,7 @@ class kmsTest extends TestCase
             self::$locationId,
             self::$keyRingId,
             self::$asymmetricDecryptKeyId,
-            "1",
+            '1',
             $plaintext
         ]);
 
@@ -650,7 +650,6 @@ class kmsTest extends TestCase
         $verifyResponse = $client->macVerify($keyVersionName, $data, $signResponse->getMac());
         $this->assertTrue($verifyResponse->getSuccess());
     }
-
 
     public function testUpdateKeyAddRotation()
     {

--- a/language/test/languageTest.php
+++ b/language/test/languageTest.php
@@ -116,7 +116,6 @@ class languageTest extends TestCase
         $this->assertStringContainsString('Name: Washington D.C.', $output);
     }
 
-
     public function testAnalyzeEntitiesFromFile()
     {
         $output = $this->runSnippet('analyze_entities_from_file', [
@@ -143,7 +142,6 @@ class languageTest extends TestCase
         $this->assertStringContainsString('  Magnitude:', $output);
         $this->assertStringContainsString('  Score:', $output);
     }
-
 
     public function testAnalyzeSentimentFromFile()
     {

--- a/logging/src/log_entry_functions.php
+++ b/logging/src/log_entry_functions.php
@@ -86,7 +86,7 @@ function list_entries($projectId, $loggerName)
             }
             $entryText = '{' . implode(', ', $entryPayload) . '}';
         }
-        printf("%s : %s" . PHP_EOL, $entryInfo['timestamp'], $entryText);
+        printf('%s : %s' . PHP_EOL, $entryInfo['timestamp'], $entryText);
     }
 }
 // [END logging_list_log_entries]

--- a/logging/src/sink_functions.php
+++ b/logging/src/sink_functions.php
@@ -81,7 +81,6 @@ function list_sinks($projectId)
 }
 // [END logging_list_sinks]
 
-
 // [START logging_update_sink]
 /**
  * Update a log sink.

--- a/logging/test/loggingTest.php
+++ b/logging/test/loggingTest.php
@@ -38,7 +38,7 @@ class loggingTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$sinkName = sprintf("sink-%s", uniqid());
+        self::$sinkName = sprintf('sink-%s', uniqid());
     }
 
     public function setUp(): void
@@ -138,7 +138,7 @@ class loggingTest extends TestCase
 
     public function testWriteAndList()
     {
-        $message = sprintf("Test Message %s", uniqid());
+        $message = sprintf('Test Message %s', uniqid());
         $output = $this->runCommand('write', [
             'project' => self::$projectId,
             'message' => $message,

--- a/monitoring/monitoring.php
+++ b/monitoring/monitoring.php
@@ -76,7 +76,6 @@ $application->add(new Command('delete-uptime-check'))
         );
     });
 
-
 $application->add(new Command('get-descriptor'))
     ->setDefinition(clone $inputDefinition)
     ->addArgument('metric_id', InputArgument::REQUIRED, 'The metric descriptor id')

--- a/monitoring/test/monitoringTest.php
+++ b/monitoring/test/monitoringTest.php
@@ -38,7 +38,7 @@ class monitoringTest extends TestCase
     // Make retry function longer because creating a metric takes a while
     private function retrySleepFunc($attempts)
     {
-        sleep(pow(2, $attempts+2));
+        sleep(pow(2, $attempts + 2));
     }
 
     public function testCreateMetric()

--- a/pubsub/app/index.php
+++ b/pubsub/app/index.php
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 // composer autoloading
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/securitycenter/src/create_notification.php
+++ b/securitycenter/src/create_notification.php
@@ -37,7 +37,7 @@ $securityCenterClient = new SecurityCenterClient();
 $organizationName = $securityCenterClient::organizationName($organizationId);
 $pubsubTopic = $securityCenterClient::topicName($projectId, $topicName);
 
-$streamingConfig = (new StreamingConfig())->setFilter("state = \"ACTIVE\"");
+$streamingConfig = (new StreamingConfig())->setFilter('state = "ACTIVE"');
 $notificationConfig = (new NotificationConfig())
     ->setDescription('A sample notification config')
     ->setPubsubTopic($pubsubTopic)

--- a/securitycenter/src/update_notification.php
+++ b/securitycenter/src/update_notification.php
@@ -41,7 +41,7 @@ $securityCenterClient = new SecurityCenterClient();
 $pubsubTopic = $securityCenterClient::topicName($projectId, $topicName);
 $notificationConfigName = $securityCenterClient::notificationConfigName($organizationId, $notificationConfigId);
 
-$streamingConfig = (new StreamingConfig())->setFilter("state = \"ACTIVE\"");
+$streamingConfig = (new StreamingConfig())->setFilter('state = "ACTIVE"');
 $fieldMask = (new FieldMask())->setPaths(['description', 'pubsub_topic', 'streaming_config.filter']);
 $notificationConfig = (new NotificationConfig())
     ->setName($notificationConfigName)

--- a/servicedirectory/src/delete_endpoint.php
+++ b/servicedirectory/src/delete_endpoint.php
@@ -37,7 +37,6 @@ use Google\Cloud\ServiceDirectory\V1beta1\RegistrationServiceClient;
 // Instantiate a client.
 $client = new RegistrationServiceClient();
 
-
 // Run request.
 $endpointName = RegistrationServiceClient::endpointName($projectId, $locationId, $namespaceId, $serviceId, $endpointId);
 $endpoint = $client->deleteEndpoint($endpointName);

--- a/spanner/src/add_numeric_column.php
+++ b/spanner/src/add_numeric_column.php
@@ -43,7 +43,7 @@ function add_numeric_column($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $operation = $database->updateDdl(
-        "ALTER TABLE Venues ADD COLUMN Revenue NUMERIC"
+        'ALTER TABLE Venues ADD COLUMN Revenue NUMERIC'
     );
 
     print('Waiting for operation to complete...' . PHP_EOL);

--- a/spanner/src/add_timestamp_column.php
+++ b/spanner/src/add_timestamp_column.php
@@ -43,7 +43,7 @@ function add_timestamp_column($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $operation = $database->updateDdl(
-        "ALTER TABLE Albums ADD COLUMN LastUpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp=true)"
+        'ALTER TABLE Albums ADD COLUMN LastUpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp=true)'
     );
 
     print('Waiting for operation to complete...' . PHP_EOL);

--- a/spanner/src/create_database.php
+++ b/spanner/src/create_database.php
@@ -46,18 +46,18 @@ function create_database($instanceId, $databaseId)
     }
 
     $operation = $instance->createDatabase($databaseId, ['statements' => [
-        "CREATE TABLE Singers (
+        'CREATE TABLE Singers (
             SingerId     INT64 NOT NULL,
             FirstName    STRING(1024),
             LastName     STRING(1024),
             SingerInfo   BYTES(MAX)
-        ) PRIMARY KEY (SingerId)",
-        "CREATE TABLE Albums (
+        ) PRIMARY KEY (SingerId)',
+        'CREATE TABLE Albums (
             SingerId     INT64 NOT NULL,
             AlbumId      INT64 NOT NULL,
             AlbumTitle   STRING(MAX)
         ) PRIMARY KEY (SingerId, AlbumId),
-        INTERLEAVE IN PARENT Singers ON DELETE CASCADE"
+        INTERLEAVE IN PARENT Singers ON DELETE CASCADE'
     ]]);
 
     print('Waiting for operation to complete...' . PHP_EOL);

--- a/spanner/src/create_database_with_default_leader.php
+++ b/spanner/src/create_database_with_default_leader.php
@@ -47,18 +47,18 @@ function create_database_with_default_leader($instanceId, $databaseId, $defaultL
     }
 
     $operation = $instance->createDatabase($databaseId, ['statements' => [
-        "CREATE TABLE Singers (
+        'CREATE TABLE Singers (
             SingerId     INT64 NOT NULL,
             FirstName    STRING(1024),
             LastName     STRING(1024),
             SingerInfo   BYTES(MAX)
-        ) PRIMARY KEY (SingerId)",
-        "CREATE TABLE Albums (
+        ) PRIMARY KEY (SingerId)',
+        'CREATE TABLE Albums (
             SingerId     INT64 NOT NULL,
             AlbumId      INT64 NOT NULL,
             AlbumTitle   STRING(MAX)
         ) PRIMARY KEY (SingerId, AlbumId),
-        INTERLEAVE IN PARENT Singers ON DELETE CASCADE",
+        INTERLEAVE IN PARENT Singers ON DELETE CASCADE',
         "ALTER DATABASE `$databaseId` SET OPTIONS (
         default_leader = '$defaultLeader')"
     ]]);

--- a/spanner/src/create_database_with_encryption_key.php
+++ b/spanner/src/create_database_with_encryption_key.php
@@ -48,18 +48,18 @@ function create_database_with_encryption_key($instanceId, $databaseId, $kmsKeyNa
 
     $operation = $instance->createDatabase($databaseId, [
         'statements' => [
-            "CREATE TABLE Singers (
+            'CREATE TABLE Singers (
                 SingerId     INT64 NOT NULL,
                 FirstName    STRING(1024),
                 LastName     STRING(1024),
                 SingerInfo   BYTES(MAX)
-            ) PRIMARY KEY (SingerId)",
-            "CREATE TABLE Albums (
+            ) PRIMARY KEY (SingerId)',
+            'CREATE TABLE Albums (
                 SingerId     INT64 NOT NULL,
                 AlbumId      INT64 NOT NULL,
                 AlbumTitle   STRING(MAX)
             ) PRIMARY KEY (SingerId, AlbumId),
-            INTERLEAVE IN PARENT Singers ON DELETE CASCADE"
+            INTERLEAVE IN PARENT Singers ON DELETE CASCADE'
         ],
         'encryptionConfig' => ['kmsKeyName' => $kmsKeyName]
     ]);

--- a/spanner/src/create_database_with_version_retention_period.php
+++ b/spanner/src/create_database_with_version_retention_period.php
@@ -47,18 +47,18 @@ function create_database_with_version_retention_period($instanceId, $databaseId,
     }
 
     $operation = $instance->createDatabase($databaseId, ['statements' => [
-        "CREATE TABLE Singers (
+        'CREATE TABLE Singers (
             SingerId     INT64 NOT NULL,
             FirstName    STRING(1024),
             LastName     STRING(1024),
             SingerInfo   BYTES(MAX)
-        ) PRIMARY KEY (SingerId)",
-        "CREATE TABLE Albums (
+        ) PRIMARY KEY (SingerId)',
+        'CREATE TABLE Albums (
             SingerId     INT64 NOT NULL,
             AlbumId      INT64 NOT NULL,
             AlbumTitle   STRING(MAX)
         ) PRIMARY KEY (SingerId, AlbumId),
-        INTERLEAVE IN PARENT Singers ON DELETE CASCADE",
+        INTERLEAVE IN PARENT Singers ON DELETE CASCADE',
         "ALTER DATABASE `$databaseId` SET OPTIONS (
         version_retention_period = '$retentionPeriod')"
     ]]);

--- a/spanner/src/create_table_with_datatypes.php
+++ b/spanner/src/create_table_with_datatypes.php
@@ -43,7 +43,7 @@ function create_table_with_datatypes($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $operation = $database->updateDdl(
-        "CREATE TABLE Venues (
+        'CREATE TABLE Venues (
             VenueId		           INT64 NOT NULL,
             VenueName              STRING(100),
             VenueInfo              BYTES(MAX),
@@ -53,7 +53,7 @@ function create_table_with_datatypes($instanceId, $databaseId)
             OutdoorVenue           BOOL,
             PopularityScore        FLOAT64,
             LastUpdateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true)
-    	) PRIMARY KEY (VenueId)"
+    	) PRIMARY KEY (VenueId)'
     );
 
     print('Waiting for operation to complete...' . PHP_EOL);

--- a/spanner/src/create_table_with_timestamp_column.php
+++ b/spanner/src/create_table_with_timestamp_column.php
@@ -43,14 +43,14 @@ function create_table_with_timestamp_column($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $operation = $database->updateDdl(
-        "CREATE TABLE Performances (
+        'CREATE TABLE Performances (
     		SingerId	INT64 NOT NULL,
     		VenueId		INT64 NOT NULL,
     		EventDate	DATE,
     		Revenue		INT64,
     		LastUpdateTime	TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true)
     	) PRIMARY KEY (SingerId, VenueId, EventDate),
-    	INTERLEAVE IN PARENT Singers on DELETE CASCADE"
+    	INTERLEAVE IN PARENT Singers on DELETE CASCADE'
     );
 
     print('Waiting for operation to complete...' . PHP_EOL);

--- a/spanner/src/delete_data_with_partitioned_dml.php
+++ b/spanner/src/delete_data_with_partitioned_dml.php
@@ -50,7 +50,7 @@ function delete_data_with_partitioned_dml($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $rowCount = $database->executePartitionedUpdate(
-        "DELETE FROM Singers WHERE SingerId > 10"
+        'DELETE FROM Singers WHERE SingerId > 10'
     );
 
     printf('Deleted %d row(s).' . PHP_EOL, $rowCount);

--- a/spanner/src/get_database_ddl.php
+++ b/spanner/src/get_database_ddl.php
@@ -44,7 +44,7 @@ function get_database_ddl($instanceId, $databaseId)
 
     printf("Retrieved database DDL for $databaseId" . PHP_EOL);
     foreach ($database->ddl() as $statement) {
-        printf("%s" . PHP_EOL, $statement);
+        printf('%s' . PHP_EOL, $statement);
     }
 }
 // [END spanner_get_database_ddl]

--- a/spanner/src/get_instance_config.php
+++ b/spanner/src/get_instance_config.php
@@ -35,7 +35,7 @@ function get_instance_config($instanceConfig)
 {
     $spanner = new SpannerClient();
     $config = $spanner->instanceConfiguration($instanceConfig);
-    printf("Available leader options for instance config %s: %s" . PHP_EOL,
+    printf('Available leader options for instance config %s: %s' . PHP_EOL,
         $instanceConfig, $config->info()['leaderOptions']
     );
 }

--- a/spanner/src/insert_data_with_dml.php
+++ b/spanner/src/insert_data_with_dml.php
@@ -48,7 +48,7 @@ function insert_data_with_dml($instanceId, $databaseId)
 
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
-            "INSERT Singers (SingerId, FirstName, LastName) "
+            'INSERT Singers (SingerId, FirstName, LastName) '
             . " VALUES (10, 'Virginia', 'Watson')");
         $t->commit();
         printf('Inserted %d row(s).' . PHP_EOL, $rowCount);

--- a/spanner/src/list_backup_operations.php
+++ b/spanner/src/list_backup_operations.php
@@ -43,8 +43,8 @@ function list_backup_operations($instanceId, $databaseId)
 
     // List the CreateBackup operations.
     $filter = "(metadata.database:$databaseId) AND " .
-              "(metadata.@type:type.googleapis.com/" .
-              "google.spanner.admin.database.v1.CreateBackupMetadata)";
+              '(metadata.@type:type.googleapis.com/' .
+              'google.spanner.admin.database.v1.CreateBackupMetadata)';
 
     $operations = $instance->backupOperations(['filter' => $filter]);
 

--- a/spanner/src/list_backups.php
+++ b/spanner/src/list_backups.php
@@ -65,7 +65,7 @@ function list_backups($instanceId)
     // List all backups that expire before a timestamp.
     $expireTime = $spanner->timestamp(new \DateTime('+30 days'));
     print("All backups that expire before $expireTime:" . PHP_EOL);
-    $filter ="expire_time < \"$expireTime\"";
+    $filter = "expire_time < \"$expireTime\"";
     foreach ($instance->backups(['filter' => $filter]) as $backup) {
         print('  ' . basename($backup->name()) . PHP_EOL);
     }

--- a/spanner/src/list_database_operations.php
+++ b/spanner/src/list_database_operations.php
@@ -41,8 +41,8 @@ function list_database_operations($instanceId)
     $instance = $spanner->instance($instanceId);
 
     // List the databases that are being optimized after a restore operation.
-    $filter = "(metadata.@type:type.googleapis.com/" .
-              "google.spanner.admin.database.v1.OptimizeRestoredDatabaseMetadata)";
+    $filter = '(metadata.@type:type.googleapis.com/' .
+              'google.spanner.admin.database.v1.OptimizeRestoredDatabaseMetadata)';
 
     $operations = $instance->databaseOperations(['filter' => $filter]);
 

--- a/spanner/src/list_databases.php
+++ b/spanner/src/list_databases.php
@@ -39,7 +39,7 @@ function list_databases($instanceId)
 {
     $spanner = new SpannerClient();
     $instance = $spanner->instance($instanceId);
-    printf("Databases for %s" . PHP_EOL, $instance->name());
+    printf('Databases for %s' . PHP_EOL, $instance->name());
     foreach ($instance->databases() as $database) {
         if (isset($database->info()['defaultLeader'])) {
             printf("\t%s (default leader = %s)" . PHP_EOL,

--- a/spanner/src/list_instance_configs.php
+++ b/spanner/src/list_instance_configs.php
@@ -37,7 +37,7 @@ function list_instance_configs()
 {
     $spanner = new SpannerClient();
     foreach ($spanner->instanceConfigurations() as $config) {
-        printf("Available leader options for instance config %s: %s" . PHP_EOL,
+        printf('Available leader options for instance config %s: %s' . PHP_EOL,
             $config->info()['displayName'], $config->info()['leaderOptions']
         );
     }

--- a/spanner/src/query_data_with_bool_parameter.php
+++ b/spanner/src/query_data_with_bool_parameter.php
@@ -58,7 +58,7 @@ function query_data_with_bool_parameter($instanceId, $databaseId)
     foreach ($results as $row) {
         printf('VenueId: %s, VenueName: %s, OutdoorVenue: %s' . PHP_EOL,
             $row['VenueId'], $row['VenueName'],
-            $row['OutdoorVenue'] ? "True" : "False");
+            $row['OutdoorVenue'] ? 'True' : 'False');
     }
 }
 // [END spanner_query_with_bool_parameter]

--- a/spanner/src/query_data_with_numeric_parameter.php
+++ b/spanner/src/query_data_with_numeric_parameter.php
@@ -43,7 +43,7 @@ function query_data_with_numeric_parameter($instanceId, $databaseId)
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);
 
-    $exampleNumeric = $spanner->numeric("100000");
+    $exampleNumeric = $spanner->numeric('100000');
 
     $results = $database->execute(
         'SELECT VenueId, Revenue FROM Venues ' .

--- a/spanner/src/restore_backup.php
+++ b/spanner/src/restore_backup.php
@@ -55,7 +55,7 @@ function restore_backup($instanceId, $databaseId, $backupId)
     $versionTime = $restoreInfo['backupInfo']['versionTime'];
 
     printf(
-        "Database %s restored from backup %s with version time %s" . PHP_EOL,
+        'Database %s restored from backup %s with version time %s' . PHP_EOL,
         $sourceDatabase, $sourceBackup, $versionTime);
 }
 // [END spanner_restore_backup]

--- a/spanner/src/restore_backup_with_encryption_key.php
+++ b/spanner/src/restore_backup_with_encryption_key.php
@@ -62,7 +62,7 @@ function restore_backup_with_encryption_key($instanceId, $databaseId, $backupId,
     $encryptionConfig = $database->info()['encryptionConfig'];
 
     printf(
-        "Database %s restored from backup %s using encryption key %s" . PHP_EOL,
+        'Database %s restored from backup %s using encryption key %s' . PHP_EOL,
         $sourceDatabase, $sourceBackup, $encryptionConfig['kmsKeyName']);
 }
 // [END spanner_restore_backup_with_encryption_key]

--- a/spanner/src/update_data_with_batch_dml.php
+++ b/spanner/src/update_data_with_batch_dml.php
@@ -53,14 +53,14 @@ function update_data_with_batch_dml($instanceId, $databaseId)
     $batchDmlResult = $database->runTransaction(function (Transaction $t) {
         $result = $t->executeUpdateBatch([
             [
-                'sql' => "INSERT INTO Albums "
-                . "(SingerId, AlbumId, AlbumTitle, MarketingBudget) "
+                'sql' => 'INSERT INTO Albums '
+                . '(SingerId, AlbumId, AlbumTitle, MarketingBudget) '
                 . "VALUES (1, 3, 'Test Album Title', 10000)"
             ],
             [
-                'sql' => "UPDATE Albums "
-                . "SET MarketingBudget = MarketingBudget * 2 "
-                . "WHERE SingerId = 1 and AlbumId = 3"
+                'sql' => 'UPDATE Albums '
+                . 'SET MarketingBudget = MarketingBudget * 2 '
+                . 'WHERE SingerId = 1 and AlbumId = 3'
             ],
         ]);
         $t->commit();

--- a/spanner/src/update_data_with_dml.php
+++ b/spanner/src/update_data_with_dml.php
@@ -52,9 +52,9 @@ function update_data_with_dml($instanceId, $databaseId)
 
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
-            "UPDATE Albums "
-            . "SET MarketingBudget = MarketingBudget * 2 "
-            . "WHERE SingerId = 1 and AlbumId = 1");
+            'UPDATE Albums '
+            . 'SET MarketingBudget = MarketingBudget * 2 '
+            . 'WHERE SingerId = 1 and AlbumId = 1');
         $t->commit();
         printf('Updated %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/update_data_with_dml_structs.php
+++ b/spanner/src/update_data_with_dml_structs.php
@@ -59,8 +59,8 @@ function update_data_with_dml_structs($instanceId, $databaseId)
 
         $rowCount = $t->executeUpdate(
             "UPDATE Singers SET LastName = 'Grant' "
-             . "WHERE STRUCT<FirstName STRING, LastName STRING>(FirstName, LastName) "
-             . "= @name",
+             . 'WHERE STRUCT<FirstName STRING, LastName STRING>(FirstName, LastName) '
+             . '= @name',
             [
                 'parameters' => [
                     'name' => $nameValue

--- a/spanner/src/update_data_with_dml_timestamp.php
+++ b/spanner/src/update_data_with_dml_timestamp.php
@@ -48,8 +48,8 @@ function update_data_with_dml_timestamp($instanceId, $databaseId)
 
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
-            "UPDATE Albums "
-            . "SET LastUpdateTime = PENDING_COMMIT_TIMESTAMP() WHERE SingerId = 1");
+            'UPDATE Albums '
+            . 'SET LastUpdateTime = PENDING_COMMIT_TIMESTAMP() WHERE SingerId = 1');
         $t->commit();
         printf('Updated %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/update_data_with_numeric_column.php
+++ b/spanner/src/update_data_with_numeric_column.php
@@ -48,9 +48,9 @@ function update_data_with_numeric_column($instanceId, $databaseId)
 
     $database->transaction(['singleUse' => true])
         ->updateBatch('Venues', [
-            ['VenueId' => 4, 'Revenue' => $spanner->numeric("35000")],
-            ['VenueId' => 19, 'Revenue' => $spanner->numeric("104500")],
-            ['VenueId' => 42, 'Revenue' => $spanner->numeric("99999999999999999999999999999.99")],
+            ['VenueId' => 4, 'Revenue' => $spanner->numeric('35000')],
+            ['VenueId' => 19, 'Revenue' => $spanner->numeric('104500')],
+            ['VenueId' => 42, 'Revenue' => $spanner->numeric('99999999999999999999999999999.99')],
         ])
         ->commit();
 

--- a/spanner/src/update_data_with_partitioned_dml.php
+++ b/spanner/src/update_data_with_partitioned_dml.php
@@ -50,7 +50,7 @@ function update_data_with_partitioned_dml($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $rowCount = $database->executePartitionedUpdate(
-        "UPDATE Albums SET MarketingBudget = 100000 WHERE SingerId > 1"
+        'UPDATE Albums SET MarketingBudget = 100000 WHERE SingerId > 1'
     );
 
     printf('Updated %d row(s).' . PHP_EOL, $rowCount);

--- a/spanner/src/update_database_with_default_leader.php
+++ b/spanner/src/update_database_with_default_leader.php
@@ -46,7 +46,7 @@ function update_database_with_default_leader($instanceId, $databaseId, $defaultL
     $database->updateDdl(
         "ALTER DATABASE `$databaseId` SET OPTIONS (default_leader = '$defaultLeader')");
 
-    printf("Updated the default leader to %d" . PHP_EOL, $database->info()['defaultLeader']);
+    printf('Updated the default leader to %d' . PHP_EOL, $database->info()['defaultLeader']);
 }
 // [END spanner_update_database_with_default_leader]
 

--- a/spanner/src/write_data_with_dml.php
+++ b/spanner/src/write_data_with_dml.php
@@ -48,7 +48,7 @@ function write_data_with_dml($instanceId, $databaseId)
 
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
-            "INSERT Singers (SingerId, FirstName, LastName) VALUES "
+            'INSERT Singers (SingerId, FirstName, LastName) VALUES '
             . "(12, 'Melissa', 'Garcia'), "
             . "(13, 'Russell', 'Morales'), "
             . "(14, 'Jacqueline', 'Long'), "

--- a/spanner/src/write_data_with_dml_transaction.php
+++ b/spanner/src/write_data_with_dml_transaction.php
@@ -57,7 +57,7 @@ function write_data_with_dml_transaction($instanceId, $databaseId)
         $transferAmount = 200000;
 
         $results = $t->execute(
-            "SELECT MarketingBudget from Albums WHERE SingerId = 2 and AlbumId = 2"
+            'SELECT MarketingBudget from Albums WHERE SingerId = 2 and AlbumId = 2'
         );
         $resultsRow = $results->rows()->current();
         $album2budget = $resultsRow['MarketingBudget'];
@@ -67,7 +67,7 @@ function write_data_with_dml_transaction($instanceId, $databaseId)
         // client library.
         if ($album2budget >= $transferAmount) {
             $results = $t->execute(
-                "SELECT MarketingBudget from Albums WHERE SingerId = 1 and AlbumId = 1"
+                'SELECT MarketingBudget from Albums WHERE SingerId = 1 and AlbumId = 1'
             );
             $resultsRow = $results->rows()->current();
             $album1budget = $resultsRow['MarketingBudget'];
@@ -77,9 +77,9 @@ function write_data_with_dml_transaction($instanceId, $databaseId)
 
             // Update the albums
             $t->executeUpdate(
-                "UPDATE Albums "
-                . "SET MarketingBudget = @AlbumBudget "
-                . "WHERE SingerId = 1 and AlbumId = 1",
+                'UPDATE Albums '
+                . 'SET MarketingBudget = @AlbumBudget '
+                . 'WHERE SingerId = 1 and AlbumId = 1',
                 [
                     'parameters' => [
                         'AlbumBudget' => $album1budget
@@ -87,9 +87,9 @@ function write_data_with_dml_transaction($instanceId, $databaseId)
                 ]
             );
             $t->executeUpdate(
-                "UPDATE Albums "
-                . "SET MarketingBudget = @AlbumBudget "
-                . "WHERE SingerId = 2 and AlbumId = 2",
+                'UPDATE Albums '
+                . 'SET MarketingBudget = @AlbumBudget '
+                . 'WHERE SingerId = 2 and AlbumId = 2',
                 [
                     'parameters' => [
                         'AlbumBudget' => $album2budget

--- a/spanner/src/write_read_with_dml.php
+++ b/spanner/src/write_read_with_dml.php
@@ -48,12 +48,12 @@ function write_read_with_dml($instanceId, $databaseId)
 
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
-            "INSERT Singers (SingerId, FirstName, LastName) "
+            'INSERT Singers (SingerId, FirstName, LastName) '
             . " VALUES (11, 'Timothy', 'Campbell')");
 
         printf('Inserted %d row(s).' . PHP_EOL, $rowCount);
 
-        $results = $t->execute("SELECT FirstName, LastName FROM Singers WHERE SingerId = 11");
+        $results = $t->execute('SELECT FirstName, LastName FROM Singers WHERE SingerId = 11');
 
         foreach ($results as $row) {
             printf('%s %s' . PHP_EOL, $row['FirstName'], $row['LastName']);

--- a/spanner/test/spannerBackupTest.php
+++ b/spanner/test/spannerBackupTest.php
@@ -87,7 +87,7 @@ class spannerBackupTest extends TestCase
         self::$instance = $spanner->instance(self::$instanceId);
 
         self::$kmsKeyName =
-            "projects/" . self::$projectId . "/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek";
+            'projects/' . self::$projectId . '/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek';
     }
 
     public function testCreateDatabaseWithVersionRetentionPeriod()
@@ -129,7 +129,7 @@ class spannerBackupTest extends TestCase
     public function testCreateBackup()
     {
         $database = self::$instance->database(self::$databaseId);
-        $results = $database->execute("SELECT TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), MICROSECOND) as Timestamp");
+        $results = $database->execute('SELECT TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), MICROSECOND) as Timestamp');
         $row = $results->rows()->current();
         $versionTime = $row['Timestamp'];
 
@@ -207,7 +207,6 @@ class spannerBackupTest extends TestCase
         $this->assertStringContainsString(self::$backupId, $output);
         $this->assertStringContainsString(self::$databaseId, $output);
     }
-
 
     /**
      * @depends testRestoreBackupWithEncryptionKey

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -101,14 +101,14 @@ class spannerTest extends TestCase
         self::$backupId = 'backup-' . self::$databaseId;
         self::$instance = $spanner->instance(self::$instanceId);
         self::$kmsKeyName =
-            "projects/" . self::$projectId . "/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek";
+            'projects/' . self::$projectId . '/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek';
         self::$lowCostInstance = $spanner->instance(self::$lowCostInstanceId);
 
         self::$multiInstanceId = 'test-' . time() . rand() . 'm';
         self::$multiDatabaseId = 'test-' . time() . rand() . 'm';
         self::$instanceConfig = 'nam3';
         self::$defaultLeader = 'us-central1';
-        self::$updatedDefaultLeader = "us-east4";
+        self::$updatedDefaultLeader = 'us-east4';
         self::$multiInstance = $spanner->instance(self::$multiInstanceId);
 
         $config = $spanner->instanceConfiguration(self::$instanceConfig);
@@ -226,7 +226,7 @@ class spannerTest extends TestCase
         );
 
         foreach ($results as $row) {
-            $this->fail("Not all data was deleted.");
+            $this->fail('Not all data was deleted.');
         }
 
         $output = $this->runFunctionSnippet('insert_data');
@@ -592,7 +592,6 @@ class spannerTest extends TestCase
         $output = $this->runFunctionSnippet('get_commit_stats');
         $this->assertStringContainsString('Updated data with 10 mutations.', $output);
     }
-
 
     /**
      * @depends testCreateDatabase

--- a/speech/quickstart.php
+++ b/speech/quickstart.php
@@ -26,7 +26,7 @@ use Google\Cloud\Speech\V1\RecognitionConfig;
 use Google\Cloud\Speech\V1\RecognitionConfig\AudioEncoding;
 
 # The name of the audio file to transcribe
-$gcsURI = "gs://cloud-samples-data/speech/brooklyn_bridge.raw";
+$gcsURI = 'gs://cloud-samples-data/speech/brooklyn_bridge.raw';
 
 # set string as audio content
 $audio = (new RecognitionAudio())

--- a/speech/src/multi_region_gcs.php
+++ b/speech/src/multi_region_gcs.php
@@ -26,7 +26,7 @@ use Google\Cloud\Speech\V1\RecognitionConfig;
 use Google\Cloud\Speech\V1\RecognitionConfig\AudioEncoding;
 
 # The name of the audio file to transcribe
-$gcsURI = "gs://cloud-samples-data/speech/brooklyn_bridge.raw";
+$gcsURI = 'gs://cloud-samples-data/speech/brooklyn_bridge.raw';
 
 # set string as audio content
 $audio = (new RecognitionAudio())

--- a/storage/src/compose_file.php
+++ b/storage/src/compose_file.php
@@ -56,7 +56,7 @@ function compose_file($bucketName, $firstObjectName, $secondObjectName, $targetO
 
     if ($targetObject->exists()) {
         printf(
-            "New composite object %s was created by combining %s and %s",
+            'New composite object %s was created by combining %s and %s',
             $targetObject->name(),
             $firstObjectName,
             $secondObjectName

--- a/storage/src/generate_signed_post_policy_v4.php
+++ b/storage/src/generate_signed_post_policy_v4.php
@@ -57,7 +57,7 @@ function generate_signed_post_policy_v4($bucketName, $objectName)
     }
     $output .= "  <input type='file' name='file'/><br />" . PHP_EOL;
     $output .= "  <input type='submit' value='Upload File' name='submit'/><br />" . PHP_EOL;
-    $output .= "</form>" . PHP_EOL;
+    $output .= '</form>' . PHP_EOL;
 
     echo $output;
 }

--- a/storage/src/generate_v4_post_policy.php
+++ b/storage/src/generate_v4_post_policy.php
@@ -57,7 +57,7 @@ function generate_v4_post_policy($bucketName, $objectName)
     }
     $output .= "  <input type='file' name='file'/><br />" . PHP_EOL;
     $output .= "  <input type='submit' value='Upload File' name='submit'/><br />" . PHP_EOL;
-    $output .= "</form>" . PHP_EOL;
+    $output .= '</form>' . PHP_EOL;
 
     echo $output;
 }

--- a/storage/src/get_bucket_metadata.php
+++ b/storage/src/get_bucket_metadata.php
@@ -39,7 +39,7 @@ function get_bucket_metadata($bucketName)
     $bucket = $storage->bucket($bucketName);
     $info = $bucket->info();
 
-    printf("Bucket Metadata: %s" . PHP_EOL, print_r($info));
+    printf('Bucket Metadata: %s' . PHP_EOL, print_r($info));
 }
 # [END storage_get_bucket_metadata]
 

--- a/storage/test/ObjectSignedUrlTest.php
+++ b/storage/test/ObjectSignedUrlTest.php
@@ -51,7 +51,7 @@ class ObjectSignedUrlTest extends TestCase
 
         $object->delete();
 
-        $this->assertStringContainsString("The signed url for " . $object->name() . " is", $output);
+        $this->assertStringContainsString('The signed url for ' . $object->name() . ' is', $output);
     }
 
     public function testGetV4SignedUrl()

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -167,7 +167,7 @@ EOF;
 
         $this->assertEquals(
             sprintf(
-                "New composite object %s was created by combining %s and %s",
+                'New composite object %s was created by combining %s and %s',
                 $targetName,
                 $object1Name,
                 $object2Name

--- a/storage/test/PublicAccessPreventionTest.php
+++ b/storage/test/PublicAccessPreventionTest.php
@@ -52,7 +52,7 @@ class PublicAccessPreventionTest extends TestCase
 
         $this->assertStringContainsString(
             sprintf(
-                "Public Access Prevention has been set to enforced for %s.",
+                'Public Access Prevention has been set to enforced for %s.',
                 self::$bucket->name()
             ),
             $output
@@ -73,7 +73,7 @@ class PublicAccessPreventionTest extends TestCase
 
         $this->assertStringContainsString(
             sprintf(
-                "Public Access Prevention has been set to unspecified for %s.",
+                'Public Access Prevention has been set to unspecified for %s.',
                 self::$bucket->name()
             ),
             $output
@@ -94,7 +94,7 @@ class PublicAccessPreventionTest extends TestCase
 
         $this->assertStringContainsString(
             sprintf(
-                "The bucket public access prevention is unspecified for %s.",
+                'The bucket public access prevention is unspecified for %s.',
                 self::$bucket->name()
             ),
             $output

--- a/storage/test/RequesterPaysTest.php
+++ b/storage/test/RequesterPaysTest.php
@@ -41,7 +41,7 @@ class RequesterPaysTest extends TestCase
             self::$bucketName,
         ]);
 
-        $this->assertStringContainsString("Requester pays has been enabled", $output);
+        $this->assertStringContainsString('Requester pays has been enabled', $output);
     }
 
     /** @depends testEnableRequesterPays */
@@ -51,7 +51,7 @@ class RequesterPaysTest extends TestCase
             self::$bucketName,
         ]);
 
-        $this->assertStringContainsString("Requester pays has been disabled", $output);
+        $this->assertStringContainsString('Requester pays has been disabled', $output);
     }
 
     /** depends testDisableRequesterPays */
@@ -61,7 +61,7 @@ class RequesterPaysTest extends TestCase
             self::$bucketName,
         ]);
 
-        $this->assertStringContainsString("Requester Pays is disabled", $output);
+        $this->assertStringContainsString('Requester Pays is disabled', $output);
     }
 
     public function testDownloadFileRequesterPays()
@@ -81,6 +81,6 @@ class RequesterPaysTest extends TestCase
             $destination,
         ]);
 
-        $this->assertStringContainsString("using requester-pays requests", $output);
+        $this->assertStringContainsString('using requester-pays requests', $output);
     }
 }

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 namespace Google\Cloud\Samples\Storage;
 
 use Google\Auth\CredentialsLoader;
@@ -60,7 +59,7 @@ class storageTest extends TestCase
             self::$tempBucket->name(),
         ]);
 
-        $this->assertRegExp("/: OWNER/", $output);
+        $this->assertRegExp('/: OWNER/', $output);
     }
 
     /**
@@ -114,7 +113,7 @@ class storageTest extends TestCase
     {
         $output = $this->runFunctionSnippet('list_buckets');
 
-        $this->assertStringContainsString("Bucket:", $output);
+        $this->assertStringContainsString('Bucket:', $output);
     }
 
     public function testCreateGetDeleteBuckets()
@@ -131,7 +130,7 @@ class storageTest extends TestCase
 
         $output = $this->runFunctionSnippet('get_bucket_metadata', [$bucketName]);
 
-        $this->assertStringContainsString("Bucket Metadata:", $output);
+        $this->assertStringContainsString('Bucket Metadata:', $output);
 
         $output = $this->runFunctionSnippet('delete_bucket', [$bucketName]);
 
@@ -146,7 +145,7 @@ class storageTest extends TestCase
             self::$tempBucket->name(),
         ]);
 
-        $this->assertStringContainsString(": OWNER", $output);
+        $this->assertStringContainsString(': OWNER', $output);
     }
 
     public function testManageBucketDefaultAcl()
@@ -297,7 +296,7 @@ class storageTest extends TestCase
     {
         $output = $this->runFunctionSnippet('generate_encryption_key');
 
-        $this->assertStringContainsString("Your encryption key:", $output);
+        $this->assertStringContainsString('Your encryption key:', $output);
     }
 
     public function testEncryptedFile()

--- a/texttospeech/quickstart.php
+++ b/texttospeech/quickstart.php
@@ -41,7 +41,7 @@ $voice = (new VoiceSelectionParams())
     ->setSsmlGender(SsmlVoiceGender::FEMALE);
 
 // Effects profile
-$effectsProfileId = "telephony-class-application";
+$effectsProfileId = 'telephony-class-application';
 
 // select the type of audio file you want returned
 $audioConfig = (new AudioConfig())

--- a/translate/src/translate_with_model.php
+++ b/translate/src/translate_with_model.php
@@ -41,7 +41,7 @@ $model = 'nmt';  // "base" for standard edition, "nmt" for premium
 $translate = new TranslateClient();
 $result = $translate->translate($text, [
     'target' => $targetLanguage,
-    'model'  => $model,
+    'model' => $model,
 ]);
 print("Source language: $result[source]\n");
 print("Translation: $result[text]\n");

--- a/translate/test/translateTest.php
+++ b/translate/test/translateTest.php
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 namespace Google\Cloud\Samples\Translate;
 
 use PHPUnit\Framework\TestCase;

--- a/video/quickstart.php
+++ b/video/quickstart.php
@@ -48,8 +48,8 @@ if ($operation->operationSucceeded()) {
             $start = $segment->getSegment()->getStartTimeOffset();
             $end = $segment->getSegment()->getEndTimeOffset();
             printf('  Segment: %ss to %ss' . PHP_EOL,
-                $start->getSeconds() + $start->getNanos()/1000000000.0,
-                $end->getSeconds() + $end->getNanos()/1000000000.0
+                $start->getSeconds() + $start->getNanos() / 1000000000.0,
+                $end->getSeconds() + $end->getNanos() / 1000000000.0
             );
             printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
         }

--- a/video/src/analyze_explicit_content.php
+++ b/video/src/analyze_explicit_content.php
@@ -57,7 +57,7 @@ if ($operation->operationSucceeded()) {
     $explicitAnnotation = $results->getExplicitAnnotation();
     foreach ($explicitAnnotation->getFrames() as $frame) {
         $time = $frame->getTimeOffset();
-        printf('At %ss:' . PHP_EOL, $time->getSeconds() + $time->getNanos()/1000000000.0);
+        printf('At %ss:' . PHP_EOL, $time->getSeconds() + $time->getNanos() / 1000000000.0);
         printf('  pornography: ' . Likelihood::name($frame->getPornographyLikelihood()) . PHP_EOL);
     }
 } else {

--- a/video/src/analyze_labels_file.php
+++ b/video/src/analyze_labels_file.php
@@ -62,8 +62,8 @@ if ($operation->operationSucceeded()) {
             $start = $segment->getSegment()->getStartTimeOffset();
             $end = $segment->getSegment()->getEndTimeOffset();
             printf('  Segment: %ss to %ss' . PHP_EOL,
-                $start->getSeconds() + $start->getNanos()/1000000000.0,
-                $end->getSeconds() + $end->getNanos()/1000000000.0);
+                $start->getSeconds() + $start->getNanos() / 1000000000.0,
+                $end->getSeconds() + $end->getNanos() / 1000000000.0);
             printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
         }
     }
@@ -79,8 +79,8 @@ if ($operation->operationSucceeded()) {
             $start = $shot->getSegment()->getStartTimeOffset();
             $end = $shot->getSegment()->getEndTimeOffset();
             printf('  Shot: %ss to %ss' . PHP_EOL,
-                $start->getSeconds() + $start->getNanos()/1000000000.0,
-                $end->getSeconds() + $end->getNanos()/1000000000.0);
+                $start->getSeconds() + $start->getNanos() / 1000000000.0,
+                $end->getSeconds() + $end->getNanos() / 1000000000.0);
             printf('  Confidence: %f' . PHP_EOL, $shot->getConfidence());
         }
     }

--- a/video/src/analyze_labels_gcs.php
+++ b/video/src/analyze_labels_gcs.php
@@ -59,8 +59,8 @@ if ($operation->operationSucceeded()) {
             $start = $segment->getSegment()->getStartTimeOffset();
             $end = $segment->getSegment()->getEndTimeOffset();
             printf('  Segment: %ss to %ss' . PHP_EOL,
-                $start->getSeconds() + $start->getNanos()/1000000000.0,
-                $end->getSeconds() + $end->getNanos()/1000000000.0);
+                $start->getSeconds() + $start->getNanos() / 1000000000.0,
+                $end->getSeconds() + $end->getNanos() / 1000000000.0);
             printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
         }
     }
@@ -76,8 +76,8 @@ if ($operation->operationSucceeded()) {
             $start = $shot->getSegment()->getStartTimeOffset();
             $end = $shot->getSegment()->getEndTimeOffset();
             printf('  Shot: %ss to %ss' . PHP_EOL,
-                $start->getSeconds() + $start->getNanos()/1000000000.0,
-                $end->getSeconds() + $end->getNanos()/1000000000.0);
+                $start->getSeconds() + $start->getNanos() / 1000000000.0,
+                $end->getSeconds() + $end->getNanos() / 1000000000.0);
             printf('  Confidence: %f' . PHP_EOL, $shot->getConfidence());
         }
     }

--- a/video/src/analyze_object_tracking.php
+++ b/video/src/analyze_object_tracking.php
@@ -57,15 +57,15 @@ if ($operation->operationSucceeded()) {
     $start = $objectEntity->getSegment()->getStartTimeOffset();
     $end = $objectEntity->getSegment()->getEndTimeOffset();
     printf('  Segment: %ss to %ss' . PHP_EOL,
-        $start->getSeconds() + $start->getNanos()/1000000000.0,
-        $end->getSeconds() + $end->getNanos()/1000000000.0);
+        $start->getSeconds() + $start->getNanos() / 1000000000.0,
+        $end->getSeconds() + $end->getNanos() / 1000000000.0);
     printf('  Confidence: %f' . PHP_EOL, $objectEntity->getConfidence());
 
     foreach ($objectEntity->getFrames() as $objectEntityFrame) {
         $offset = $objectEntityFrame->getTimeOffset();
         $boundingBox = $objectEntityFrame->getNormalizedBoundingBox();
         printf('  Time offset: %ss' . PHP_EOL,
-            $offset->getSeconds() + $offset->getNanos()/1000000000.0);
+            $offset->getSeconds() + $offset->getNanos() / 1000000000.0);
         printf('  Bounding box position:' . PHP_EOL);
         printf('   Left: %s', $boundingBox->getLeft());
         printf('   Top: %s', $boundingBox->getTop());

--- a/video/src/analyze_object_tracking_file.php
+++ b/video/src/analyze_object_tracking_file.php
@@ -60,15 +60,15 @@ if ($operation->operationSucceeded()) {
     $start = $objectEntity->getSegment()->getStartTimeOffset();
     $end = $objectEntity->getSegment()->getEndTimeOffset();
     printf('  Segment: %ss to %ss' . PHP_EOL,
-        $start->getSeconds() + $start->getNanos()/1000000000.0,
-        $end->getSeconds() + $end->getNanos()/1000000000.0);
+        $start->getSeconds() + $start->getNanos() / 1000000000.0,
+        $end->getSeconds() + $end->getNanos() / 1000000000.0);
     printf('  Confidence: %f' . PHP_EOL, $objectEntity->getConfidence());
 
     foreach ($objectEntity->getFrames() as $objectEntityFrame) {
         $offset = $objectEntityFrame->getTimeOffset();
         $boundingBox = $objectEntityFrame->getNormalizedBoundingBox();
         printf('  Time offset: %ss' . PHP_EOL,
-            $offset->getSeconds() + $offset->getNanos()/1000000000.0);
+            $offset->getSeconds() + $offset->getNanos() / 1000000000.0);
         printf('  Bounding box position:' . PHP_EOL);
         printf('   Left: %s', $boundingBox->getLeft());
         printf('   Top: %s', $boundingBox->getTop());

--- a/video/src/analyze_shots.php
+++ b/video/src/analyze_shots.php
@@ -52,8 +52,8 @@ if ($operation->operationSucceeded()) {
         $start = $shot->getStartTimeOffset();
         $end = $shot->getEndTimeOffset();
         printf('Shot: %ss to %ss' . PHP_EOL,
-            $start->getSeconds() + $start->getNanos()/1000000000.0,
-            $end->getSeconds() + $end->getNanos()/1000000000.0);
+            $start->getSeconds() + $start->getNanos() / 1000000000.0,
+            $end->getSeconds() + $end->getNanos() / 1000000000.0);
     }
 } else {
     print_r($operation->getError());

--- a/video/src/analyze_text_detection.php
+++ b/video/src/analyze_text_detection.php
@@ -56,8 +56,8 @@ if ($operation->operationSucceeded()) {
             $start = $segment->getSegment()->getStartTimeOffset();
             $end = $segment->getSegment()->getEndTimeOffset();
             printf('  Segment: %ss to %ss' . PHP_EOL,
-                $start->getSeconds() + $start->getNanos()/1000000000.0,
-                $end->getSeconds() + $end->getNanos()/1000000000.0);
+                $start->getSeconds() + $start->getNanos() / 1000000000.0,
+                $end->getSeconds() + $end->getNanos() / 1000000000.0);
             printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
         }
     }

--- a/video/src/analyze_text_detection_file.php
+++ b/video/src/analyze_text_detection_file.php
@@ -59,8 +59,8 @@ if ($operation->operationSucceeded()) {
             $start = $segment->getSegment()->getStartTimeOffset();
             $end = $segment->getSegment()->getEndTimeOffset();
             printf('  Segment: %ss to %ss' . PHP_EOL,
-                $start->getSeconds() + $start->getNanos()/1000000000.0,
-                $end->getSeconds() + $end->getNanos()/1000000000.0);
+                $start->getSeconds() + $start->getNanos() / 1000000000.0,
+                $end->getSeconds() + $end->getNanos() / 1000000000.0);
             printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
         }
     }

--- a/vision/quickstart.php
+++ b/vision/quickstart.php
@@ -36,7 +36,7 @@ $response = $imageAnnotator->labelDetection($image);
 $labels = $response->getLabelAnnotations();
 
 if ($labels) {
-    echo("Labels:" . PHP_EOL);
+    echo('Labels:' . PHP_EOL);
     foreach ($labels as $label) {
         echo($label->getDescription() . PHP_EOL);
     }

--- a/vision/src/detect_face.php
+++ b/vision/src/detect_face.php
@@ -40,16 +40,16 @@ function detect_face($path, $outFile = null)
     $likelihoodName = ['UNKNOWN', 'VERY_UNLIKELY', 'UNLIKELY',
     'POSSIBLE', 'LIKELY', 'VERY_LIKELY'];
 
-    printf("%d faces found:" . PHP_EOL, count($faces));
+    printf('%d faces found:' . PHP_EOL, count($faces));
     foreach ($faces as $face) {
         $anger = $face->getAngerLikelihood();
-        printf("Anger: %s" . PHP_EOL, $likelihoodName[$anger]);
+        printf('Anger: %s' . PHP_EOL, $likelihoodName[$anger]);
 
         $joy = $face->getJoyLikelihood();
-        printf("Joy: %s" . PHP_EOL, $likelihoodName[$joy]);
+        printf('Joy: %s' . PHP_EOL, $likelihoodName[$joy]);
 
         $surprise = $face->getSurpriseLikelihood();
-        printf("Surprise: %s" . PHP_EOL, $likelihoodName[$surprise]);
+        printf('Surprise: %s' . PHP_EOL, $likelihoodName[$surprise]);
 
         # get bounds
         $vertices = $face->getBoundingPoly()->getVertices();

--- a/vision/src/detect_face_gcs.php
+++ b/vision/src/detect_face_gcs.php
@@ -34,16 +34,16 @@ function detect_face_gcs($path)
     $likelihoodName = ['UNKNOWN', 'VERY_UNLIKELY', 'UNLIKELY',
     'POSSIBLE', 'LIKELY', 'VERY_LIKELY'];
 
-    printf("%d faces found:" . PHP_EOL, count($faces));
+    printf('%d faces found:' . PHP_EOL, count($faces));
     foreach ($faces as $face) {
         $anger = $face->getAngerLikelihood();
-        printf("Anger: %s" . PHP_EOL, $likelihoodName[$anger]);
+        printf('Anger: %s' . PHP_EOL, $likelihoodName[$anger]);
 
         $joy = $face->getJoyLikelihood();
-        printf("Joy: %s" . PHP_EOL, $likelihoodName[$joy]);
+        printf('Joy: %s' . PHP_EOL, $likelihoodName[$joy]);
 
         $surprise = $face->getSurpriseLikelihood();
-        printf("Surprise: %s" . PHP_EOL, $likelihoodName[$surprise]);
+        printf('Surprise: %s' . PHP_EOL, $likelihoodName[$surprise]);
 
         # get bounds
         $vertices = $face->getBoundingPoly()->getVertices();

--- a/vision/src/detect_image_property.php
+++ b/vision/src/detect_image_property.php
@@ -31,13 +31,13 @@ function detect_image_property($path)
     $response = $imageAnnotator->imagePropertiesDetection($image);
     $props = $response->getImagePropertiesAnnotation();
 
-    print("Properties:" . PHP_EOL);
+    print('Properties:' . PHP_EOL);
     foreach ($props->getDominantColors()->getColors() as $colorInfo) {
-        printf("Fraction: %s" . PHP_EOL, $colorInfo->getPixelFraction());
+        printf('Fraction: %s' . PHP_EOL, $colorInfo->getPixelFraction());
         $color = $colorInfo->getColor();
-        printf("Red: %s" . PHP_EOL, $color->getRed());
-        printf("Green: %s" . PHP_EOL, $color->getGreen());
-        printf("Blue: %s" . PHP_EOL, $color->getBlue());
+        printf('Red: %s' . PHP_EOL, $color->getRed());
+        printf('Green: %s' . PHP_EOL, $color->getGreen());
+        printf('Blue: %s' . PHP_EOL, $color->getBlue());
         print(PHP_EOL);
     }
 

--- a/vision/src/detect_image_property_gcs.php
+++ b/vision/src/detect_image_property_gcs.php
@@ -30,15 +30,14 @@ function detect_image_property_gcs($path)
     $response = $imageAnnotator->imagePropertiesDetection($path);
     $props = $response->getImagePropertiesAnnotation();
 
-
     if ($props) {
-        print("Properties:" . PHP_EOL);
+        print('Properties:' . PHP_EOL);
         foreach ($props->getDominantColors()->getColors() as $colorInfo) {
-            printf("Fraction: %s" . PHP_EOL, $colorInfo->getPixelFraction());
+            printf('Fraction: %s' . PHP_EOL, $colorInfo->getPixelFraction());
             $color = $colorInfo->getColor();
-            printf("Red: %s" . PHP_EOL, $color->getRed());
-            printf("Green: %s" . PHP_EOL, $color->getGreen());
-            printf("Blue: %s" . PHP_EOL, $color->getBlue());
+            printf('Red: %s' . PHP_EOL, $color->getRed());
+            printf('Green: %s' . PHP_EOL, $color->getGreen());
+            printf('Blue: %s' . PHP_EOL, $color->getBlue());
             print(PHP_EOL);
         }
     } else {

--- a/vision/src/detect_label.php
+++ b/vision/src/detect_label.php
@@ -32,7 +32,7 @@ function detect_label($path)
     $labels = $response->getLabelAnnotations();
 
     if ($labels) {
-        print("Labels:" . PHP_EOL);
+        print('Labels:' . PHP_EOL);
         foreach ($labels as $label) {
             print($label->getDescription() . PHP_EOL);
         }

--- a/vision/src/detect_label_gcs.php
+++ b/vision/src/detect_label_gcs.php
@@ -31,7 +31,7 @@ function detect_label_gcs($path)
     $labels = $response->getLabelAnnotations();
 
     if ($labels) {
-        print("Labels:" . PHP_EOL);
+        print('Labels:' . PHP_EOL);
         foreach ($labels as $label) {
             print($label->getDescription() . PHP_EOL);
         }

--- a/vision/src/detect_safe_search.php
+++ b/vision/src/detect_safe_search.php
@@ -36,16 +36,16 @@ function detect_safe_search($path)
     $spoof = $safe->getSpoof();
     $violence = $safe->getViolence();
     $racy = $safe->getRacy();
-    
+
     # names of likelihood from google.cloud.vision.enums
     $likelihoodName = ['UNKNOWN', 'VERY_UNLIKELY', 'UNLIKELY',
     'POSSIBLE', 'LIKELY', 'VERY_LIKELY'];
 
-    printf("Adult: %s" . PHP_EOL, $likelihoodName[$adult]);
-    printf("Medical: %s" . PHP_EOL, $likelihoodName[$medical]);
-    printf("Spoof: %s" . PHP_EOL, $likelihoodName[$spoof]);
-    printf("Violence: %s" . PHP_EOL, $likelihoodName[$violence]);
-    printf("Racy: %s" . PHP_EOL, $likelihoodName[$racy]);
+    printf('Adult: %s' . PHP_EOL, $likelihoodName[$adult]);
+    printf('Medical: %s' . PHP_EOL, $likelihoodName[$medical]);
+    printf('Spoof: %s' . PHP_EOL, $likelihoodName[$spoof]);
+    printf('Violence: %s' . PHP_EOL, $likelihoodName[$violence]);
+    printf('Racy: %s' . PHP_EOL, $likelihoodName[$racy]);
 
     $imageAnnotator->close();
 }

--- a/vision/src/detect_safe_search_gcs.php
+++ b/vision/src/detect_safe_search_gcs.php
@@ -41,11 +41,11 @@ function detect_safe_search_gcs($path)
         $likelihoodName = ['UNKNOWN', 'VERY_UNLIKELY', 'UNLIKELY',
         'POSSIBLE', 'LIKELY', 'VERY_LIKELY'];
 
-        printf("Adult: %s" . PHP_EOL, $likelihoodName[$adult]);
-        printf("Medical: %s" . PHP_EOL, $likelihoodName[$medical]);
-        printf("Spoof: %s" . PHP_EOL, $likelihoodName[$spoof]);
-        printf("Violence: %s" . PHP_EOL, $likelihoodName[$violence]);
-        printf("Racy: %s" . PHP_EOL, $likelihoodName[$racy]);
+        printf('Adult: %s' . PHP_EOL, $likelihoodName[$adult]);
+        printf('Medical: %s' . PHP_EOL, $likelihoodName[$medical]);
+        printf('Spoof: %s' . PHP_EOL, $likelihoodName[$spoof]);
+        printf('Violence: %s' . PHP_EOL, $likelihoodName[$violence]);
+        printf('Racy: %s' . PHP_EOL, $likelihoodName[$racy]);
     } else {
         print('No Results.' . PHP_EOL);
     }

--- a/vision/test/visionTest.php
+++ b/vision/test/visionTest.php
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 namespace Google\Cloud\Samples\Vision;
 
 use Google\Cloud\TestUtils\TestTrait;


### PR DESCRIPTION
WIP for #1465 

Following are the test cases considered:
## single_quote

### Input:
```
print("Test double quote string" . PHP_EOL); // -> Only this is changed
print("Test string with variable $a" . PHP_EOL);
print("Test string with 'single quotes'" . PHP_EOL);
print("Test string with \n\t\\\"escape characters" . PHP_EOL);
```
## cast_spaces: Adds a single space b/w cast and operand.

### Input:
```
$a = (int)'89';
$b = (int)   '90';
```
### Output:
```
$a = (int) '89';
$b = (int) '90';
```
## binary_operator_spaces

### Input:
```
// simple assignment
$a=123;
// aray
$b  =['a'=>'b'];
$c=  ['a'  =>  'b'];
// arithmetic
$d=1+9;
$e = 8*10;
// logical
$f = true||false;
$g = 0 &&false;
// bitwise
$h = 120^20;
// comparison
$i = $a<50;
// unary is not touched
$j = !0;
```
### Output:
```
$a = 123;
$b = ['a' => 'b'];
$c = ['a' => 'b'];
$d = 1 + 9;
$e = 8 * 10;
$f = true || false;
$g = 0 && false;
$h = 120 ^ 20;
$i = $a < 50;
$j = !0;
```
## no_extra_blank_lines

### Input:
```
$a = 3;


$b = 5;



$c = 8;

// not a blank line
$d = 10;
```
### Output:
```
$a = 3;

$b = 5;

$c = 8;

// not a blank line
$d = 10;
```

## phpdoc_trim_consecutive_blank_line_separation

### Input:
```
/**
 * Description 
 * @param param1
 * @param param2
 */

/**
 * Description
 *
 * 
 * 
 * @param param1
 * @param param2
 * @throws Exception
 * @return void
 */

/**
 * Multiline
 *
 * Description
 * 
 * 
 * @param param1
 * @param param2
 */
```
### Output:
```
/**
 * Description
 * @param param1
 * @param param2
 */

/**
 * Description
 *
 * @param param1
 * @param param2
 * @throws Exception
 * @return void
 */

/**
 * Multiline
 *
 * Description
 *
 * @param param1
 * @param param2
 */
```