### PR TITLE
feat(Spanner): Run backup tests only when requested explicitly

### DIFF
--- a/spanner/test/spannerBackupTest.php
+++ b/spanner/test/spannerBackupTest.php
@@ -72,6 +72,9 @@ class spannerBackupTest extends TestCase
         if (!extension_loaded('grpc')) {
             self::markTestSkipped('Must enable grpc extension.');
         }
+        if ('true' !== getenv('GOOGLE_SPANNER_RUN_BACKUP_TESTS')) {
+            self::markTestSkipped('Skipping backup tests.');
+        }
         self::$instanceId = self::requireEnv('GOOGLE_SPANNER_INSTANCE_ID');
 
         $spanner = new SpannerClient([

--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -85,12 +85,19 @@ FILES_CHANGED=$(git diff --name-only HEAD $(git merge-base HEAD master))
 if [ -z "$PULL_REQUEST_NUMBER" ]; then
     RUN_ALL_TESTS=1
 else
+    labels=$(curl "https://api.github.com/repos/GoogleCloudPlatform/php-docs-samples/issues/$PULL_REQUEST_NUMBER/labels")
+    
     # Check to see if the repo includes the "kokoro:run-all" label
-    if curl "https://api.github.com/repos/GoogleCloudPlatform/php-docs-samples/issues/$PULL_REQUEST_NUMBER/labels" \
-        | grep -q "kokoro:run-all"; then
+    if  grep -q "kokoro:run-all" <<< $labels; then
         RUN_ALL_TESTS=1
     else
         RUN_ALL_TESTS=0
+    fi
+
+    # Check to see if the repo includes the "spanner:run-backup-tests" label
+    # If we intend to run the backup tests in Spanner, we set the env variable
+    if grep -q "spanner:run-backup-tests" <<< $labels; then
+        export GOOGLE_SPANNER_RUN_BACKUP_TESTS=true
     fi
 
 fi


### PR DESCRIPTION
This aims to run the Backup tests only when requested. That will be recognised by the presence of a label `spanner:run-backup-tests` on the PR.

If the label isn't present, the backup tests will be skipped.

Otherwise they will be run.

This will heavily help in the frequent quota errors we are seeing in spanner related PRs.