### PR TITLE
Adding samples for printing bucket/object ACLs

### DIFF
--- a/storage/src/print_bucket_acl_for_user.php
+++ b/storage/src/print_bucket_acl_for_user.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_print_bucket_acl_for_user]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Print an entity role for a bucket ACL.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ * @param string $entity The entity for which to query access controls.
+ */
+function print_bucket_acl_for_user(
+    string $bucketName,
+    string $entity
+): void {
+    // $bucketName = 'my-bucket';
+    // $entity = 'user-example@domain.com';
+
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $acl = $bucket->acl();
+
+    $item = $acl->get(['entity' => $entity]);
+    printf('%s: %s' . PHP_EOL, $item['entity'], $item['role']);
+}
+# [END storage_print_bucket_acl_for_user]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/print_file_acl_for_user.php
+++ b/storage/src/print_file_acl_for_user.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_print_file_acl_for_user]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Print an entity role for a file ACL.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ * @param string $objectName The name of your Cloud Storage object.
+ * @param string $entity The entity for which to query access controls.
+ */
+function print_file_acl_for_user(
+    string $bucketName,
+    string $objectName,
+    string $entity
+): void {
+    // $bucketName = 'my-bucket';
+    // $objectName = 'my-object';
+    // $entity = 'user-example@domain.com';
+
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $object = $bucket->object($objectName);
+    $acl = $object->acl();
+    $item = $acl->get(['entity' => $entity]);
+    printf('%s: %s' . PHP_EOL, $item['entity'], $item['role']);
+}
+# [END storage_print_file_acl_for_user]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/test/ObjectAclTest.php
+++ b/storage/test/ObjectAclTest.php
@@ -100,4 +100,70 @@ Deleted allAuthenticatedUsers from $objectUrl ACL
 EOF;
         $this->assertEquals($output, $outputString);
     }
+
+    public function testPrintFileAclForUser()
+    {
+        $objectName = $this->requireEnv('GOOGLE_STORAGE_OBJECT');
+
+        $bucket = self::$storage->bucket(self::$bucketName);
+        $object = $bucket->object($objectName);
+        $acl = $object->acl();
+
+        $output = self::runFunctionSnippet('add_object_acl', [
+            self::$bucketName,
+            $objectName,
+            'allAuthenticatedUsers',
+            'READER',
+        ]);
+
+        $aclInfo = $acl->get(['entity' => 'allAuthenticatedUsers']);
+        $this->assertArrayHasKey('role', $aclInfo);
+        $this->assertEquals('READER', $aclInfo['role']);
+
+        $output .= self::runFunctionSnippet('print_file_acl_for_user', [
+            self::$bucketName,
+            $objectName,
+            'allAuthenticatedUsers',
+        ]);
+
+        $objectUrl = sprintf('gs://%s/%s', self::$bucketName, $objectName);
+        $outputString = <<<EOF
+Added allAuthenticatedUsers (READER) to $objectUrl ACL
+allAuthenticatedUsers: READER
+
+EOF;
+        $this->assertEquals($output, $outputString);
+    }
+
+    public function testPrintBucketAclForUser()
+    {
+        $objectName = $this->requireEnv('GOOGLE_STORAGE_OBJECT');
+
+        $bucket = self::$storage->bucket(self::$bucketName);
+        $object = $bucket->object($objectName);
+        $acl = $object->acl();
+
+        $output = self::runFunctionSnippet('add_bucket_acl', [
+            self::$bucketName,
+            'allAuthenticatedUsers',
+            'READER',
+        ]);
+
+        $aclInfo = $acl->get(['entity' => 'allAuthenticatedUsers']);
+        $this->assertArrayHasKey('role', $aclInfo);
+        $this->assertEquals('READER', $aclInfo['role']);
+
+        $output .= self::runFunctionSnippet('print_bucket_acl_for_user', [
+            self::$bucketName,
+            'allAuthenticatedUsers',
+        ]);
+
+        $bucketUrl = sprintf('gs://%s', self::$bucketName);
+        $outputString = <<<EOF
+Added allAuthenticatedUsers (READER) to $bucketUrl ACL
+allAuthenticatedUsers: READER
+
+EOF;
+        $this->assertEquals($output, $outputString);
+    }
 }


### PR DESCRIPTION
## Goal
Implement 2 samples:

```
storage_print_file_acl_for_user
storage_print_bucket_acl_for_user
```

## Change Summary

1. Adding `print_file_acl_for_user.php` and `print_bucket_acl_for_user.php`.
2. Adding tests for the above 2 samples here: `ObjectAclTest.php`


## Tests

1. Ran the samples:

```
➜  storage git:(storage_print_acl_for_user) ✗ php src/add_bucket_acl.php $GOOGLE_STORAGE_BUCKET_LEGACY 'allAuthenticatedUsers' 'READER' 
Added allAuthenticatedUsers (READER) to gs://gcp-acl_test_bucket ACL
➜  storage git:(storage_print_acl_for_user) ✗ php src/print_bucket_acl_for_user.php $GOOGLE_STORAGE_BUCKET_LEGACY 'allAuthenticatedUsers'    
allAuthenticatedUsers: READER
➜  storage git:(storage_print_acl_for_user) ✗ 
➜  storage git:(storage_print_acl_for_user) ✗ php src/add_object_acl.php $GOOGLE_STORAGE_BUCKET_LEGACY $GOOGLE_STORAGE_OBJECT 'allAuthenticatedUsers' 'READER'
Added allAuthenticatedUsers (READER) to gs://gcp-acl_test_bucket/sample.txt ACL
➜  storage git:(storage_print_acl_for_user) ✗ php src/print_file_acl_for_user.php $GOOGLE_STORAGE_BUCKET_LEGACY $GOOGLE_STORAGE_OBJECT 'allAuthenticatedUsers'
allAuthenticatedUsers: READER
➜  storage git:(storage_print_acl_for_user) ✗ 
```

3. Tests running successfully (previously there were only 2 tests in `ObjectAclTest.php`):

```
➜  storage git:(storage_print_acl_for_user) XDEBUG_MODE=coverage  ../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/ObjectAclTest.php
PHPUnit 8.5.23 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.28 with Xdebug 3.1.2
Configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/storage/phpunit.xml.dist

....                                                                4 / 4 (100%)

Time: 1.25 seconds, Memory: 10.00 MB

OK (4 tests, 11 assertions)

Generating code coverage report in Clover XML format ... done [255 ms]
➜  storage git:(storage_print_acl_for_user) 
```