### PR TITLE
fix: php version check

### DIFF
--- a/functions/helloworld_pubsub/composer.json
+++ b/functions/helloworld_pubsub/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "php": ">= 7.4",
         "cloudevents/sdk-php": "^1.0",
         "google/cloud-functions-framework": "^1.1"
     },

--- a/testing/check_version.php
+++ b/testing/check_version.php
@@ -1,0 +1,15 @@
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+if (count($argv) > 2) {
+    die('Usage: check_version.php CONSTRAINT' . PHP_EOL);
+}
+
+if ('null' === $argv[1]) {
+    // If there is no php constraint, it satisfies
+    echo '0';
+    return;
+}
+
+echo Composer\Semver\Semver::satisfies(PHP_VERSION, $argv[1]) ? '0' : '1';

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -8,6 +8,7 @@
         "google/cloud-tools": "dev-master",
         "guzzlehttp/guzzle": "^7.0",
         "phpunit/phpunit": "^7|^8",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "composer/semver": "^3.2"
     }
 }

--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -170,7 +170,7 @@ do
         # Generate the lock file (required for check-platform-reqs)
         composer update --ignore-platform-reqs
         # If the PHP required version is too low, skip the test
-        EXPLICITLY_SKIPPED=$(php $TESTDIR/check_version.php $(cat composer.json | jq -r .require.php));
+        EXPLICITLY_SKIPPED=$(php $TESTDIR/check_version.php "$(cat composer.json | jq -r .require.php)");
         if composer check-platform-reqs | grep "requires php" | grep failed && [ "$EXPLICITLY_SKIPPED" -eq "1" ]; then
             echo "Skipping tests in $DIR (incompatible PHP version)"
         else

--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -170,7 +170,8 @@ do
         # Generate the lock file (required for check-platform-reqs)
         composer update --ignore-platform-reqs
         # If the PHP required version is too low, skip the test
-        if composer check-platform-reqs | grep "requires php" | grep failed ; then
+        EXPLICITLY_SKIPPED=$(php $TESTDIR/check_version.php $(cat composer.json | jq -r .require.php));
+        if composer check-platform-reqs | grep "requires php" | grep failed && [ "$EXPLICITLY_SKIPPED" -eq "1" ]; then
             echo "Skipping tests in $DIR (incompatible PHP version)"
         else
             # Run composer without "-q"


### PR DESCRIPTION
Require that PHP versions are explicitly marked in `composer.json` to be skipped. This avoids things like sub-dependencies being updated to a newer PHP version causing tests to be skipped unknowingly (see #1562)