### PR TITLE
Storage: Changed references from 'unspecified' to 'inherited'

### DIFF
--- a/storage/src/set_public_access_prevention_inherited.php
+++ b/storage/src/set_public_access_prevention_inherited.php
@@ -23,15 +23,15 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_set_public_access_prevention_unspecified]
+# [START storage_set_public_access_prevention_inherited]
 use Google\Cloud\Storage\StorageClient;
 
 /**
- * Set the bucket Public Access Prevention to unspecified.
+ * Set the bucket Public Access Prevention to inherited.
  *
  * @param string $bucketName the name of your Cloud Storage bucket.
  */
-function set_public_access_prevention_unspecified($bucketName)
+function set_public_access_prevention_inherited($bucketName)
 {
     // $bucketName = 'my-bucket';
 
@@ -40,16 +40,16 @@ function set_public_access_prevention_unspecified($bucketName)
 
     $bucket->update([
         'iamConfiguration' => [
-            'publicAccessPrevention' => 'unspecified'
+            'publicAccessPrevention' => 'inherited'
         ]
     ]);
 
     printf(
-        'Public Access Prevention has been set to unspecified for %s.' . PHP_EOL,
+        'Public Access Prevention has been set to inherited for %s.' . PHP_EOL,
         $bucketName
     );
 }
-# [END storage_set_public_access_prevention_unspecified]
+# [END storage_set_public_access_prevention_inherited]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/set_public_access_prevention_unspecified.php
+++ b/storage/src/set_public_access_prevention_unspecified.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_set_public_access_prevention_unspecified]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Set the bucket Public Access Prevention to unspecified.
+ *
+ * @param string $bucketName the name of your Cloud Storage bucket.
+ */
+function set_public_access_prevention_unspecified($bucketName)
+{
+    // $bucketName = 'my-bucket';
+
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+
+    $bucket->update([
+        'iamConfiguration' => [
+            'publicAccessPrevention' => 'unspecified'
+        ]
+    ]);
+
+    printf(
+        'Public Access Prevention has been set to unspecified for %s.' . PHP_EOL,
+        $bucketName
+    );
+}
+# [END storage_set_public_access_prevention_unspecified]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/test/PublicAccessPreventionTest.php
+++ b/storage/test/PublicAccessPreventionTest.php
@@ -65,15 +65,15 @@ class PublicAccessPreventionTest extends TestCase
     }
 
     /** @depends testSetPublicAccessPreventionToEnforced */
-    public function testSetPublicAccessPreventionToUnspecified()
+    public function testSetPublicAccessPreventionToInherited()
     {
-        $output = self::runFunctionSnippet('set_public_access_prevention_unspecified', [
+        $output = self::runFunctionSnippet('set_public_access_prevention_inherited', [
             self::$bucket->name(),
         ]);
 
         $this->assertStringContainsString(
             sprintf(
-                "Public Access Prevention has been set to unspecified for %s.",
+                "Public Access Prevention has been set to inherited for %s.",
                 self::$bucket->name()
             ),
             $output
@@ -82,10 +82,10 @@ class PublicAccessPreventionTest extends TestCase
         self::$bucket->reload();
         $bucketInformation = self::$bucket->info();
         $pap = $bucketInformation['iamConfiguration']['publicAccessPrevention'];
-        $this->assertEquals('unspecified', $pap);
+        $this->assertEquals('inherited', $pap);
     }
 
-    /** @depends testSetPublicAccessPreventionToUnspecified */
+    /** @depends testSetPublicAccessPreventionToInherited */
     public function testGetPublicAccessPrevention()
     {
         $output = self::runFunctionSnippet('get_public_access_prevention', [
@@ -94,7 +94,7 @@ class PublicAccessPreventionTest extends TestCase
 
         $this->assertStringContainsString(
             sprintf(
-                "The bucket public access prevention is unspecified for %s.",
+                "The bucket public access prevention is inherited for %s.",
                 self::$bucket->name()
             ),
             $output
@@ -103,6 +103,6 @@ class PublicAccessPreventionTest extends TestCase
         self::$bucket->reload();
         $bucketInformation = self::$bucket->info();
         $pap = $bucketInformation['iamConfiguration']['publicAccessPrevention'];
-        $this->assertEquals('unspecified', $pap);
+        $this->assertEquals('inherited', $pap);
     }
 }


### PR DESCRIPTION
Changed the references of `unspecified` in storage samples and tests to `inherited` as per #1534 

~One test would fail right now as the API hasn't changed the response yet.~