### PR TITLE
feat(Compute): string enums with constants for library Ga

### DIFF
--- a/compute/cloud-client/instances/src/create_firewall_rule.php
+++ b/compute/cloud-client/instances/src/create_firewall_rule.php
@@ -27,7 +27,12 @@ namespace Google\Cloud\Samples\Compute;
 use Google\Cloud\Compute\V1\FirewallsClient;
 use Google\Cloud\Compute\V1\Allowed;
 use Google\Cloud\Compute\V1\Firewall;
-use Google\Cloud\Compute\V1\Firewall\Direction;
+
+/**
+ * To correctly handle string enums in Cloud Compute library
+ * use constants defined in Enums subfolder.
+ */
+use Google\Cloud\Compute\V1\Enums\Firewall\Direction;
 
 /**
  * Creates a simple firewall rule allowing for incoming HTTP and HTTPS access from the entire Internet.
@@ -56,7 +61,7 @@ function create_firewall_rule(string $projectId, string $firewallRuleName, strin
       ->setPorts(['80', '443']);
     $firewallResource = (new Firewall())
       ->setName($firewallRuleName)
-      ->setDirection(Direction::name(Direction::INGRESS))
+      ->setDirection(Direction::INGRESS)
       ->setAllowed([$allowedPorts])
       ->setSourceRanges(['0.0.0.0/0'])
       ->setTargetTags(['web'])

--- a/compute/cloud-client/instances/src/create_instance.php
+++ b/compute/cloud-client/instances/src/create_instance.php
@@ -29,7 +29,12 @@ use Google\Cloud\Compute\V1\AttachedDisk;
 use Google\Cloud\Compute\V1\AttachedDiskInitializeParams;
 use Google\Cloud\Compute\V1\Instance;
 use Google\Cloud\Compute\V1\NetworkInterface;
-use Google\Cloud\Compute\V1\Operation;
+
+/**
+ * To correctly handle string enums in Cloud Compute library
+ * use constants defined in Enums subfolder.
+ */
+use Google\Cloud\Compute\V1\Enums\AttachedDisk\Type;
 
 /**
  * Create an instance in the specified project and zone.
@@ -65,6 +70,7 @@ function create_instance(
     $disk = (new AttachedDisk())
         ->setBoot(true)
         ->setAutoDelete(true)
+        ->setType(Type::PERSISTENT)
         ->setInitializeParams($diskInitializeParams);
 
     // Use the network interface provided in the $networkName argument.


### PR DESCRIPTION
Handling string enums with constants for the Cloud Compute library GA release.

For testing please use gce_rc1 branch from google-cloud-php library set.
[See here](https://stackoverflow.com/questions/33525885/composer-require-branch-name/69183847#69183847) more information on how to switch composer to pull the lib from another branch.

To be merged after Cloud Compute 0.6.0 is released.