### PR TITLE
Adding a sample to set storage endpoint

### DIFF
--- a/storage/src/set_client_endpoint.php
+++ b/storage/src/set_client_endpoint.php
@@ -44,7 +44,27 @@ function set_client_endpoint(
         'apiEndpoint' => $endpoint,
     ]);
 
-    print_r($storage);
+    // fetching apiEndpoint and baseUri from StorageClient is excluded for brevity
+    # [START_EXCLUDE]
+    $connectionProperty = new \ReflectionProperty($storage, 'connection');
+    $connectionProperty->setAccessible(true);
+    $connection = $connectionProperty->getValue($storage);
+
+    $apiEndpointProperty = new \ReflectionProperty($connection, 'apiEndpoint');
+    $apiEndpointProperty->setAccessible(true);
+    $apiEndpoint = $apiEndpointProperty->getValue($connection);
+
+    $requestBuilderProperty = new \ReflectionProperty($connection, 'requestBuilder');
+    $requestBuilderProperty->setAccessible(true);
+    $requestBuilder = $requestBuilderProperty->getValue($connection);
+
+    $baseUriProperty = new \ReflectionProperty($requestBuilder, 'baseUri');
+    $baseUriProperty->setAccessible(true);
+    $baseUri = $baseUriProperty->getValue($requestBuilder);
+    # [END_EXCLUDE]
+
+    printf('API endpoint: %s' . PHP_EOL, $apiEndpoint);
+    printf('Base URI: %s' . PHP_EOL, $baseUri);
     print('Storage Client initialized.' . PHP_EOL);
 }
 # [END storage_set_client_endpoint]

--- a/storage/src/set_client_endpoint.php
+++ b/storage/src/set_client_endpoint.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_set_client_endpoint]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Sets a custom endpoint for storage client.
+ *
+ * @param string $projectId The ID of your Google Cloud Platform project.
+ * @param string $endpoint The endpoint for storage client to target.
+ */
+function set_client_endpoint(
+    string $projectId,
+    string $endpoint
+): void {
+    // $projectId = 'my-project-id';
+    // $endpoint = 'https://storage.googleapis.com';
+
+    $storage = new StorageClient([
+        'projectId' => $projectId,
+        'apiEndpoint' => $endpoint,
+    ]);
+
+    print_r($storage);
+    print('Storage Client initialized.' . PHP_EOL);
+}
+# [END storage_set_client_endpoint]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/set_client_endpoint.php
+++ b/storage/src/set_client_endpoint.php
@@ -61,10 +61,10 @@ function set_client_endpoint(
     $baseUriProperty = new \ReflectionProperty($requestBuilder, 'baseUri');
     $baseUriProperty->setAccessible(true);
     $baseUri = $baseUriProperty->getValue($requestBuilder);
-    # [END_EXCLUDE]
 
     printf('API endpoint: %s' . PHP_EOL, $apiEndpoint);
     printf('Base URI: %s' . PHP_EOL, $baseUri);
+    # [END_EXCLUDE]
     print('Storage Client initialized.' . PHP_EOL);
 }
 # [END storage_set_client_endpoint]

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -813,8 +813,8 @@ class storageTest extends TestCase
           $testEndpoint,
         ]);
 
-        $this->assertStringContainsString(sprintf('[apiEndpoint:Google\Cloud\Storage\Connection\Rest:private] => %s', $testEndpoint), $output);
-        $this->assertStringContainsString(sprintf('[baseUri:Google\Cloud\Core\RequestBuilder:private] => %s/storage/v1/', $testEndpoint), $output);
+        $this->assertStringContainsString(sprintf('API endpoint: %s', $testEndpoint), $output);
+        $this->assertStringContainsString(sprintf('Base URI: %s/storage/v1/', $testEndpoint), $output);
         $this->assertStringContainsString('Storage Client initialized.', $output);
     }
 

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -809,8 +809,8 @@ class storageTest extends TestCase
         $testEndpoint = 'https://test-endpoint.com';
 
         $output = self::runFunctionSnippet('set_client_endpoint', [
-          self::$projectId,
-          $testEndpoint,
+            self::$projectId,
+            $testEndpoint,
         ]);
 
         $this->assertStringContainsString(sprintf('API endpoint: %s', $testEndpoint), $output);

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -804,6 +804,20 @@ class storageTest extends TestCase
         $this->assertFileExists($downloadTo);
     }
 
+    public function testSetClientEndpoint()
+    {
+        $testEndpoint = 'https://test-endpoint.com';
+
+        $output = self::runFunctionSnippet('set_client_endpoint', [
+          self::$projectId,
+          $testEndpoint,
+        ]);
+
+        $this->assertStringContainsString(sprintf('[apiEndpoint:Google\Cloud\Storage\Connection\Rest:private] => %s', $testEndpoint), $output);
+        $this->assertStringContainsString(sprintf('[baseUri:Google\Cloud\Core\RequestBuilder:private] => %s/storage/v1/', $testEndpoint), $output);
+        $this->assertStringContainsString('Storage Client initialized.', $output);
+    }
+
     private function keyName()
     {
         return sprintf(


### PR DESCRIPTION
## Change Summary

1. Added a sample for `storage_set_client_endpoint` and its test.

## Tests

Ran the test locally and its successful:

```
➜  storage git:(storage_set_endpoint) ✗ XDEBUG_MODE=coverage  ../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/storageTest.php --filter="testSetClientEndpoint"         
PHPUnit 8.5.23 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.28 with Xdebug 3.1.2
Configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/storage/phpunit.xml.dist

.                                                                   1 / 1 (100%)

Time: 1.7 seconds, Memory: 10.00 MB

OK (1 test, 3 assertions)

Generating code coverage report in Clover XML format ... done [219 ms]
➜  storage git:(storage_set_endpoint) ✗
```

~~## Still in progress:~~
~~1. Still validating, whats the best way to test. Currently, I just printed the whole object which is insanely weird!~~

~~2. The `StorageClient` seems to override the `baseURI` variable from [storage-v1 JSON config here](https://github.com/googleapis/google-cloud-php/blob/main/Storage/src/Connection/ServiceDefinition/storage-v1.json#L5-L8). It needs to be checked whether this change is sufficient or would need an additional library modifications to override the setting of default service paths in [RequestBuilder here](https://github.com/googleapis/google-cloud-php-core/blob/72706f7d1824777f42294a3c9ccdaddaad670017/src/RequestBuilder.php#L59).~~

## References
1. Python equivalent change [here](https://github.com/googleapis/nodejs-storage/pull/1812)

2. Output of `StorageClient` object dump:

```
Google\Cloud\Storage\StorageClient Object
(
    [connection:protected] => Google\Cloud\Storage\Connection\Rest Object
        (
            [projectId:Google\Cloud\Storage\Connection\Rest:private] => the-book-club-337319
            [apiEndpoint:Google\Cloud\Storage\Connection\Rest:private] => http://localhost:10000/
            [requestBuilder:Google\Cloud\Storage\Connection\Rest:private] => Google\Cloud\Core\RequestBuilder Object
                (
                    [servicePath:Google\Cloud\Core\RequestBuilder:private] =>
                    [baseUri:Google\Cloud\Core\RequestBuilder:private] => http://localhost:10000/storage/v1/
                    [resourceRoot:Google\Cloud\Core\RequestBuilder:private] => Array
                        (
                        )

                    [service:Google\Cloud\Core\RequestBuilder:private] => Array
                        (
                            [kind] => discovery#restDescription
                            [version] => v1
                            [id] => storage:v1
                            [rootUrl] => https://storage.googleapis.com/
                            [mtlsRootUrl] => https://storage.mtls.googleapis.com/
                            [baseUrl] => https://storage.googleapis.com/storage/v1/
                            [basePath] => /storage/v1/
                            [servicePath] => storage/v1/
                            [batchPath] => batch/storage/v1
                            [discoveryVersion] => v1
                            [name] => storage
                            [title] => Cloud Storage JSON API
                            [description] => Stores and retrieves potentially large, immutable data objects.
                            [ownerDomain] => google.com
                            [ownerName] => Google
                            [icons] => Array
                                (
                                    [x16] => https://www.google.com/images/icons/product/cloud_storage-16.png
                                    [x32] => https://www.google.com/images/icons/product/cloud_storage-32.png
                                )
.
.
.
.
.
        )

    [projectId:Google\Cloud\Storage\StorageClient:private] => the-book-club-337319
)
Storage Client initialized.
```
(Note there are multiple URIs here in the dump)