### PR TITLE
Use binary-only images for installing Composer

### DIFF
--- a/cloud_sql/sqlserver/pdo/Dockerfile
+++ b/cloud_sql/sqlserver/pdo/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/google_appengine/php72
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:latest-bin /composer /usr/local/bin/composer
 
 COPY . .
 


### PR DESCRIPTION
See: https://blog.codito.dev/2022/11/composer-binary-only-docker-images/
