### PR TITLE
Complex upload download samples

### DIFF
--- a/storage/src/download_object_into_memory.php
+++ b/storage/src/download_object_into_memory.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,7 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_download_file]
-# [START storage_stream_file_download]
+# [START storage_file_download_from_memory]
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -32,27 +31,24 @@ use Google\Cloud\Storage\StorageClient;
  *
  * @param string $bucketName The name of your Cloud Storage bucket.
  * @param string $objectName The name of your Cloud Storage object.
- * @param string $destination The local destination to save the object.
  */
-function download_object($bucketName, $objectName, $destination)
+function download_object_into_memory($bucketName, $objectName)
 {
     // $bucketName = 'my-bucket';
     // $objectName = 'my-object';
-    // $destination = '/path/to/your/file';
 
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
     $object = $bucket->object($objectName);
-    $object->downloadToFile($destination);
+    $contents = $object->downloadAsString();
     printf(
-        'Downloaded gs://%s/%s to %s' . PHP_EOL,
+        'Downloaded %s from gs://%s/%s' . PHP_EOL,
+        $contents,
         $bucketName,
-        $objectName,
-        basename($destination)
+        $objectName
     );
 }
-# [END storage_stream_file_download]
-# [END storage_download_file]
+# [END storage_file_download_from_memory]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/download_object_into_memory.php
+++ b/storage/src/download_object_into_memory.php
@@ -23,7 +23,7 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_file_download_from_memory]
+# [START storage_file_download_into_memory]
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -48,7 +48,7 @@ function download_object_into_memory($bucketName, $objectName)
         $objectName
     );
 }
-# [END storage_file_download_from_memory]
+# [END storage_file_download_into_memory]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/upload_object.php
+++ b/storage/src/upload_object.php
@@ -24,6 +24,7 @@
 namespace Google\Cloud\Samples\Storage;
 
 # [START storage_upload_file]
+# [START storage_stream_file_upload]
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -47,6 +48,7 @@ function upload_object($bucketName, $objectName, $source)
     ]);
     printf('Uploaded %s to gs://%s/%s' . PHP_EOL, basename($source), $bucketName, $objectName);
 }
+# [END storage_stream_file_upload]
 # [END storage_upload_file]
 
 // The following 2 lines are only needed to run the samples

--- a/storage/src/upload_object_from_memory.php
+++ b/storage/src/upload_object_from_memory.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,36 +23,31 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_download_file]
-# [START storage_stream_file_download]
+# [START storage_file_upload_from_memory]
 use Google\Cloud\Storage\StorageClient;
 
 /**
- * Download an object from Cloud Storage and save it as a local file.
+ * Upload a file.
  *
  * @param string $bucketName The name of your Cloud Storage bucket.
  * @param string $objectName The name of your Cloud Storage object.
- * @param string $destination The local destination to save the object.
+ * @param string $contents The contents to upload to the file.
  */
-function download_object($bucketName, $objectName, $destination)
+function upload_object_from_memory($bucketName, $objectName, $contents)
 {
     // $bucketName = 'my-bucket';
     // $objectName = 'my-object';
-    // $destination = '/path/to/your/file';
+    // $contents = 'these are my contents';
 
     $storage = new StorageClient();
+    $stream = fopen('data://text/plain,' . $contents, 'r');
     $bucket = $storage->bucket($bucketName);
-    $object = $bucket->object($objectName);
-    $object->downloadToFile($destination);
-    printf(
-        'Downloaded gs://%s/%s to %s' . PHP_EOL,
-        $bucketName,
-        $objectName,
-        basename($destination)
-    );
+    $bucket->upload($stream, [
+        'name' => $objectName,
+    ]);
+    printf('Uploaded %s to gs://%s/%s' . PHP_EOL, $contents, $bucketName, $objectName);
 }
-# [END storage_stream_file_download]
-# [END storage_download_file]
+# [END storage_file_upload_from_memory]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -180,6 +180,31 @@ EOF;
         $bucket->object($targetName)->delete();
     }
 
+    public function testUploadAndDownloadObjectFromMemory()
+    {
+        $objectName = 'test-object-' . time();
+        $bucket = self::$storage->bucket(self::$bucketName);
+        $contents = ' !"#$%&\'()*,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+        $object = $bucket->object($objectName);
+
+        $this->assertFalse($object->exists());
+
+        $output = self::runFunctionSnippet('upload_object_from_memory', [
+          self::$bucketName,
+          $objectName,
+          $contents,
+      ]);
+
+        $object->reload();
+        $this->assertTrue($object->exists());
+
+        $output = self::runFunctionSnippet('download_object_into_memory', [
+          self::$bucketName,
+          $objectName
+      ]);
+        $this->assertStringContainsString($contents, $output);
+    }
+
     public function testChangeStorageClass()
     {
         $objectName = uniqid('change-storage-class-');


### PR DESCRIPTION

## Background

PHP has not yet implemented any sample to show how a class can be fetched from memory or from a stream. This sample will cover that.

## Change Summary

1. Added `storage_stream_file_download` and `storage_stream_file_upload` to existing samples.
2. Added samples for `storage_file_upload_from_memory` and `storage_file_download_into_memory`
3. Added `testUploadAndDownloadObjectFromMemory` which can be executed and validated.

## Tests

1. Newly added test `testUploadAndDownloadObjectFromMemory` runs successfully:

```
➜  storage git:(complex_upload_download_samples) ✗ XDEBUG_MODE=coverage  ../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/ObjectsTest.php --filter=testUploadAndDownloadObjectFromMemory
PHPUnit 8.5.23 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.28 with Xdebug 3.1.2
Configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/storage/phpunit.xml.dist

.                                                                   1 / 1 (100%)

Time: 2.08 seconds, Memory: 10.00 MB

OK (1 test, 3 assertions)

Generating code coverage report in Clover XML format ... done [223 ms]
➜  storage git:(complex_upload_download_samples)
➜  storage git:(complex_upload_download_samples)
```

2. All objects tests also run successfully:

```
➜  storage git:(complex_upload_download_samples) XDEBUG_MODE=coverage  ../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/ObjectsTest.php
PHPUnit 8.5.23 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.28 with Xdebug 3.1.2
Configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/storage/phpunit.xml.dist

........                                                            8 / 8 (100%)

Time: 13.69 seconds, Memory: 14.00 MB

OK (8 tests, 36 assertions)

Generating code coverage report in Clover XML format ... done [235 ms]
➜  storage git:(complex_upload_download_samples)
➜  storage git:(complex_upload_download_samples)
```

> Test run succeeded on local with PHPv7.4.28 and phpunitv8.5.23.

> Other tests need a lot of setup so skipped on local.
