### PR TITLE
Added new sample for storage to upload chunked stream

### DIFF
--- a/storage/src/upload_object_stream.php
+++ b/storage/src/upload_object_stream.php
@@ -43,7 +43,7 @@ function upload_object_stream($bucketName, $objectName, $source)
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
     $writeStream = new WriteStream(null, [
-        'chunkSize' => 1024*256, // 256KB
+        'chunkSize' => 1024 * 256, // 256KB
     ]);
     $uploader = $bucket->getStreamableUploader($writeStream, [
         'name' => $objectName

--- a/storage/src/upload_object_stream.php
+++ b/storage/src/upload_object_stream.php
@@ -32,13 +32,13 @@ use Google\Cloud\Storage\WriteStream;
  *
  * @param string $bucketName The name of your Cloud Storage bucket.
  * @param string $objectName The name of your Cloud Storage object.
- * @param string $source The path to the file to upload.
+ * @param string $contents The contents to upload via stream chunks.
  */
-function upload_object_stream($bucketName, $objectName, $source)
+function upload_object_stream($bucketName, $objectName, $contents)
 {
     // $bucketName = 'my-bucket';
     // $objectName = 'my-object';
-    // $source = '/path/to/your/file';
+    // $contents = 'these are my contents';
 
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
@@ -49,14 +49,13 @@ function upload_object_stream($bucketName, $objectName, $source)
         'name' => $objectName
     ]);
     $writeStream->setUploader($uploader);
-    $file = fopen($source, 'r');
-    while (($line = stream_get_line($file, 1024 * 256)) !== false) {
+    $stream = fopen('data://text/plain,' . $contents, 'r');
+    while (($line = stream_get_line($stream, 1024 * 256)) !== false) {
         $writeStream->write($line);
     }
     $writeStream->close();
-    fclose($file);
 
-    printf('Uploaded %s to gs://%s/%s' . PHP_EOL, basename($source), $bucketName, $objectName);
+    printf('Uploaded %s to gs://%s/%s' . PHP_EOL, $contents, $bucketName, $objectName);
 }
 # [END storage_stream_file_upload]
 

--- a/storage/src/upload_object_stream.php
+++ b/storage/src/upload_object_stream.php
@@ -34,7 +34,7 @@ use Google\Cloud\Storage\WriteStream;
  * @param string $objectName The name of your Cloud Storage object.
  * @param string $contents The contents to upload via stream chunks.
  */
-function upload_object_stream($bucketName, $objectName, $contents)
+function upload_object_stream(string $bucketName, string $objectName, string $contents): void
 {
     // $bucketName = 'my-bucket';
     // $objectName = 'my-object';
@@ -46,7 +46,7 @@ function upload_object_stream($bucketName, $objectName, $contents)
         'chunkSize' => 1024 * 256, // 256KB
     ]);
     $uploader = $bucket->getStreamableUploader($writeStream, [
-        'name' => $objectName
+        'name' => $objectName,
     ]);
     $writeStream->setUploader($uploader);
     $stream = fopen('data://text/plain,' . $contents, 'r');
@@ -59,6 +59,6 @@ function upload_object_stream($bucketName, $objectName, $contents)
 }
 # [END storage_stream_file_upload]
 
-// The following 2 lines are only needed to run the samples
+// The following 2 lines are only needed to run the samples from the CLI
 require_once __DIR__ . '/../../testing/sample_helpers.php';
 \Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -208,26 +208,17 @@ EOF;
     public function testUploadAndDownloadObjectStream()
     {
         $objectName = 'test-object-stream-' . time();
-        $bucket = self::$storage->bucket(self::$bucketName);
         $contents = ' !"#$%&\'()*,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-
         //make contents larger than atleast one chunk size
         $contents = str_repeat($contents, 1024 * 256);
-
+        $bucket = self::$storage->bucket(self::$bucketName);
         $object = $bucket->object($objectName);
-
-        $uploadFrom = tempnam(sys_get_temp_dir(), '/teststream');
-        $basename = basename($uploadFrom);
-        file_put_contents($uploadFrom, $contents);
-        $downloadTo = tempnam(sys_get_temp_dir(), '/teststream');
-        $downloadToBasename = basename($downloadTo);
-
         $this->assertFalse($object->exists());
 
         $output = self::runFunctionSnippet('upload_object_stream', [
             self::$bucketName,
             $objectName,
-            $uploadFrom,
+            $contents,
         ]);
 
         $object->reload();

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -209,9 +209,11 @@ EOF;
     {
         $objectName = 'test-object-stream-' . time();
         $bucket = self::$storage->bucket(self::$bucketName);
-        $contents = ' !"#$%&\'()*,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'. rand();
+        $contents = ' !"#$%&\'()*,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+
         //make contents larger than atleast one chunk size
-        $contents = str_repeat($contents, 1024*256);
+        $contents = str_repeat($contents, 1024 * 256);
+
         $object = $bucket->object($objectName);
 
         $uploadFrom = tempnam(sys_get_temp_dir(), '/teststream');

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -205,6 +205,39 @@ EOF;
         $this->assertStringContainsString($contents, $output);
     }
 
+    public function testUploadAndDownloadObjectStream()
+    {
+        $objectName = 'test-object-stream-' . time();
+        $bucket = self::$storage->bucket(self::$bucketName);
+        $contents = ' !"#$%&\'()*,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~'. rand();
+        //make contents larger than atleast one chunk size
+        $contents = str_repeat($contents, 1024*256);
+        $object = $bucket->object($objectName);
+
+        $uploadFrom = tempnam(sys_get_temp_dir(), '/teststream');
+        $basename = basename($uploadFrom);
+        file_put_contents($uploadFrom, $contents);
+        $downloadTo = tempnam(sys_get_temp_dir(), '/teststream');
+        $downloadToBasename = basename($downloadTo);
+
+        $this->assertFalse($object->exists());
+
+        $output = self::runFunctionSnippet('upload_object_stream', [
+            self::$bucketName,
+            $objectName,
+            $uploadFrom,
+        ]);
+
+        $object->reload();
+        $this->assertTrue($object->exists());
+
+        $output = self::runFunctionSnippet('download_object_into_memory', [
+            self::$bucketName,
+            $objectName
+        ]);
+        $this->assertStringContainsString($contents, $output);
+    }
+
     public function testDownloadByteRange()
     {
         $objectName = 'test-object-download-byte-range-' . time();


### PR DESCRIPTION
Per https://github.com/googleapis/google-cloud-php/issues/4155, our users are requesting a sample / documentation for uploading objects of a fixed chunk sizes to Storage. Existing samples cover file/memory uploads in entirety but not with controlled chunk sizes.

**NOTE:** This change will replace the samples already published [on this devsite link](https://cloud.google.com/storage/docs/samples/storage-stream-file-upload#storage_stream_file_upload-php).

## Changes
1. Added a new sample: `storage_stream_file_upload`
2. Added test for `testUploadAndDownloadObjectStream`
3. Removed sample tag from older sample to upload files: `upload_object.php`

## Tests

1. Uploaded a local file by executing sample:

```
➜  storage git:(upload_chunked_stream) ✗ php src/upload_object_stream.php $GOOGLE_STORAGE_BUCKET "stream-$(date +%F-%Ih-%Mm-%Ss)" "abcdedghijklmnopqrstuvwxyz"                                                                
Uploaded abcdedghijklmnopqrstuvwxyz to gs://thebookclub/stream-2022-06-17-10h-14m-54s
➜  storage git:(upload_chunked_stream)
```

2. Test run:

```
➜  storage git:(upload_chunked_stream) ✗ XDEBUG_MODE=coverage ../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/ObjectsTest.php                                             
PHPUnit 8.5.23 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.2 with Xdebug 3.1.2
Configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/storage/phpunit.xml.dist
Error:         This version of PHPUnit does not support code coverage on PHP 8

..........                                                        10 / 10 (100%)

Time: 3.42 seconds, Memory: 16.00 MB

OK (10 tests, 44 assertions)
➜  storage git:(upload_chunked_stream)
```
