### PR TITLE
feat: samples for dual region bucket creation

### DIFF
--- a/storage/composer.json
+++ b/storage/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "google/cloud-storage": "^1.20.1",
+        "google/cloud-storage": "^1.28.0",
         "paragonie/random_compat": "^9.0.0"
     },
     "require-dev": {

--- a/storage/src/create_bucket_dual_region.php
+++ b/storage/src/create_bucket_dual_region.php
@@ -30,21 +30,25 @@ use Google\Cloud\Storage\StorageClient;
  * Create a new bucket with a custom default storage class and location.
  *
  * @param string $bucketName The name of your Cloud Storage bucket.
- * @param string $location1 First location for the bucket's regions. Case-insensitive.
- * @param string $location2 Second location for the bucket's regions. Case-insensitive.
+ * @param string $location Location for the bucket's regions. Case-insensitive.
+ * @param string $region1 First region for the bucket's regions. Case-insensitive.
+ * @param string $region2 Second region for the bucket's regions. Case-insensitive.
  */
-function create_bucket_dual_region($bucketName, $location1, $location2)
+function create_bucket_dual_region($bucketName, $location, $region1, $region2)
 {
     // $bucketName = 'my-bucket';
-    // $location1 = 'US-EAST1';
-    // $location2 = 'US-WEST1';
+    // $location = 'US';
+    // $region1 = 'US-EAST1';
+    // $region2 = 'US-WEST1';
 
     $storage = new StorageClient();
     $bucket = $storage->createBucket($bucketName, [
-        'location' => "${location1}+${location2}",
+        'location' => $location,
+        'customPlacementConfig' => [
+            'dataLocations' => [$region1, $region2],
+        ],
     ]);
-
-    printf("Created dual-region bucket '%s' in '%s+%s'", $bucket->name(), $location1, $location2);
+    printf("Bucket '%s' created in '%s' and '%s'", $bucket->name(), $region1, $region2);
 }
 # [END storage_create_bucket_dual_region]
 

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -674,23 +674,38 @@ class storageTest extends TestCase
 
     public function testCreateBucketDualRegion()
     {
-        $location1 = 'US-EAST1';
-        $location2 = 'US-WEST1';
+        $location = 'US';
+        $region1 = 'US-EAST1';
+        $region2 = 'US-WEST1';
 
         $bucketName = uniqid('samples-create-bucket-dual-region-');
         $output = self::runFunctionSnippet('create_bucket_dual_region', [
             $bucketName,
-            $location1,
-            $location2
+            $location,
+            $region1,
+            $region2
         ]);
 
         $bucket = self::$storage->bucket($bucketName);
+        $info = $bucket->reload();
         $exists = $bucket->exists();
         $bucket->delete();
 
         $this->assertTrue($exists);
-        $this->assertStringContainsString('Created dual-region bucket', $output);
-        $this->assertStringContainsString("${location1}+${location2}", $output);
+        $this->assertEquals(
+            sprintf(
+                "Bucket '%s' created in '%s' and '%s'",
+                $bucketName,
+                $region1,
+                $region2
+            ),
+            $output
+        );
+        $this->assertEquals($location, $info['location']);
+        $this->assertArrayHasKey('customPlacementConfig', $info);
+        $this->assertArrayHasKey('dataLocations', $info['customPlacementConfig']);
+        $this->assertContains($region1, $info['customPlacementConfig']['dataLocations']);
+        $this->assertContains($region2, $info['customPlacementConfig']['dataLocations']);
     }
 
     public function testObjectCsekToCmek()


### PR DESCRIPTION
Fixing sample for dual region bucket creation

Fixes: 
https://github.com/googleapis/google-cloud-php/issues/5313
and
https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1645

# Tests

```
php-docs-samples/storage % php src/create_bucket_dual_region.php 'samples-create-bucket-dual-region-xyz12321' 'US' 'US-EAST1' 'US-WEST1'
Created dual-region bucket 'samples-create-bucket-dual-region-xyz12321' in 'US-EAST1+US-WEST1'
php-docs-samples/storage %
```

Shows up as:
<img width="947" alt="Screenshot 2022-07-29 at 11 03 08" src="https://user-images.githubusercontent.com/7369612/181689504-f08c5b65-8308-4a97-a5cd-e566efe831b6.png">

