### PR TITLE
fix: change Firestore document name to match public docs

### DIFF
--- a/firestore/src/data_reference_document.php
+++ b/firestore/src/data_reference_document.php
@@ -38,7 +38,7 @@ function data_reference_document(string $projectId): void
     ]);
     # [START fs_document_ref]
     # [START firestore_data_reference_document]
-    $document = $db->collection('samples/php/users')->document('lovelace');
+    $document = $db->collection('samples/php/users')->document('alovelace');
     # [END firestore_data_reference_document]
     # [END fs_document_ref]
     printf('Retrieved document: %s' . PHP_EOL, $document->name());

--- a/firestore/src/data_reference_document_path.php
+++ b/firestore/src/data_reference_document_path.php
@@ -38,7 +38,7 @@ function data_reference_document_path(string $projectId): void
     ]);
     # [START fs_document_path_ref]
     # [START firestore_data_reference_document_path]
-    $document = $db->document('users/lovelace');
+    $document = $db->document('users/alovelace');
     # [END firestore_data_reference_document_path]
     # [END fs_document_path_ref]
     printf('Retrieved document from path: %s' . PHP_EOL, $document->name());

--- a/firestore/src/setup_dataset.php
+++ b/firestore/src/setup_dataset.php
@@ -38,7 +38,7 @@ function setup_dataset(string $projectId): void
     ]);
     # [START fs_add_data_1]
     # [START firestore_setup_dataset_pt1]
-    $docRef = $db->collection('samples/php/users')->document('lovelace');
+    $docRef = $db->collection('samples/php/users')->document('alovelace');
     $docRef->set([
         'first' => 'Ada',
         'last' => 'Lovelace',


### PR DESCRIPTION
This PR is to address https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1532

The document name is correctly used in the repo since the setup code inserted a document of just `lovelace` however it seems it is preferable to match public documentations, I have modified the relevant files to reference `alovelace` instead. 