### PR TITLE
chore: revert cs-fixer and fix a few styles

### DIFF
--- a/appengine/flexible/storage/app.php
+++ b/appengine/flexible/storage/app.php
@@ -49,7 +49,7 @@ $app->get('/', function (Request $request, Response $response) use ($container) 
         <input type="submit" />
     </form>
 EOF
-);
+    );
     if ($content) {
         $response->getBody()->write(
             "<p><strong>Your content:</strong><p><p>$escapedContent</p>"

--- a/appengine/standard/auth/test/DeployTest.php
+++ b/appengine/standard/auth/test/DeployTest.php
@@ -38,8 +38,7 @@ class DeployTest extends TestCase
         } catch (\GuzzleHttp\Exception\ServerException $e) {
             $this->fail($e->getResponse()->getBody());
         }
-        $this->assertEquals('200', $resp->getStatusCode(),
-                            'top page status code');
+        $this->assertEquals('200', $resp->getStatusCode(), 'top page status code');
         $contents = $resp->getBody()->getContents();
         $this->assertStringContainsString(
             sprintf('Bucket: %s', $projectId),

--- a/appengine/standard/grpc/test/DeployTest.php
+++ b/appengine/standard/grpc/test/DeployTest.php
@@ -35,11 +35,8 @@ class DeployTest extends TestCase
         } catch (\GuzzleHttp\Exception\ServerException $e) {
             $this->fail($e->getResponse()->getBody());
         }
-        $this->assertEquals('200', $resp->getStatusCode(),
-                            'top page status code');
-        $this->assertStringContainsString(
-            'Spanner',
-            $resp->getBody()->getContents());
+        $this->assertEquals('200', $resp->getStatusCode(), 'top page status code');
+        $this->assertStringContainsString('Spanner', $resp->getBody()->getContents());
     }
 
     public static function beforeDeploy()
@@ -77,11 +74,8 @@ class DeployTest extends TestCase
         } catch (\GuzzleHttp\Exception\ServerException $e) {
             $this->fail($e->getResponse()->getBody());
         }
-        $this->assertEquals('200', $resp->getStatusCode(),
-                            'top page status code');
-        $this->assertStringContainsString(
-            'Hello World',
-            $resp->getBody()->getContents());
+        $this->assertEquals('200', $resp->getStatusCode(), 'top page status code');
+        $this->assertStringContainsString('Hello World', $resp->getBody()->getContents());
     }
 
     public function testMonitoring()
@@ -92,11 +86,11 @@ class DeployTest extends TestCase
         } catch (\GuzzleHttp\Exception\ServerException $e) {
             $this->fail($e->getResponse()->getBody());
         }
-        $this->assertEquals('200', $resp->getStatusCode(),
-                            'top page status code');
+        $this->assertEquals('200', $resp->getStatusCode(), 'top page status code');
         $this->assertStringContainsString(
             'Successfully submitted a time series',
-            $resp->getBody()->getContents());
+            $resp->getBody()->getContents()
+        );
     }
 
     public function testSpeech()
@@ -107,10 +101,10 @@ class DeployTest extends TestCase
         } catch (\GuzzleHttp\Exception\ServerException $e) {
             $this->fail($e->getResponse()->getBody());
         }
-        $this->assertEquals('200', $resp->getStatusCode(),
-                            'top page status code');
+        $this->assertEquals('200', $resp->getStatusCode(), 'top page status code');
         $this->assertStringContainsString(
             'Transcription: how old is the Brooklyn Bridge',
-            $resp->getBody()->getContents());
+            $resp->getBody()->getContents()
+        );
     }
 }

--- a/appengine/standard/slim-framework/index.php
+++ b/appengine/standard/slim-framework/index.php
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- /**
+
+/**
  * This front controller is called by the App Engine web server to handle all
  * incoming requests. To change this, you will need to modify the "entrypoint"
  * directive in `app.yaml`.

--- a/asset/src/list_assets.php
+++ b/asset/src/list_assets.php
@@ -31,11 +31,10 @@ function list_assets(string $projectId, array $assetTypes = [], int $pageSize = 
     $client = new AssetServiceClient();
 
     // Run request
-    $response = $client->listAssets(
-      "projects/$projectId", [
+    $response = $client->listAssets("projects/$projectId", [
         'assetTypes' => $assetTypes,
         'pageSize' => $pageSize,
-      ]);
+    ]);
 
     // Print the asset names in the result
     foreach ($response->getPage() as $asset) {

--- a/bigtable/test/BigtableTestTrait.php
+++ b/bigtable/test/BigtableTestTrait.php
@@ -77,8 +77,8 @@ trait BigtableTestTrait
 
         $columns = $columns ?: ['stats_summary'];
         $table = (new Table())->setColumnFamilies(array_combine(
-                $columns,
-                array_fill(0, count($columns), new ColumnFamily)
+            $columns,
+            array_fill(0, count($columns), new ColumnFamily)
         ));
 
         self::$tableAdminClient->createtable(

--- a/compute/api-client/helloworld/app.php
+++ b/compute/api-client/helloworld/app.php
@@ -188,8 +188,7 @@ if ($client->getAccessToken()) {
     $new_instance->setMachineType($machineType);
     $new_instance->setNetworkInterfaces(array($googleNetworkInterfaceObj));
 
-    $insertInstance = $computeService->instances->insert(DEFAULT_PROJECT,
-    $zone, $new_instance);
+    $insertInstance = $computeService->instances->insert(DEFAULT_PROJECT, $zone, $new_instance);
     $insertInstanceMarkup = generateMarkup('Insert Instance', $insertInstance);
 
     /**

--- a/iot/src/list_devices_for_gateway.php
+++ b/iot/src/list_devices_for_gateway.php
@@ -48,7 +48,7 @@ function list_devices_for_gateway(
 
     // Call the API
     $devices = $deviceManager->listDevices($registryName,
-      ['gatewayListOptions' => $gatewayListOptions]
+        ['gatewayListOptions' => $gatewayListOptions]
     );
 
     // Print the result

--- a/secretmanager/quickstart.php
+++ b/secretmanager/quickstart.php
@@ -44,7 +44,7 @@ $parent = $client->projectName($projectId);
 
 // Create the parent secret.
 $secret = $client->createSecret($parent, $secretId,
-  new Secret([
+    new Secret([
         'replication' => new Replication([
             'automatic' => new Automatic(),
         ]),

--- a/spanner/src/query_data_with_nested_struct_field.php
+++ b/spanner/src/query_data_with_nested_struct_field.php
@@ -48,8 +48,8 @@ function query_data_with_nested_struct_field($instanceId, $databaseId)
 
     $nameType = new ArrayType(
         (new StructType)
-             ->add('FirstName', Database::TYPE_STRING)
-             ->add('LastName', Database::TYPE_STRING)
+            ->add('FirstName', Database::TYPE_STRING)
+            ->add('LastName', Database::TYPE_STRING)
     );
     $songInfoType = (new StructType)
         ->add('SongName', Database::TYPE_STRING)

--- a/spanner/src/query_data_with_nested_struct_field.php
+++ b/spanner/src/query_data_with_nested_struct_field.php
@@ -47,9 +47,9 @@ function query_data_with_nested_struct_field($instanceId, $databaseId)
     $database = $instance->database($databaseId);
 
     $nameType = new ArrayType(
-       (new StructType)
-            ->add('FirstName', Database::TYPE_STRING)
-            ->add('LastName', Database::TYPE_STRING)
+        (new StructType)
+             ->add('FirstName', Database::TYPE_STRING)
+             ->add('LastName', Database::TYPE_STRING)
     );
     $songInfoType = (new StructType)
         ->add('SongName', Database::TYPE_STRING)

--- a/storage/src/delete_hmac_key.php
+++ b/storage/src/delete_hmac_key.php
@@ -43,8 +43,8 @@ function delete_hmac_key($projectId, $accessId)
 
     $hmacKey->delete();
     print(
-      'The key is deleted, though it may still appear in the results of calls ' .
-      'to StorageClient.hmacKeys([\'showDeletedKeys\' => true])' . PHP_EOL
+        'The key is deleted, though it may still appear in the results of calls ' .
+        'to StorageClient.hmacKeys([\'showDeletedKeys\' => true])' . PHP_EOL
     );
 }
 # [END storage_delete_hmac_key]

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -8,7 +8,7 @@
         "google/cloud-tools": "dev-main",
         "guzzlehttp/guzzle": "^7.0",
         "phpunit/phpunit": "^7|^8",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "friendsofphp/php-cs-fixer": "3.8.0",
         "composer/semver": "^3.2"
     }
 }

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -8,7 +8,7 @@
         "google/cloud-tools": "dev-main",
         "guzzlehttp/guzzle": "^7.0",
         "phpunit/phpunit": "^7|^8",
-        "friendsofphp/php-cs-fixer": "3.8.0",
+        "friendsofphp/php-cs-fixer": "^3,<3.9",
         "composer/semver": "^3.2"
     }
 }

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -7,7 +7,7 @@
         "google/auth": "^1.12",
         "google/cloud-tools": "dev-main",
         "guzzlehttp/guzzle": "^7.0",
-        "phpunit/phpunit": "^7|^8",
+        "phpunit/phpunit": "^7|^8,<8.5.27",
         "friendsofphp/php-cs-fixer": "^3,<3.9",
         "composer/semver": "^3.2"
     }

--- a/video/src/analyze_object_tracking_file.php
+++ b/video/src/analyze_object_tracking_file.php
@@ -18,7 +18,7 @@
 
 namespace Google\Cloud\Samples\VideoIntelligence;
 
- // [START video_object_tracking]
+// [START video_object_tracking]
 use Google\Cloud\VideoIntelligence\V1\VideoIntelligenceServiceClient;
 use Google\Cloud\VideoIntelligence\V1\Feature;
 


### PR DESCRIPTION
 - addresses phpunit errors on PHP 7.3 (see https://github.com/sebastianbergmann/phpunit/issues/5016)
 - Pin `php-cs-fixer` to `v3.8.0` because `v3.9` broke several things for us.
 - Fix a few cs problems that the later version actually caught