### PR TITLE
[Issue 1598] Fixing version checker condition

### DIFF
--- a/testing/check_version.php
+++ b/testing/check_version.php
@@ -2,7 +2,7 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-if (count($argv) > 2) {
+if (count($argv) != 2) {
     die('Usage: check_version.php CONSTRAINT' . PHP_EOL);
 }
 


### PR DESCRIPTION
Now the php check_version script doesnt crash:


```
➜  php-docs-samples git:(master) ✗ php testing/check_version.php
Usage: check_version.php CONSTRAINT
➜  php-docs-samples git:(master) ✗

```