### PR TITLE
feat(Spanner): Added samples for PG JSONB

### DIFF
--- a/spanner/src/pg_add_jsonb_column.php
+++ b/spanner/src/pg_add_jsonb_column.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/spanner/README.md
+ */
+
+namespace Google\Cloud\Samples\Spanner;
+
+// [START spanner_postgresql_jsonb_add_column]
+use Google\Cloud\Spanner\SpannerClient;
+
+/**
+ * Add a JSONB column to a table present in a PG Spanner database.
+ *
+ * @param string $instanceId The Spanner instance ID.
+ * @param string $databaseId The Spanner database ID.
+ * @param string $tableName The table in which the column needs to be added.
+ */
+function pg_add_jsonb_column(
+    string $instanceId,
+    string $databaseId,
+    string $tableName = 'Venues'
+): void {
+    $spanner = new SpannerClient();
+    $instance = $spanner->instance($instanceId);
+    $database = $instance->database($databaseId);
+
+    $operation = $database->updateDdl(
+        sprintf('ALTER TABLE %s ADD COLUMN VenueDetails JSONB', $tableName)
+    );
+
+    print('Waiting for operation to complete...' . PHP_EOL);
+    $operation->pollUntilComplete();
+
+    print(sprintf('Added column VenueDetails on table %s.', $tableName) . PHP_EOL);
+}
+// [END spanner_postgresql_jsonb_add_column]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/spanner/src/pg_jsonb_query_parameter.php
+++ b/spanner/src/pg_jsonb_query_parameter.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/spanner/README.md
+ */
+
+namespace Google\Cloud\Samples\Spanner;
+
+// [START spanner_postgresql_jsonb_query_parameter]
+
+use Google\Cloud\Spanner\Database;
+use Google\Cloud\Spanner\SpannerClient;
+
+/**
+ * Query data to a jsonb column in a PostgreSQL table.
+ *
+ * @param string $instanceId The Spanner instance ID.
+ * @param string $databaseId The Spanner database ID.
+ * @param string $tableName The table from which the data needs to be queried.
+ */
+function pg_jsonb_query_parameter(string $instanceId, string $databaseId, string $tableName = 'Venues'): void
+{
+    $spanner = new SpannerClient();
+    $instance = $spanner->instance($instanceId);
+    $database = $instance->database($databaseId);
+
+    $results = $database->execute(
+        sprintf('SELECT venueid, venuedetails FROM %s', $tableName) .
+        " WHERE CAST(venuedetails ->> 'rating' AS INTEGER) > $1",
+        [
+        'parameters' => [
+            'p1' => 2
+        ],
+        'types' => [
+            'p1' => Database::TYPE_INT64
+        ]
+    ]);
+
+    foreach ($results as $row) {
+        printf('VenueId: %s, VenueDetails: %s' . PHP_EOL, $row['venueid'], $row['venuedetails']);
+    }
+}
+// [END spanner_postgresql_jsonb_query_parameter]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/spanner/src/pg_jsonb_query_parameter.php
+++ b/spanner/src/pg_jsonb_query_parameter.php
@@ -35,8 +35,11 @@ use Google\Cloud\Spanner\SpannerClient;
  * @param string $databaseId The Spanner database ID.
  * @param string $tableName The table from which the data needs to be queried.
  */
-function pg_jsonb_query_parameter(string $instanceId, string $databaseId, string $tableName = 'Venues'): void
-{
+function pg_jsonb_query_parameter(
+    string $instanceId,
+    string $databaseId,
+    string $tableName = 'Venues'
+): void {
     $spanner = new SpannerClient();
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);

--- a/spanner/src/pg_jsonb_update_data.php
+++ b/spanner/src/pg_jsonb_update_data.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/spanner/README.md
+ */
+
+namespace Google\Cloud\Samples\Spanner;
+
+// [START spanner_postgresql_jsonb_update_data]
+use Google\Cloud\Spanner\SpannerClient;
+
+/**
+ * Insert/update data in a JSONB column in a Postgres table.
+ *
+ * @param string $instanceId The Spanner instance ID.
+ * @param string $databaseId The Spanner database ID.
+ * @param string $tableName The table in which the data needs to be updated.
+ */
+function pg_jsonb_update_data(
+    string $instanceId,
+    string $databaseId,
+    string $tableName = 'Venues'
+): void {
+    $spanner = new SpannerClient();
+    $instance = $spanner->instance($instanceId);
+    $database = $instance->database($databaseId);
+
+    $database->insertOrUpdateBatch($tableName, [
+        [
+            'VenueId' => 1,
+            'VenueDetails' => '{"rating": 9, "open": true}'
+        ],
+        [
+            'VenueId' => 4,
+            'VenueDetails' => json_encode([
+                [
+                    'name' => null,
+                    'available' => true
+                ],
+                // PG JSONB sorts first by key length and then lexicographically with
+                // equivalent key length and takes the last value in the case of duplicate keys
+                [
+                    'name' => 'room 2',
+                    'available' => false,
+                    'name' => 'room 3'
+                ],
+                [
+                    'main hall' => [
+                        'description' => 'this is the biggest space',
+                        'size' => 200
+                    ]
+                ]
+            ])
+        ],
+        [
+            'VenueId' => 42,
+            'VenueDetails' => $spanner->pgJsonb([
+                'name' => null,
+                'open' => [
+                    'Monday' => true,
+                    'Tuesday' => false
+                ],
+                'tags' => ['large', 'airy'],
+            ])
+        ]
+    ]);
+
+    print(sprintf('Inserted/updated 3 rows in table %s', $tableName) . PHP_EOL);
+}
+// [END spanner_postgresql_jsonb_update_data]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/spanner/test/spannerPgTest.php
+++ b/spanner/test/spannerPgTest.php
@@ -22,20 +22,15 @@ use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use Google\Cloud\TestUtils\TestTrait;
-use PHPUnitRetry\RetryTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @retryAttempts 3
- * @retryDelayMethod exponentialBackoff
- */
 class spannerPgTest extends TestCase
 {
     use TestTrait {
         TestTrait::runFunctionSnippet as traitRunFunctionSnippet;
     }
 
-    use RetryTrait, EventuallyConsistentTestTrait;
+    use EventuallyConsistentTestTrait;
 
     /** @var string instanceId */
     protected static $instanceId;
@@ -285,6 +280,19 @@ class spannerPgTest extends TestCase
         self::$lastUpdateDataTimestamp = time();
 
         $this->assertStringContainsString(sprintf('Inserted/updated 3 rows in table %s', self::$jsonbTable), $output);
+    }
+
+    /**
+     * @depends testJsonbUpdateData
+     */
+    public function testJsonbQueryParam()
+    {
+        $output = $this->runFunctionSnippet('pg_jsonb_query_parameter', [
+            self::$instanceId, self::$databaseId, self::$jsonbTable
+        ]);
+        self::$lastUpdateDataTimestamp = time();
+
+        $this->assertEquals('VenueId: 1, VenueDetails: {"open": true, "rating": 9}' . PHP_EOL, $output);
     }
 
     /**

--- a/spanner/test/spannerPgTest.php
+++ b/spanner/test/spannerPgTest.php
@@ -49,6 +49,9 @@ class spannerPgTest extends TestCase
     /** @var $lastUpdateData int */
     protected static $lastUpdateDataTimestamp;
 
+    /** @var $jsonbTable string */
+    protected static $jsonbTable;
+
     public static function setUpBeforeClass(): void
     {
         self::checkProjectEnvVars();
@@ -243,6 +246,45 @@ class spannerPgTest extends TestCase
         $this->assertStringContainsString('Inserted 1 venue(s).', $output);
         $this->assertStringContainsString('Inserted 1 venue(s) with NULL revenue.', $output);
         $this->assertStringContainsString('Inserted 1 venue(s) with NaN revenue.', $output);
+    }
+
+    /**
+     * @depends testCreateDatabase
+     */
+    public function testJsonbAddColumn()
+    {
+        self::$jsonbTable = 'Venues' . time() . rand();
+
+        // Create the table for our JSONB tests.
+        $database = self::$instance->database(self::$databaseId);
+        $op = $database->updateDdl(
+            sprintf('CREATE TABLE %s (
+                VenueId  bigint NOT NULL PRIMARY KEY
+            )', self::$jsonbTable)
+        );
+
+        $op->pollUntilComplete();
+
+        // Now run the test
+        $output = $this->runFunctionSnippet('pg_add_jsonb_column', [
+            self::$instanceId, self::$databaseId, self::$jsonbTable
+        ]);
+        self::$lastUpdateDataTimestamp = time();
+
+        $this->assertStringContainsString(sprintf('Added column VenueDetails on table %s.', self::$jsonbTable), $output);
+    }
+
+    /**
+     * @depends testJsonbAddColumn
+     */
+    public function testJsonbUpdateData()
+    {
+        $output = $this->runFunctionSnippet('pg_jsonb_update_data', [
+            self::$instanceId, self::$databaseId, self::$jsonbTable
+        ]);
+        self::$lastUpdateDataTimestamp = time();
+
+        $this->assertStringContainsString(sprintf('Inserted/updated 3 rows in table %s', self::$jsonbTable), $output);
     }
 
     /**


### PR DESCRIPTION
Note: Removed the RetryTrait as I think it is used in the backups tests mostly. Using it here adds to the quota of Admin calls.
We can re-add it if we feel it is required.