### PR TITLE
feat: add new samples for bigquery

### DIFF
--- a/bigquery/api/phpunit.xml.dist
+++ b/bigquery/api/phpunit.xml.dist
@@ -25,8 +25,8 @@
     </logging>
     <filter>
         <whitelist>
-	         <directory suffix=".php">./src</directory>
-           <exclude>
+            <directory suffix=".php">./src</directory>
+            <exclude>
               <directory>./vendor</directory>
             </exclude>
         </whitelist>

--- a/bigquery/api/phpunit.xml.dist
+++ b/bigquery/api/phpunit.xml.dist
@@ -25,7 +25,7 @@
     </logging>
     <filter>
         <whitelist>
-	         <directory suffix=".php">./snippets</directory>
+	         <directory suffix=".php">./src</directory>
            <exclude>
               <directory>./vendor</directory>
             </exclude>

--- a/bigquery/api/src/dry_run_query.php
+++ b/bigquery/api/src/dry_run_query.php
@@ -51,4 +51,4 @@ $queryJob = $bigQuery->startJob($jobConfig);
 $info = $queryJob->info();
 
 printf('This query will process %s bytes' . PHP_EOL, $info['statistics']['totalBytesProcessed']);
-# [START bigquery_query_dry_run]
+# [END bigquery_query_dry_run]

--- a/bigquery/api/src/dry_run_query.php
+++ b/bigquery/api/src/dry_run_query.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/bigquery/api/README.md
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 3) {
+    return printf("Usage: php %s PROJECT_ID SQL_QUERY\n", __FILE__);
+}
+list($_, $projectId, $query) = $argv;
+
+# [START bigquery_query_dry_run]
+use Google\Cloud\BigQuery\BigQueryClient;
+
+/** Uncomment and populate these variables in your code */
+// $projectId = 'The Google project ID';
+// $query = 'SELECT id, view_count FROM `bigquery-public-data.stackoverflow.posts_questions`';
+
+// Construct a BigQuery client object.
+$bigQuery = new BigQueryClient([
+    'projectId' => $projectId,
+]);
+
+// Set job configs
+$jobConfig = $bigQuery->query($query);
+$jobConfig->useQueryCache(false);
+$jobConfig->dryRun(true);
+
+// Extract query results
+$queryJob = $bigQuery->startJob($jobConfig);
+$info = $queryJob->info();
+
+printf('This query will process %s bytes' . PHP_EOL, $info['statistics']['totalBytesProcessed']);
+# [START bigquery_query_dry_run]

--- a/bigquery/api/src/query_no_cache.php
+++ b/bigquery/api/src/query_no_cache.php
@@ -56,4 +56,4 @@ foreach ($queryResults as $row) {
     }
 }
 printf('Found %s row(s)' . PHP_EOL, $i);
-# [START bigquery_query_no_cache]
+# [END bigquery_query_no_cache]

--- a/bigquery/api/src/query_no_cache.php
+++ b/bigquery/api/src/query_no_cache.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/bigquery/api/README.md
+ */
+
+// Include Google Cloud dependendencies using Composer
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 3) {
+    return printf("Usage: php %s PROJECT_ID SQL_QUERY\n", __FILE__);
+}
+list($_, $projectId, $query) = $argv;
+
+# [START bigquery_query_no_cache]
+use Google\Cloud\BigQuery\BigQueryClient;
+
+/** Uncomment and populate these variables in your code */
+// $projectId = 'The Google project ID';
+// $query = 'SELECT id, view_count FROM `bigquery-public-data.stackoverflow.posts_questions`';
+
+// Construct a BigQuery client object.
+$bigQuery = new BigQueryClient([
+    'projectId' => $projectId,
+]);
+
+// Set job configs
+$jobConfig = $bigQuery->query($query);
+$jobConfig->useQueryCache(false);
+
+// Extract query results
+$queryResults = $bigQuery->runQuery($jobConfig);
+
+$i = 0;
+foreach ($queryResults as $row) {
+    printf('--- Row %s ---' . PHP_EOL, ++$i);
+    foreach ($row as $column => $value) {
+        printf('%s: %s' . PHP_EOL, $column, json_encode($value));
+    }
+}
+printf('Found %s row(s)' . PHP_EOL, $i);
+# [START bigquery_query_no_cache]

--- a/bigquery/api/test/bigqueryTest.php
+++ b/bigquery/api/test/bigqueryTest.php
@@ -287,6 +287,32 @@ class FunctionsTest extends TestCase
         $this->assertStringContainsString('Found 1 row(s)', $output);
     }
 
+    public function testDryRunQuery()
+    {
+        $tableId = $this->createTempTable();
+        $query = sprintf(
+            'SELECT * FROM `%s.%s` LIMIT 1',
+            self::$datasetId,
+            $tableId
+        );
+
+        $output = $this->runSnippet('dry_run_query', [$query]);
+        $this->assertStringContainsString('This query will process 126 bytes', $output);
+    }
+
+    public function testQueryNoCache()
+    {
+        $tableId = $this->createTempTable();
+        $query = sprintf(
+            'SELECT * FROM `%s.%s` LIMIT 1',
+            self::$datasetId,
+            $tableId
+        );
+
+        $output = $this->runSnippet('query_no_cache', [$query]);
+        $this->assertStringContainsString('Found 1 row(s)', $output);
+    }
+
     public function testQueryLegacy()
     {
         $output = $this->runSnippet('query_legacy');


### PR DESCRIPTION
Adding samples which are missing on these pages:

`bigquery_query_dry_run` -> https://cloud.google.com/bigquery/docs/dry-run-queries
`bigquery_query_no_cache` -> https://cloud.google.com/bigquery/docs/cached-results

## Tests: 
> Passes in my local

```
➜  api git:(bigquery_samples) XDEBUG_MODE=coverage ../../testing/vendor/bin/phpunit --verbose -c phpunit.xml.dist test/*
PHPUnit 8.5.27 #StandWithUkraine

Runtime:       PHP 7.3.33 with Xdebug 3.1.5
Configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/bigquery/api/phpunit.xml.dist
Error:         This version of PHPUnit does not support code coverage on PHP 8

.......................                                           23 / 23 (100%)

Time: 1.73 minutes, Memory: 58.00 MB

OK (23 tests, 64 assertions)
➜  api git:(bigquery_samples) 
```