### PR TITLE
fix: php version check for tests

### DIFF
--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -167,8 +167,10 @@ do
         composer -q install
     fi
     if [ $? != 0 ]; then
+        # Generate the lock file (required for check-platform-reqs)
+        composer update --ignore-platform-reqs
         # If the PHP required version is too low, skip the test
-        if composer check-platform-reqs | grep "__root__ requires php" | grep failed ; then
+        if composer check-platform-reqs | grep "requires php" | grep failed ; then
             echo "Skipping tests in $DIR (incompatible PHP version)"
         else
             # Run composer without "-q"


### PR DESCRIPTION
Composer 2 changed the way `composer check-platform-reqs` works (we need to generate the lock file before checking), and also I updated the script to allow for automatically skipping when sub-dependencies don't meet requirements (like the functions framework). This means adding `php` to the `required` section of `composer.json` is no longer necessary.