### PR TITLE
fix (bigquery): add order into test query

### DIFF
--- a/bigquery/api/test/bigqueryTest.php
+++ b/bigquery/api/test/bigqueryTest.php
@@ -266,7 +266,10 @@ class FunctionsTest extends TestCase
     public function testRunQuery()
     {
         $query = 'SELECT corpus, COUNT(*) as unique_words
-            FROM `publicdata.samples.shakespeare` GROUP BY corpus LIMIT 10';
+            FROM `publicdata.samples.shakespeare`
+            GROUP BY corpus
+            ORDER BY unique_words DESC
+            LIMIT 10';
 
         $output = $this->runSnippet('run_query', [$query]);
         $this->assertStringContainsString('hamlet', $output);


### PR DESCRIPTION
From latest builds, [ref](https://source.cloud.google.com/results/invocations/d79d96e9-00a9-4e6b-a011-3cdebb3a7c9b/targets/cloud-devrel%2Fphp-docs-samples%2Fpresubmit%2Fphp73/log) it seems bigquery tests are breaking and hence all downstream tests.

The tests were failing because it queries grouped counts of values in `publicdata.samples.shakespeare`. Since, there's no order as of today expected fields are not showing up. There has been no change in pubic dataset, so I added an ordering to make the tests reliable.

