### PR TITLE
chore: add PHP codesniffer and fix errors/warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   styles:
+    name: PHP CS Fixer
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -14,11 +15,29 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.0'
-
     - name: Run Script
       run: testing/run_cs_check.sh
 
+  styles2:
+      name: PHP Code Sniffer
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+      - name: Install Dependencies
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: composer global require squizlabs/php_codesniffer
+      - name: Run PHPCS Code Style Checker
+        run: ~/.composer/vendor/bin/phpcs --standard=phpcs-ruleset.xml -p -s
+
   staticanalysis:
+      name: PHPStan Static Analysis
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/analyticsdata/src/run_report_with_dimension_and_metric_filters.php
+++ b/analyticsdata/src/run_report_with_dimension_and_metric_filters.php
@@ -96,7 +96,7 @@ function run_report_with_dimension_and_metric_filters(string $propertyId)
                                 'value' => 'in_app_purchase',
                             ])
                         ])
-                   ]),
+                    ]),
                 ],
             ]),
         ]),

--- a/analyticsdata/test/quickstartTest.php
+++ b/analyticsdata/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\AnalyticsData\Test;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/asset/src/batch_get_assets_history.php
+++ b/asset/src/batch_get_assets_history.php
@@ -30,7 +30,12 @@ function batch_get_assets_history(string $projectId, array $assetNames)
     $contentType = ContentType::RESOURCE;
     $readTimeWindow = new TimeWindow(['start_time' => new Timestamp(['seconds' => time()])]);
 
-    $resp = $client->batchGetAssetsHistory($formattedParent, $contentType, $readTimeWindow, ['assetNames' => $assetNames]);
+    $resp = $client->batchGetAssetsHistory(
+        $formattedParent,
+        $contentType,
+        $readTimeWindow,
+        ['assetNames' => $assetNames]
+    );
 
     # Do things with response.
     print($resp->serializeToString());

--- a/auth/src/auth_http_explicit.php
+++ b/auth/src/auth_http_explicit.php
@@ -41,7 +41,8 @@ function auth_http_explicit($projectId, $serviceAccountPath)
     # and Google Auth library's ServiceAccountCredentials class.
     $serviceAccountCredentials = new ServiceAccountCredentials(
         'https://www.googleapis.com/auth/cloud-platform',
-        $serviceAccountPath);
+        $serviceAccountPath
+    );
     $middleware = new AuthTokenMiddleware($serviceAccountCredentials);
     $stack = HandlerStack::create();
     $stack->push($middleware);

--- a/auth/src/auth_http_implicit.php
+++ b/auth/src/auth_http_implicit.php
@@ -38,7 +38,8 @@ function auth_http_implicit($projectId)
     # Get the credentials and project ID from the environment using Google Auth
     # library's ApplicationDefaultCredentials class.
     $middleware = ApplicationDefaultCredentials::getMiddleware(
-        'https://www.googleapis.com/auth/cloud-platform');
+        'https://www.googleapis.com/auth/cloud-platform'
+    );
     $stack = HandlerStack::create();
     $stack->push($middleware);
 

--- a/bigquery/api/src/dry_run_query.php
+++ b/bigquery/api/src/dry_run_query.php
@@ -30,7 +30,8 @@ use Google\Cloud\BigQuery\BigQueryClient;
  * Dry runs the given query
  *
  * @param string $projectId The project Id of your Google Cloud Project.
- * @param string $query The query to be run. For eg: $query = 'SELECT id, view_count FROM `bigquery-public-data.stackoverflow.posts_questions`'
+ * @param string $query The query to be run. For eg:
+ *                      'SELECT id, view_count FROM `bigquery-public-data.stackoverflow.posts_questions`'
  */
 function dry_run_query(string $projectId, string $query): void
 {

--- a/bigquery/api/src/import_from_storage_json_truncate.php
+++ b/bigquery/api/src/import_from_storage_json_truncate.php
@@ -46,7 +46,9 @@ function import_from_storage_json_truncate(
 
     // create the import job
     $gcsUri = 'gs://cloud-samples-data/bigquery/us-states/us-states.json';
-    $loadConfig = $table->loadFromStorage($gcsUri)->sourceFormat('NEWLINE_DELIMITED_JSON')->writeDisposition('WRITE_TRUNCATE');
+    $loadConfig = $table->loadFromStorage($gcsUri)
+        ->sourceFormat('NEWLINE_DELIMITED_JSON')
+        ->writeDisposition('WRITE_TRUNCATE');
     $job = $table->runJob($loadConfig);
 
     // check if the job is complete

--- a/bigquery/stackoverflow/test/stackoverflowTest.php
+++ b/bigquery/stackoverflow/test/stackoverflowTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\BigQuery\StackOverflow\Test;
+
 use PHPUnit\Framework\TestCase;
 
 class stackoverflowTest extends TestCase

--- a/bigquerydatatransfer/test/quickstartTest.php
+++ b/bigquerydatatransfer/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\BigQueryDataTransfer\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 class quickstartTest extends TestCase

--- a/bigtable/src/create_app_profile.php
+++ b/bigtable/src/create_app_profile.php
@@ -34,7 +34,8 @@ use Google\ApiCore\ApiException;
  *
  * @param string $projectId The Google Cloud project ID
  * @param string $instanceId The ID of the Bigtable instance
- * @param string $clusterId The ID of the cluster where the new App Profile will route it's requests(in case of single cluster routing)
+ * @param string $clusterId The ID of the cluster where the new App Profile will route it's requests
+ *                          (in case of single cluster routing)
  * @param string $appProfileId The ID of the App Profile to create
  */
 function create_app_profile(
@@ -52,7 +53,8 @@ function create_app_profile(
     ]);
 
     // create a new routing policy
-    // allow_transactional_writes refers to Single-Row-Transactions(https://cloud.google.com/bigtable/docs/app-profiles#single-row-transactions)
+    // allow_transactional_writes refers to Single-Row-Transactions
+    // (https://cloud.google.com/bigtable/docs/app-profiles#single-row-transactions)
     $routingPolicy = new SingleClusterRouting([
         'cluster_id' => $clusterId,
         'allow_transactional_writes' => false

--- a/bigtable/src/delete_app_profile.php
+++ b/bigtable/src/delete_app_profile.php
@@ -46,7 +46,8 @@ function delete_app_profile(
     printf('Deleting the App Profile: %s' . PHP_EOL, $appProfileId);
 
     try {
-        // If $ignoreWarnings is set to false, Bigtable will warn you that all future requests using the AppProfile will fail
+        // If $ignoreWarnings is set to false, Bigtable will warn you that all
+        // future requests using the AppProfile will fail
         $instanceAdminClient->deleteAppProfile($appProfileName, $ignoreWarnings);
         printf('App Profile %s deleted.' . PHP_EOL, $appProfileId);
     } catch (ApiException $e) {

--- a/bigtable/src/filter_composing_chain.php
+++ b/bigtable/src/filter_composing_chain.php
@@ -54,7 +54,8 @@ function filter_composing_chain(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_composing_condition.php
+++ b/bigtable/src/filter_composing_condition.php
@@ -58,7 +58,8 @@ function filter_composing_condition(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_composing_interleave.php
+++ b/bigtable/src/filter_composing_interleave.php
@@ -54,7 +54,8 @@ function filter_composing_interleave(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_block_all.php
+++ b/bigtable/src/filter_limit_block_all.php
@@ -52,7 +52,8 @@ function filter_limit_block_all(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_cells_per_col.php
+++ b/bigtable/src/filter_limit_cells_per_col.php
@@ -52,7 +52,8 @@ function filter_limit_cells_per_col(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_cells_per_row.php
+++ b/bigtable/src/filter_limit_cells_per_row.php
@@ -52,7 +52,8 @@ function filter_limit_cells_per_row(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_cells_per_row_offset.php
+++ b/bigtable/src/filter_limit_cells_per_row_offset.php
@@ -52,7 +52,8 @@ function filter_limit_cells_per_row_offset(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_col_family_regex.php
+++ b/bigtable/src/filter_limit_col_family_regex.php
@@ -52,7 +52,8 @@ function filter_limit_col_family_regex(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_col_qualifier_regex.php
+++ b/bigtable/src/filter_limit_col_qualifier_regex.php
@@ -52,7 +52,8 @@ function filter_limit_col_qualifier_regex(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_col_range.php
+++ b/bigtable/src/filter_limit_col_range.php
@@ -55,7 +55,8 @@ function filter_limit_col_range(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_pass_all.php
+++ b/bigtable/src/filter_limit_pass_all.php
@@ -52,7 +52,8 @@ function filter_limit_pass_all(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_row_regex.php
+++ b/bigtable/src/filter_limit_row_regex.php
@@ -52,7 +52,8 @@ function filter_limit_row_regex(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_row_sample.php
+++ b/bigtable/src/filter_limit_row_sample.php
@@ -52,7 +52,8 @@ function filter_limit_row_sample(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_timestamp_range.php
+++ b/bigtable/src/filter_limit_timestamp_range.php
@@ -59,7 +59,8 @@ function filter_limit_timestamp_range(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_value_range.php
+++ b/bigtable/src/filter_limit_value_range.php
@@ -55,7 +55,8 @@ function filter_limit_value_range(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_limit_value_regex.php
+++ b/bigtable/src/filter_limit_value_regex.php
@@ -52,7 +52,8 @@ function filter_limit_value_regex(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_modify_apply_label.php
+++ b/bigtable/src/filter_modify_apply_label.php
@@ -52,7 +52,8 @@ function filter_modify_apply_label(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/filter_modify_strip_value.php
+++ b/bigtable/src/filter_modify_strip_value.php
@@ -52,7 +52,8 @@ function filter_modify_strip_value(
     ]);
 
     foreach ($rows as $key => $row) {
-        // The "print_row" helper function is defined in https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
+        // The "print_row" helper function is defined in
+        // https://cloud.google.com/bigtable/docs/samples/bigtable-reads-print
         print_row($key, $row);
     }
 }

--- a/bigtable/src/get_cluster.php
+++ b/bigtable/src/get_cluster.php
@@ -58,12 +58,15 @@ function get_cluster(
     printf('Printing Details:' . PHP_EOL);
 
     // Fetch some commonly used metadata
-    printf('Name: ' . $cluster->getName() . PHP_EOL);
-    printf('Location: ' . $cluster->getLocation() . PHP_EOL);
-    printf('State: ' . State::name($cluster->getState()) . PHP_EOL);
-    printf('Default Storage Type: ' . StorageType::name($cluster->getDefaultStorageType()) . PHP_EOL);
-    printf('Nodes: ' . $cluster->getServeNodes() . PHP_EOL);
-    printf('Encryption Config: ' . ($cluster->hasEncryptionConfig() ? $cluster->getEncryptionConfig()->getKmsKeyName() : 'N/A') . PHP_EOL);
+    printf('Name: %s' . PHP_EOL, $cluster->getName());
+    printf('Location: %s' . PHP_EOL, $cluster->getLocation());
+    printf('State: %s' . PHP_EOL, State::name($cluster->getState()));
+    printf('Default Storage Type: %s' . PHP_EOL, StorageType::name($cluster->getDefaultStorageType()));
+    printf('Nodes: %s' . PHP_EOL, $cluster->getServeNodes());
+    printf(
+        'Encryption Config: %s' . PHP_EOL,
+        $cluster->hasEncryptionConfig() ? $cluster->getEncryptionConfig()->getKmsKeyName() : 'N/A'
+    );
 }
 // [END bigtable_get_cluster]
 

--- a/bigtable/src/get_iam_policy.php
+++ b/bigtable/src/get_iam_policy.php
@@ -41,7 +41,8 @@ function get_iam_policy(
     $instanceName = $instanceAdminClient->instanceName($projectId, $instanceId);
 
     try {
-        // we could instantiate the BigtableTableAdminClient and pass the tableName to get the IAM policy for the table resource as well.
+        // we could instantiate the BigtableTableAdminClient and pass the
+        // tableName to get the IAM policy for the table resource as well.
         $iamPolicy = $instanceAdminClient->getIamPolicy($instanceName);
 
         printf($iamPolicy->getVersion() . PHP_EOL);

--- a/bigtable/src/get_instance.php
+++ b/bigtable/src/get_instance.php
@@ -67,7 +67,10 @@ function get_instance(
     // Labels are an object of the MapField class which implement the IteratorAggregate, Countable
     // and ArrayAccess interfaces so you can do the following:
     printf("\tNum of Labels: " . $labels->count() . PHP_EOL);
-    printf("\tLabel with a key(dev-label): " . ($labels->offsetExists('dev-label') ? $labels['dev-label'] : 'N/A') . PHP_EOL);
+    printf(
+        "\tLabel with a key(dev-label): %s\n",
+        $labels->offsetExists('dev-label') ? $labels['dev-label'] : 'N/A'
+    );
 
     // we can even loop over all the labels
     foreach ($labels as $key => $val) {

--- a/bigtable/src/set_iam_policy.php
+++ b/bigtable/src/set_iam_policy.php
@@ -35,7 +35,8 @@ use Google\Cloud\Iam\V1\Policy;
  * @param string $projectId The Google Cloud project ID
  * @param string $instanceId The ID of the Bigtable instance
  * @param string $email The email of the member to be assigned the role(Format: 'user:EMAIL_ID')
- * @param string $role The role to be assigned. For a list of roles check out https://cloud.google.com/bigtable/docs/access-control
+ * @param string $role The role to be assigned. For a list of roles check out
+ *                     https://cloud.google.com/bigtable/docs/access-control
  */
 function set_iam_policy(
     string $projectId,

--- a/bigtable/src/update_app_profile.php
+++ b/bigtable/src/update_app_profile.php
@@ -35,7 +35,8 @@ use Google\Protobuf\FieldMask;
  *
  * @param string $projectId The Google Cloud project ID
  * @param string $instanceId The ID of the Bigtable instance
- * @param string $clusterId The ID of the new cluster where the new App Profile will route it's requests(in case of single cluster routing)
+ * @param string $clusterId The ID of the new cluster where the new App Profile will route it's
+ *                          requests (in case of single cluster routing).
  * @param string $appProfileId The ID of the App Profile to update
  */
 function update_app_profile(
@@ -53,7 +54,8 @@ function update_app_profile(
     ]);
 
     // create a new routing policy
-    // allow_transactional_writes refers to Single-Row-Transactions(https://cloud.google.com/bigtable/docs/app-profiles#single-row-transactions)
+    // allow_transactional_writes refers to Single-Row-Transactions
+    // (https://cloud.google.com/bigtable/docs/app-profiles#single-row-transactions)
     $routingPolicy = new SingleClusterRouting([
         'cluster_id' => $clusterId,
         'allow_transactional_writes' => true
@@ -79,7 +81,11 @@ function update_app_profile(
         // Bigtable warns you while updating the routing policy, or when toggling the allow_transactional_writes
         // to force it to update, we set ignoreWarnings to true.
         // If you just want to update something simple like description, you can remove it.
-        $operationResponse = $instanceAdminClient->updateAppProfile($appProfile, $updateMask, ['ignoreWarnings' => true]);
+        $operationResponse = $instanceAdminClient->updateAppProfile(
+            $appProfile,
+            $updateMask,
+            ['ignoreWarnings' => true]
+        );
 
         $operationResponse->pollUntilComplete();
         if ($operationResponse->operationSucceeded()) {

--- a/cdn/signUrl.php
+++ b/cdn/signUrl.php
@@ -41,7 +41,7 @@ function base64url_decode($input)
 function base64url_encode($input, $padding = true)
 {
     $output = strtr(base64_encode($input), '+/', '-_');
-    return ($padding) ? $output : str_replace('=', '',  $output);
+    return ($padding) ? $output : str_replace('=', '', $output);
 }
 
 /**

--- a/cdn/test/signUrlTest.php
+++ b/cdn/test/signUrlTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Cdn\Test;
+
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../signUrl.php';
@@ -28,7 +30,10 @@ class signUrlTest extends TestCase
 
     public function testBase64UrlEncodeWithoutPadding()
     {
-        $this->assertEquals(base64url_encode(hex2bin('9d9b51a2174d17d9b770a336e0870ae3'), false), 'nZtRohdNF9m3cKM24IcK4w');
+        $this->assertEquals(
+            base64url_encode(hex2bin('9d9b51a2174d17d9b770a336e0870ae3'), false),
+            'nZtRohdNF9m3cKM24IcK4w'
+        );
     }
 
     public function testBase64UrlDecode()
@@ -45,14 +50,27 @@ class signUrlTest extends TestCase
     {
         $encoded_key = 'nZtRohdNF9m3cKM24IcK4w=='; // base64url encoded key
 
-        $cases = array(
-            array('http://35.186.234.33/index.html', 'my-key', 1558131350,
-                  'http://35.186.234.33/index.html?Expires=1558131350&KeyName=my-key&Signature=fm6JZSmKNsB5sys8VGr-JE4LiiE='),
-            array('https://www.google.com/', 'my-key', 1549751401,
-                  'https://www.google.com/?Expires=1549751401&KeyName=my-key&Signature=M_QO7BGHi2sGqrJO-MDr0uhDFuc='),
-            array('https://www.example.com/some/path?some=query&another=param', 'my-key', 1549751461,
-                  'https://www.example.com/some/path?some=query&another=param&Expires=1549751461&KeyName=my-key&Signature=sTqqGX5hUJmlRJ84koAIhWW_c3M='),
-        );
+        $cases = [
+            [   'http://35.186.234.33/index.html',
+                'my-key',
+                1558131350,
+                'http://35.186.234.33/index.html?Expires=1558131350&KeyName=my-key'
+                    . '&Signature=fm6JZSmKNsB5sys8VGr-JE4LiiE='
+            ],
+            [
+                'https://www.google.com/',
+                'my-key',
+                1549751401,
+                'https://www.google.com/?Expires=1549751401&KeyName=my-key&Signature=M_QO7BGHi2sGqrJO-MDr0uhDFuc='
+            ],
+            [
+                'https://www.example.com/some/path?some=query&another=param',
+                'my-key',
+                1549751461,
+                'https://www.example.com/some/path?some=query&another=param&Expires=1549751461&KeyName=my-key'
+                    . '&Signature=sTqqGX5hUJmlRJ84koAIhWW_c3M='
+            ],
+        ];
 
         foreach ($cases as $c) {
             $this->assertEquals(sign_url($c[0], $c[1], $encoded_key, $c[2]), $c[3]);

--- a/compute/api-client/helloworld/app.php
+++ b/compute/api-client/helloworld/app.php
@@ -336,7 +336,7 @@ if ($client->getAccessToken()) {
 
       <?php if (isset($getInstanceWithMetadataMarkup)): ?>
         <div id="getInstanceWithMetadata">
-          <?php print $getInstanceWithMetadataMarkup ?>
+            <?php print $getInstanceWithMetadataMarkup ?>
         </div>
       <?php endif ?>
 
@@ -350,7 +350,7 @@ if ($client->getAccessToken()) {
 
       <?php if (isset($deleteInstanceWithMetadataMarkup)): ?>
         <div id="deleteInstanceWithMetadata">
-          <?php print $deleteInstanceWithMetadataMarkup ?>
+            <?php print $deleteInstanceWithMetadataMarkup ?>
         </div>
       <?php endif ?>
 
@@ -360,7 +360,7 @@ if ($client->getAccessToken()) {
 
       <?php if (isset($insertInstanceWithMetadataMarkup)): ?>
         <div id="insertInstanceWithMetadata">
-          <?php print $insertInstanceWithMetadataMarkup?>
+            <?php print $insertInstanceWithMetadataMarkup?>
         </div>
       <?php endif ?>
 
@@ -374,7 +374,7 @@ if ($client->getAccessToken()) {
         } else {
             print "<a class='logout' href='?logout'>Logout</a>";
         }
-      ?>
+        ?>
     </div>
   </body>
 </html>

--- a/compute/cloud-client/firewall/src/list_firewall_rules.php
+++ b/compute/cloud-client/firewall/src/list_firewall_rules.php
@@ -42,7 +42,12 @@ function list_firewall_rules(string $projectId)
 
     print('--- Firewall Rules ---' . PHP_EOL);
     foreach ($firewallList->iterateAllElements() as $firewall) {
-        printf(' -  %s : %s : %s' . PHP_EOL, $firewall->getName(), $firewall->getDescription(), $firewall->getNetwork());
+        printf(
+            ' -  %s : %s : %s' . PHP_EOL,
+            $firewall->getName(),
+            $firewall->getDescription(),
+            $firewall->getNetwork()
+        );
     }
 }
 # [END compute_firewall_list]

--- a/compute/cloud-client/firewall/src/print_firewall_rule.php
+++ b/compute/cloud-client/firewall/src/print_firewall_rule.php
@@ -52,12 +52,12 @@ function print_firewall_rule(string $projectId, string $firewallRuleName)
     print('--Allowed--' . PHP_EOL);
     foreach ($response->getAllowed() as $item) {
         printf('Protocol: %s' . PHP_EOL, $item->getIPProtocol());
-        foreach ($item->getPorts()as $ports) {
+        foreach ($item->getPorts() as $ports) {
             printf(' - Ports: %s' . PHP_EOL, $ports);
         }
     }
     print('--Source Ranges--' . PHP_EOL);
-    foreach ($response->getSourceRanges()as $ranges) {
+    foreach ($response->getSourceRanges() as $ranges) {
         printf(' - Range: %s' . PHP_EOL, $ranges);
     }
 }

--- a/compute/cloud-client/firewall/test/firewallTest.php
+++ b/compute/cloud-client/firewall/test/firewallTest.php
@@ -129,7 +129,7 @@ class firewallTest extends TestCase
                 'projectId' => self::$projectId,
                 'firewallRuleName' => self::$firewallRuleName
             ]);
-            $this->assertStringContainsString('Rule ' . self::$firewallRuleName . ' deleted',  $output);
+            $this->assertStringContainsString('Rule ' . self::$firewallRuleName . ' deleted', $output);
         } catch (ApiException $e) {
             if ($e->getCode() != 404) {
                 throw new ApiException($e->getMessage(), $e->getCode(), $e->getStatus());

--- a/compute/cloud-client/instances/src/disable_usage_export_bucket.php
+++ b/compute/cloud-client/instances/src/disable_usage_export_bucket.php
@@ -46,7 +46,11 @@ function disable_usage_export_bucket(string $projectId)
         printf('Compute Engine usage export bucket for project `%s` was disabled.', $projectId);
     } else {
         $error = $operation->getError();
-        printf('Failed to disable usage report bucket for project `%s`: %s' . PHP_EOL, $projectId, $error->getMessage());
+        printf(
+            'Failed to disable usage report bucket for project `%s`: %s' . PHP_EOL,
+            $projectId,
+            $error->getMessage()
+        );
     }
 }
 # [END compute_usage_report_disable]

--- a/compute/cloud-client/instances/src/start_instance_with_encryption_key.php
+++ b/compute/cloud-client/instances/src/start_instance_with_encryption_key.php
@@ -69,7 +69,12 @@ function start_instance_with_encryption_key(
         ->setDisks(array($diskData));
 
     // Start the instance with encrypted disk.
-    $operation = $instancesClient->startWithEncryptionKey($instanceName, $instancesStartWithEncryptionKeyRequest, $projectId, $zone);
+    $operation = $instancesClient->startWithEncryptionKey(
+        $instanceName,
+        $instancesStartWithEncryptionKeyRequest,
+        $projectId,
+        $zone
+    );
 
     // Wait for the operation to complete.
     $operation->pollUntilComplete();

--- a/compute/logging/test/loggingTest.php
+++ b/compute/logging/test/loggingTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Compute\Logging\Test;
+
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/mocks/FluentLogger.php';

--- a/datastore/api/test/ConceptsTest.php
+++ b/datastore/api/test/ConceptsTest.php
@@ -67,7 +67,8 @@ class ConceptsTest extends TestCase
             getenv('DATASTORE_EMULATOR_HOST') === false) {
             $this->markTestSkipped(
                 'No application credentials were found, also not using the '
-                . 'datastore emulator');
+                . 'datastore emulator'
+            );
         }
         self::$datastore = new DatastoreClient(
             array('namespaceId' => generateRandomString())
@@ -384,7 +385,8 @@ class ConceptsTest extends TestCase
                 self::assertEquals(2, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key2->path());
                 $this->assertTrue($entities[1]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testRunQuery()
@@ -415,7 +417,8 @@ class ConceptsTest extends TestCase
                 self::assertEquals(2, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key2->path());
                 $this->assertTrue($entities[1]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testRunGqlQuery()
@@ -446,7 +449,8 @@ class ConceptsTest extends TestCase
                 self::assertEquals(2, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key2->path());
                 $this->assertTrue($entities[1]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testPropertyFilter()
@@ -474,7 +478,8 @@ class ConceptsTest extends TestCase
                 }
                 self::assertEquals(1, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testCompositeFilter()
@@ -504,7 +509,8 @@ class ConceptsTest extends TestCase
                 }
                 self::assertEquals(1, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testKeyFilter()
@@ -530,7 +536,8 @@ class ConceptsTest extends TestCase
                 }
                 self::assertEquals(1, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testAscendingSort()
@@ -559,7 +566,8 @@ class ConceptsTest extends TestCase
                 self::assertEquals(2, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key2->path());
                 $this->assertTrue($entities[1]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testDescendingSort()
@@ -588,7 +596,8 @@ class ConceptsTest extends TestCase
                 self::assertEquals(2, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key2->path());
                 $this->assertTrue($entities[1]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testMultiSort()
@@ -629,7 +638,8 @@ class ConceptsTest extends TestCase
                 $this->assertEquals(4, $entities[2]['priority']);
                 $this->assertTrue($entities[0]['created'] > $entities[1]['created']);
                 $this->assertTrue($entities[1]['created'] < $entities[2]['created']);
-            });
+            }
+        );
     }
 
     public function testAncestorQuery()
@@ -677,7 +687,8 @@ class ConceptsTest extends TestCase
                 }
                 self::assertEquals(1, $num);
                 $this->assertTrue($entities[0]->key()->path() == $key1->path());
-            });
+            }
+        );
     }
 
     public function testKeysOnlyQuery()
@@ -1059,7 +1070,8 @@ class ConceptsTest extends TestCase
                 $this->assertEquals($taskKey->path(), $e->key()->path());
                 $this->assertEquals(
                     'learn eventual consistency',
-                    $e['description']);
+                    $e['description']
+                );
                 $num += 1;
             }
             self::assertEquals(1, $num);

--- a/dialogflow/dialogflow.php
+++ b/dialogflow/dialogflow.php
@@ -31,14 +31,29 @@ $application = new Application('Dialogflow');
 
 // detect text intent command
 $application->add((new Command('detect-intent-texts'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session. Defaults to random.')
-    ->addOption('language-code', 'l', InputOption::VALUE_REQUIRED,
-        'Language code of the query. Defaults to "en-US".', 'en-US')
-    ->addArgument('texts', InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-        'Text inputs.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session. Defaults to random.'
+    )
+    ->addOption(
+        'language-code',
+        'l',
+        InputOption::VALUE_REQUIRED,
+        'Language code of the query. Defaults to "en-US".',
+        'en-US'
+    )
+    ->addArgument(
+        'texts',
+        InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+        'Text inputs.'
+    )
     ->setDescription('Detect intent of text inputs using Dialogflow.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command detects the intent of provided text
@@ -54,17 +69,28 @@ EOF
         $languageCode = $input->getOption('language-code');
         $texts = $input->getArgument('texts');
         detect_intent_texts($projectId, $texts, $sessionId, $languageCode);
-    })
-);
+    }));
 
 // detect audio intent command
 $application->add((new Command('detect-intent-audio'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session. Defaults to random.')
-    ->addOption('language-code', 'l', InputOption::VALUE_REQUIRED,
-        'Language code of the query. Defaults to "en-US".', 'en-US')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session. Defaults to random.'
+    )
+    ->addOption(
+        'language-code',
+        'l',
+        InputOption::VALUE_REQUIRED,
+        'Language code of the query. Defaults to "en-US".',
+        'en-US'
+    )
     ->addArgument('path', InputArgument::REQUIRED, 'Path to audio file.')
     ->setDescription('Detect intent of audio file using Dialogflow.')
     ->setHelp(<<<EOF
@@ -81,17 +107,28 @@ EOF
         $languageCode = $input->getOption('language-code');
         $path = $input->getArgument('path');
         detect_intent_audio($projectId, $path, $sessionId, $languageCode);
-    })
-);
+    }));
 
 // detect stream intent command
 $application->add((new Command('detect-intent-stream'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session. Defaults to random.')
-    ->addOption('language-code', 'l', InputOption::VALUE_REQUIRED,
-        'Language code of the query. Defaults to "en-US".', 'en-US')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session. Defaults to random.'
+    )
+    ->addOption(
+        'language-code',
+        'l',
+        InputOption::VALUE_REQUIRED,
+        'Language code of the query. Defaults to "en-US".',
+        'en-US'
+    )
     ->addArgument('path', InputArgument::REQUIRED, 'Path to audio file.')
     ->setDescription('Detect intent of audio stream using Dialogflow.')
     ->setHelp(<<<EOF
@@ -108,13 +145,15 @@ EOF
         $languageCode = $input->getOption('language-code');
         $path = $input->getArgument('path');
         detect_intent_stream($projectId, $path, $sessionId, $languageCode);
-    })
-);
+    }));
 
 // list intent command
 $application->add((new Command('intent-list'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
     ->setDescription('List intents.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command lists intents.
@@ -125,20 +164,28 @@ EOF
     ->setCode(function ($input, $output) {
         $projectId = $input->getArgument('project-id');
         intent_list($projectId);
-    })
-);
+    }));
 
 // create intent command
 $application->add((new Command('intent-create'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addArgument('display-name', InputArgument::REQUIRED,
-        'Display name of intent.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addArgument(
+        'display-name',
+        InputArgument::REQUIRED,
+        'Display name of intent.'
+    )
     ->addOption('training-phrases-parts', 't', InputOption::VALUE_REQUIRED |
         InputOption::VALUE_IS_ARRAY, 'Training phrases.')
-    ->addOption('message-texts', 'm',
+    ->addOption(
+        'message-texts',
+        'm',
         InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-        'Message texts for the agent\'s response when the intent is detected.')
+        'Message texts for the agent\'s response when the intent is detected.'
+    )
     ->setDescription('Create intent of provided display name.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command creates intent of provided display name.
@@ -153,13 +200,15 @@ EOF
         $traingPhrases = $input->getOption('training-phrases-parts');
         $messageTexts = $input->getOption('message-texts');
         intent_create($projectId, $displayName, $traingPhrases, $messageTexts);
-    })
-);
+    }));
 
 // delete intent command
 $application->add((new Command('intent-delete'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
     ->addArgument('intent-id', InputArgument::REQUIRED, 'ID of intent.')
     ->setDescription('Delete intent of provided intent id.')
     ->setHelp(<<<EOF
@@ -172,13 +221,15 @@ EOF
         $projectId = $input->getArgument('project-id');
         $intentId = $input->getArgument('intent-id');
         intent_delete($projectId, $intentId);
-    })
-);
+    }));
 
 // list entity type command
 $application->add((new Command('entity-type-list'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
     ->setDescription('List entity types.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command lists entity types.
@@ -189,17 +240,27 @@ EOF
     ->setCode(function ($input, $output) {
         $projectId = $input->getArgument('project-id');
         entity_type_list($projectId);
-    })
-);
+    }));
 
 // create entity type command
 $application->add((new Command('entity-type-create'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addArgument('display-name', InputArgument::REQUIRED,
-        'Display name of the entity.')
-    ->addOption('kind', 'k', InputOption::VALUE_REQUIRED,
-        'Kind of entity. KIND_MAP (default) or KIND_LIST', Kind::KIND_MAP)
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addArgument(
+        'display-name',
+        InputArgument::REQUIRED,
+        'Display name of the entity.'
+    )
+    ->addOption(
+        'kind',
+        'k',
+        InputOption::VALUE_REQUIRED,
+        'Kind of entity. KIND_MAP (default) or KIND_LIST',
+        Kind::KIND_MAP
+    )
     ->setDescription('Create entity types with provided display name.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command creates entity type with provided name.
@@ -212,13 +273,15 @@ EOF
         $displayName = $input->getArgument('display-name');
         $kind = $input->getOption('kind');
         entity_type_create($projectId, $displayName, $kind);
-    })
-);
+    }));
 
 // delete entity type command
 $application->add((new Command('entity-type-delete'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
     ->addArgument('entity-type-id', InputArgument::REQUIRED, 'ID of entity type.')
     ->setDescription('Delete entity types of provided entity type id.')
     ->setHelp(<<<EOF
@@ -231,13 +294,15 @@ EOF
         $projectId = $input->getArgument('project-id');
         $entityTypeId = $input->getArgument('entity-type-id');
         entity_type_delete($projectId, $entityTypeId);
-    })
-);
+    }));
 
 // list entity command
 $application->add((new Command('entity-list'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
     ->addArgument('entity-type-id', InputArgument::REQUIRED, 'ID of entity type.')
     ->setDescription('List entities of provided entity type id.')
     ->setHelp(<<<EOF
@@ -250,17 +315,22 @@ EOF
         $projectId = $input->getArgument('project-id');
         $entityTypeId = $input->getArgument('entity-type-id');
         entity_list($projectId, $entityTypeId);
-    })
-);
+    }));
 
 // create entity command
 $application->add((new Command('entity-create'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
     ->addArgument('entity-type-id', InputArgument::REQUIRED, 'ID of entity type.')
     ->addArgument('entity-value', InputArgument::REQUIRED, 'Value of the entity.')
-    ->addArgument('synonyms', InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-        'Synonyms that will map to provided entity value.')
+    ->addArgument(
+        'synonyms',
+        InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+        'Synonyms that will map to provided entity value.'
+    )
     ->setDescription('Create entity value for entity type id.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command creates entity value for entity type id.
@@ -274,13 +344,15 @@ EOF
         $entityValue = $input->getArgument('entity-value');
         $synonyms = $input->getArgument('synonyms');
         entity_create($projectId, $entityTypeId, $entityValue, $synonyms);
-    })
-);
+    }));
 
 // delete entity command
 $application->add((new Command('entity-delete'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
     ->addArgument('entity-type-id', InputArgument::REQUIRED, 'ID of entity type.')
     ->addArgument('entity-value', InputArgument::REQUIRED, 'Value of the entity.')
     ->setDescription('Delete entity value from entity type id.')
@@ -295,15 +367,21 @@ EOF
         $entityTypeId = $input->getArgument('entity-type-id');
         $entityValue = $input->getArgument('entity-value');
         entity_delete($projectId, $entityTypeId, $entityValue);
-    })
-);
+    }));
 
 // list context command
 $application->add((new Command('context-list'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session.'
+    )
     ->setDescription('List contexts.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command lists contexts.
@@ -315,18 +393,29 @@ EOF
         $projectId = $input->getArgument('project-id');
         $sessionId = $input->getOption('session-id');
         context_list($projectId, $sessionId);
-    })
-);
+    }));
 
 // create context command
 $application->add((new Command('context-create'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session.'
+    )
     ->addArgument('context-id', InputArgument::REQUIRED, 'ID of the context.')
-    ->addOption('lifespan-count', 'c', InputOption::VALUE_REQUIRED,
-        'Lifespan count of the context. Defaults to 1.', 1)
+    ->addOption(
+        'lifespan-count',
+        'c',
+        InputOption::VALUE_REQUIRED,
+        'Lifespan count of the context. Defaults to 1.',
+        1
+    )
     ->setDescription('Create context of provided context id.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command creates context of provided context id.
@@ -341,15 +430,21 @@ EOF
         $contextId = $input->getArgument('context-id');
         $lifespan = $input->getOption('lifespan-count');
         context_create($projectId, $contextId, $sessionId, $lifespan);
-    })
-);
+    }));
 
 // delete context command
 $application->add((new Command('context-delete'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session.'
+    )
     ->addArgument('context-id', InputArgument::REQUIRED, 'ID of the context.')
     ->setDescription('Delete context of provided context id.')
     ->setHelp(<<<EOF
@@ -363,15 +458,21 @@ EOF
         $sessionId = $input->getOption('session-id');
         $contextId = $input->getArgument('context-id');
         context_delete($projectId, $contextId, $sessionId);
-    })
-);
+    }));
 
 // list session entity type command
 $application->add((new Command('session-entity-type-list'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session.'
+    )
     ->setDescription('List session entity types.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command lists session entity types.
@@ -383,22 +484,35 @@ EOF
         $projectId = $input->getArgument('project-id');
         $sessionId = $input->getOption('session-id');
         session_entity_type_list($projectId, $sessionId);
-    })
-);
+    }));
 
 // create session entity type command
 $application->add((new Command('session-entity-type-create'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session.')
-    ->addArgument('entity-type-display-name', InputArgument::REQUIRED,
-        'Display name of the entity type.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session.'
+    )
+    ->addArgument(
+        'entity-type-display-name',
+        InputArgument::REQUIRED,
+        'Display name of the entity type.'
+    )
     ->addArgument('entity-values', InputArgument::IS_ARRAY |
         InputArgument::REQUIRED, 'Entity values of the session entity type.')
-    ->addOption('entity-override-mode', 'o', InputOption::VALUE_REQUIRED,
+    ->addOption(
+        'entity-override-mode',
+        'o',
+        InputOption::VALUE_REQUIRED,
         'ENTITY_OVERRIDE_MODE_OVERRIDE (default) or ENTITY_OVERRIDE_MODE_SUPPLEMENT',
-        EntityOverrideMode::ENTITY_OVERRIDE_MODE_OVERRIDE)
+        EntityOverrideMode::ENTITY_OVERRIDE_MODE_OVERRIDE
+    )
     ->setDescription('Create session entity type.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command creates session entity type with
@@ -415,19 +529,33 @@ EOF
         $displayName = $input->getArgument('entity-type-display-name');
         $values = $input->getArgument('entity-values');
         $overrideMode = $input->getOption('entity-override-mode');
-        session_entity_type_create($projectId, $displayName, $values,
-            $sessionId, $overrideMode);
-    })
-);
+        session_entity_type_create(
+            $projectId,
+            $displayName,
+            $values,
+            $sessionId,
+            $overrideMode
+        );
+    }));
 
 // delete session entity type command
 $application->add((new Command('session-entity-type-delete'))
-    ->addArgument('project-id', InputArgument::REQUIRED,
-        'Project/agent id. Required.')
-    ->addOption('session-id', 's', InputOption::VALUE_REQUIRED,
-        'Identifier of the DetectIntent session.')
-    ->addArgument('entity-type-display-name', InputArgument::REQUIRED,
-        'Display name of the entity type.')
+    ->addArgument(
+        'project-id',
+        InputArgument::REQUIRED,
+        'Project/agent id. Required.'
+    )
+    ->addOption(
+        'session-id',
+        's',
+        InputOption::VALUE_REQUIRED,
+        'Identifier of the DetectIntent session.'
+    )
+    ->addArgument(
+        'entity-type-display-name',
+        InputArgument::REQUIRED,
+        'Display name of the entity type.'
+    )
     ->setDescription('Delete session entity type of provided display name.')
     ->setHelp(<<<EOF
 The <info>%command.name%</info> command deletes specified session entity type.
@@ -441,8 +569,7 @@ EOF
         $sessionId = $input->getOption('session-id');
         $displayName = $input->getArgument('entity-type-display-name');
         session_entity_type_delete($projectId, $displayName, $sessionId);
-    })
-);
+    }));
 
 if (getenv('PHPUNIT_TESTS') === '1') {
     return $application;

--- a/dialogflow/src/context_delete.php
+++ b/dialogflow/src/context_delete.php
@@ -24,8 +24,11 @@ function context_delete($projectId, $contextId, $sessionId)
 {
     $contextsClient = new ContextsClient();
 
-    $contextName = $contextsClient->contextName($projectId, $sessionId,
-        $contextId);
+    $contextName = $contextsClient->contextName(
+        $projectId,
+        $sessionId,
+        $contextId
+    );
     $contextsClient->deleteContext($contextName);
     printf('Context deleted: %s' . PHP_EOL, $contextName);
 

--- a/dialogflow/src/detect_intent_audio.php
+++ b/dialogflow/src/detect_intent_audio.php
@@ -60,8 +60,11 @@ function detect_intent_audio($projectId, $path, $sessionId, $languageCode = 'en-
     // output relevant info
     print(str_repeat('=', 20) . PHP_EOL);
     printf('Query text: %s' . PHP_EOL, $queryText);
-    printf('Detected intent: %s (confidence: %f)' . PHP_EOL, $displayName,
-        $confidence);
+    printf(
+        'Detected intent: %s (confidence: %f)' . PHP_EOL,
+        $displayName,
+        $confidence
+    );
     print(PHP_EOL);
     printf('Fulfilment text: %s' . PHP_EOL, $fulfilmentText);
 

--- a/dialogflow/src/detect_intent_stream.php
+++ b/dialogflow/src/detect_intent_stream.php
@@ -98,8 +98,11 @@ function detect_intent_stream($projectId, $path, $sessionId, $languageCode = 'en
 
         // output relevant info
         printf('Query text: %s' . PHP_EOL, $queryText);
-        printf('Detected intent: %s (confidence: %f)' . PHP_EOL, $displayName,
-            $confidence);
+        printf(
+            'Detected intent: %s (confidence: %f)' . PHP_EOL,
+            $displayName,
+            $confidence
+        );
         print(PHP_EOL);
         printf('Fulfilment text: %s' . PHP_EOL, $fulfilmentText);
     }

--- a/dialogflow/src/detect_intent_texts.php
+++ b/dialogflow/src/detect_intent_texts.php
@@ -57,8 +57,11 @@ function detect_intent_texts($projectId, $texts, $sessionId, $languageCode = 'en
         // output relevant info
         print(str_repeat('=', 20) . PHP_EOL);
         printf('Query text: %s' . PHP_EOL, $queryText);
-        printf('Detected intent: %s (confidence: %f)' . PHP_EOL, $displayName,
-            $confidence);
+        printf(
+            'Detected intent: %s (confidence: %f)' . PHP_EOL,
+            $displayName,
+            $confidence
+        );
         print(PHP_EOL);
         printf('Fulfilment text: %s' . PHP_EOL, $fulfilmentText);
     }

--- a/dialogflow/src/entity_create.php
+++ b/dialogflow/src/entity_create.php
@@ -33,8 +33,10 @@ function entity_create($projectId, $entityTypeId, $entityValue, $synonyms = [])
     }
 
     $entityTypesClient = new EntityTypesClient();
-    $parent = $entityTypesClient->entityTypeName($projectId,
-        $entityTypeId);
+    $parent = $entityTypesClient->entityTypeName(
+        $projectId,
+        $entityTypeId
+    );
 
     // prepare entity
     $entity = new Entity();

--- a/dialogflow/src/entity_delete.php
+++ b/dialogflow/src/entity_delete.php
@@ -27,8 +27,10 @@ function entity_delete($projectId, $entityTypeId, $entityValue)
 {
     $entityTypesClient = new EntityTypesClient();
 
-    $parent = $entityTypesClient->entityTypeName($projectId,
-        $entityTypeId);
+    $parent = $entityTypesClient->entityTypeName(
+        $projectId,
+        $entityTypeId
+    );
     $entityTypesClient->batchDeleteEntities($parent, [$entityValue]);
     printf('Entity deleted: %s' . PHP_EOL, $entityValue);
 

--- a/dialogflow/src/entity_list.php
+++ b/dialogflow/src/entity_list.php
@@ -25,8 +25,10 @@ function entity_list($projectId, $entityTypeId)
     $entityTypesClient = new EntityTypesClient();
 
     // prepare
-    $parent = $entityTypesClient->entityTypeName($projectId,
-        $entityTypeId);
+    $parent = $entityTypesClient->entityTypeName(
+        $projectId,
+        $entityTypeId
+    );
     $entityType = $entityTypesClient->getEntityType($parent);
 
     // get entities

--- a/dialogflow/src/entity_type_delete.php
+++ b/dialogflow/src/entity_type_delete.php
@@ -27,8 +27,10 @@ function entity_type_delete($projectId, $entityTypeId)
 {
     $entityTypesClient = new EntityTypesClient();
 
-    $parent = $entityTypesClient->entityTypeName($projectId,
-        $entityTypeId);
+    $parent = $entityTypesClient->entityTypeName(
+        $projectId,
+        $entityTypeId
+    );
     $entityTypesClient->deleteEntityType($parent);
     printf('Entity type deleted: %s' . PHP_EOL, $parent);
 

--- a/dialogflow/src/intent_create.php
+++ b/dialogflow/src/intent_create.php
@@ -28,9 +28,12 @@ use Google\Cloud\Dialogflow\V2\Intent;
 /**
 * Create an intent of the given intent type.
 */
-function intent_create($projectId, $displayName, $trainingPhraseParts = [],
-    $messageTexts = [])
-{
+function intent_create(
+    $projectId,
+    $displayName,
+    $trainingPhraseParts = [],
+    $messageTexts = []
+) {
     $intentsClient = new IntentsClient();
 
     // prepare parent

--- a/dialogflow/src/intent_list.php
+++ b/dialogflow/src/intent_list.php
@@ -33,10 +33,14 @@ function intent_list($projectId)
         printf('Intent name: %s' . PHP_EOL, $intent->getName());
         printf('Intent display name: %s' . PHP_EOL, $intent->getDisplayName());
         printf('Action: %s' . PHP_EOL, $intent->getAction());
-        printf('Root followup intent: %s' . PHP_EOL,
-            $intent->getRootFollowupIntentName());
-        printf('Parent followup intent: %s' . PHP_EOL,
-            $intent->getParentFollowupIntentName());
+        printf(
+            'Root followup intent: %s' . PHP_EOL,
+            $intent->getRootFollowupIntentName()
+        );
+        printf(
+            'Parent followup intent: %s' . PHP_EOL,
+            $intent->getParentFollowupIntentName()
+        );
         print(PHP_EOL);
 
         print('Input contexts: ' . PHP_EOL);

--- a/dialogflow/src/session_entity_type_create.php
+++ b/dialogflow/src/session_entity_type_create.php
@@ -26,9 +26,13 @@ use Google\Cloud\Dialogflow\V2\EntityType\Entity;
 /**
 * Create a session entity type with the given display name.
 */
-function session_entity_type_create($projectId, $displayName, $values,
-    $sessionId, $overrideMode = EntityOverrideMode::ENTITY_OVERRIDE_MODE_OVERRIDE)
-{
+function session_entity_type_create(
+    $projectId,
+    $displayName,
+    $values,
+    $sessionId,
+    $overrideMode = EntityOverrideMode::ENTITY_OVERRIDE_MODE_OVERRIDE
+) {
     $sessionEntityTypesClient = new SessionEntityTypesClient();
     $parent = $sessionEntityTypesClient->sessionName($projectId, $sessionId);
 
@@ -52,8 +56,10 @@ function session_entity_type_create($projectId, $displayName, $values,
         ->setEntities($entities);
 
     // create session entity type
-    $response = $sessionEntityTypesClient->createSessionEntityType($parent,
-        $sessionEntityType);
+    $response = $sessionEntityTypesClient->createSessionEntityType(
+        $parent,
+        $sessionEntityType
+    );
     printf('Session entity type created: %s' . PHP_EOL, $response->getName());
 
     $sessionEntityTypesClient->close();

--- a/dlp/src/create_trigger.php
+++ b/dlp/src/create_trigger.php
@@ -51,7 +51,8 @@ use Google\Protobuf\Duration;
  * @param string $description          (Optional) A description for the trigger to be created
  * @param int    $scanPeriod           (Optional) How often to wait between scans, in days (minimum = 1 day)
  * @param bool   $autoPopulateTimespan (Optional) Automatically limit scan to new content only
- * @param int    $maxFindings          (Optional) The maximum number of findings to report per request (0 = server maximum)
+ * @param int    $maxFindings          (Optional) The maximum number of findings to report per request
+ *                                     (0 = server maximum)
  */
 function create_trigger(
     string $callingProjectId,

--- a/dlp/src/deidentify_fpe.php
+++ b/dlp/src/deidentify_fpe.php
@@ -67,7 +67,8 @@ function deidentify_fpe(
         ->setCryptoKeyName($keyName);
 
     // The set of characters to replace sensitive ones with
-    // For more information, see https://cloud.google.com/dlp/docs/reference/rest/V2/organizations.deidentifyTemplates#ffxcommonnativealphabet
+    // For more information, see
+    // https://cloud.google.com/dlp/docs/reference/rest/V2/organizations.deidentifyTemplates#ffxcommonnativealphabet
     $commonAlphabet = FfxCommonNativeAlphabet::NUMERIC;
 
     // Create the crypto key configuration object

--- a/dlp/src/inspect_datastore.php
+++ b/dlp/src/inspect_datastore.php
@@ -153,7 +153,11 @@ function inspect_datastore(
                 print('No findings.' . PHP_EOL);
             } else {
                 foreach ($infoTypeStats as $infoTypeStat) {
-                    printf('  Found %s instance(s) of infoType %s' . PHP_EOL, $infoTypeStat->getCount(), $infoTypeStat->getInfoType()->getName());
+                    printf(
+                        '  Found %s instance(s) of infoType %s' . PHP_EOL,
+                        $infoTypeStat->getCount(),
+                        $infoTypeStat->getInfoType()->getName()
+                    );
                 }
             }
             break;

--- a/dlp/src/inspect_gcs.php
+++ b/dlp/src/inspect_gcs.php
@@ -46,7 +46,8 @@ use Google\Cloud\PubSub\PubSubClient;
  * @param string $topicId           The name of the Pub/Sub topic to notify once the job completes
  * @param string $subscriptionId    The name of the Pub/Sub subscription to use when listening for job
  * @param string $bucketId          The name of the bucket where the file resides
- * @param string $file              The path to the file within the bucket to inspect. Can contain wildcards e.g. "my-image.*"
+ * @param string $file              The path to the file within the bucket to inspect. Can contain wildcards
+ *                                  e.g. "my-image.*"
  * @param int    $maxFindings       (Optional) The maximum number of findings to report per request (0 = server maximum)
  */
 function inspect_gcs(
@@ -148,7 +149,11 @@ function inspect_gcs(
                 print('No findings.' . PHP_EOL);
             } else {
                 foreach ($infoTypeStats as $infoTypeStat) {
-                    printf('  Found %s instance(s) of infoType %s' . PHP_EOL, $infoTypeStat->getCount(), $infoTypeStat->getInfoType()->getName());
+                    printf(
+                        '  Found %s instance(s) of infoType %s' . PHP_EOL,
+                        $infoTypeStat->getCount(),
+                        $infoTypeStat->getInfoType()->getName()
+                    );
                 }
             }
             break;

--- a/dlp/src/list_triggers.php
+++ b/dlp/src/list_triggers.php
@@ -53,8 +53,10 @@ function list_triggers(string $callingProjectId): void
         printf('  Status: %s' . PHP_EOL, $trigger->getStatus());
         printf('  Error count: %s' . PHP_EOL, count($trigger->getErrors()));
         $timespanConfig = $trigger->getInspectJob()->getStorageConfig()->getTimespanConfig();
-        printf('  Auto-populates timespan config: %s' . PHP_EOL,
-            ($timespanConfig && $timespanConfig->getEnableAutoPopulationOfTimespanConfig() ? 'yes' : 'no'));
+        printf(
+            '  Auto-populates timespan config: %s' . PHP_EOL,
+            ($timespanConfig && $timespanConfig->getEnableAutoPopulationOfTimespanConfig() ? 'yes' : 'no')
+        );
     }
 }
 # [END dlp_list_triggers]

--- a/dlp/src/reidentify_fpe.php
+++ b/dlp/src/reidentify_fpe.php
@@ -65,7 +65,8 @@ function reidentify_fpe(
     $infoTypes = [$ssnInfoType];
 
     // The set of characters to replace sensitive ones with
-    // For more information, see https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#ffxcommonnativealphabet
+    // For more information, see
+    // https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#ffxcommonnativealphabet
     $commonAlphabet = FfxCommonNativeAlphabet::NUMERIC;
 
     // Create the wrapped crypto key configuration object

--- a/dlp/test/quickstartTest.php
+++ b/dlp/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Dlp\Test;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/documentai/test/quickstartTest.php
+++ b/documentai/test/quickstartTest.php
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+namespace Google\Cloud\Samples\DocumentAI\Test;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/endpoints/getting-started/EndpointsCommand.php
+++ b/endpoints/getting-started/EndpointsCommand.php
@@ -47,7 +47,7 @@ class EndpointsCommand extends Command
             ->addArgument(
                 'credentials',
                 InputArgument::OPTIONAL,
-                'The path to your credentials file. This can be service account credentials, client secrets, or omitted.'
+                'The path to your credentials file. This can be service account credentials, client secrets, or omitted'
             )
             ->addOption(
                 'message',

--- a/endpoints/getting-started/test/EndpointsCommandTest.php
+++ b/endpoints/getting-started/test/EndpointsCommandTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Endpoints\Test;
+
 use Google\Cloud\Samples\Appengine\Endpoints\EndpointsCommand;
 use Google\Cloud\TestUtils\TestTrait;
 use Symfony\Component\Console\Tester\CommandTester;

--- a/endpoints/getting-started/test/LocalTest.php
+++ b/endpoints/getting-started/test/LocalTest.php
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+namespace Google\Cloud\Samples\Endpoints\Test;
+
 use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Factory\RequestFactory;
 

--- a/firestore/src/query_filter_array_contains_any.php
+++ b/firestore/src/query_filter_array_contains_any.php
@@ -41,7 +41,10 @@ function query_filter_array_contains_any(string $projectId): void
     $containsQuery = $citiesRef->where('regions', 'array-contains-any', ['west_coast', 'east_coast']);
     # [END firestore_query_filter_array_contains_any]
     foreach ($containsQuery->documents() as $document) {
-        printf('Document %s returned by query regions array-contains-any [west_coast, east_coast]' . PHP_EOL, $document->id());
+        printf(
+            'Document %s returned by query regions array-contains-any [west_coast, east_coast]' . PHP_EOL,
+            $document->id()
+        );
     }
 }
 

--- a/firestore/src/query_filter_range_invalid.php
+++ b/firestore/src/query_filter_range_invalid.php
@@ -26,7 +26,8 @@ namespace Google\Cloud\Samples\Firestore;
 use Google\Cloud\Firestore\FirestoreClient;
 
 /**
- * An example of an invalid range query. @see https://cloud.google.com/firestore/docs/query-data/queries#compound_queries
+ * An example of an invalid range query.
+ * @see https://cloud.google.com/firestore/docs/query-data/queries#compound_queries
  *
  * @param string $projectId The Google Cloud Project ID
  */

--- a/firestore/src/transaction_document_update.php
+++ b/firestore/src/transaction_document_update.php
@@ -47,7 +47,8 @@ function transaction_document_update(string $projectId): void
         ]);
     });
     # [END firestore_transaction_document_update]
-    printf('Ran a simple transaction to update the population field in the SF document in the cities collection.' . PHP_EOL);
+    print('Ran a simple transaction to update the population field in the SF document in the cities collection.');
+    print(PHP_EOF);
 }
 
 // The following 2 lines are only needed to run the samples

--- a/functions/firebase_auth/test/DeployTest.php
+++ b/functions/firebase_auth/test/DeployTest.php
@@ -121,7 +121,9 @@ class DeployTest extends TestCase
     private function createAuthUser(string $email): void
     {
         if (empty(self::$apiHttpClient)) {
-            $credentials = ApplicationDefaultCredentials::getCredentials('https://www.googleapis.com/auth/cloud-platform');
+            $credentials = ApplicationDefaultCredentials::getCredentials(
+                'https://www.googleapis.com/auth/cloud-platform'
+            );
             self::$apiHttpClient = CredentialsLoader::makeHttpClient($credentials, [
                 'base_uri' => 'https://identitytoolkit.googleapis.com/'
             ]);

--- a/functions/firebase_remote_config/test/DeployTest.php
+++ b/functions/firebase_remote_config/test/DeployTest.php
@@ -140,7 +140,9 @@ class DeployTest extends TestCase
         $projectId = self::requireEnv('GOOGLE_PROJECT_ID');
 
         if (empty(self::$apiHttpClient)) {
-            $credentials = ApplicationDefaultCredentials::getCredentials('https://www.googleapis.com/auth/cloud-platform');
+            $credentials = ApplicationDefaultCredentials::getCredentials(
+                'https://www.googleapis.com/auth/cloud-platform'
+            );
             self::$apiHttpClient = CredentialsLoader::makeHttpClient($credentials, [
                 'base_uri' => 'https://firebaseremoteconfig.googleapis.com/v1/projects/' . $projectId . '/remoteConfig'
             ]);

--- a/functions/helloworld_pubsub/test/IntegrationTest.php
+++ b/functions/helloworld_pubsub/test/IntegrationTest.php
@@ -74,8 +74,13 @@ class IntegrationTest extends TestCase
     /**
      * @dataProvider dataProvider
      */
-    public function testHelloworldPubsub(array $cloudevent, array $data, int $statusCode, string $expected, string $label): void
-    {
+    public function testHelloworldPubsub(
+        array $cloudevent,
+        array $data,
+        int $statusCode,
+        string $expected,
+        string $label
+    ): void {
         // Prepare the HTTP headers for a CloudEvent.
         $cloudEventHeaders = [];
         foreach ($cloudevent as $key => $value) {

--- a/functions/http_content_type/index.php
+++ b/functions/http_content_type/index.php
@@ -26,30 +26,30 @@ function helloContent(ServerRequestInterface $request): string
     switch ($request->getHeaderLine('content-type')) {
         // '{"name":"John"}'
         case 'application/json':
-          if (!empty($body)) {
-              $json = json_decode($body, true);
-              if (json_last_error() != JSON_ERROR_NONE) {
-                  throw new RuntimeException(sprintf(
-                      'Could not parse body: %s',
-                      json_last_error_msg()
-                  ));
-              }
-              $name = $json['name'] ?? $name;
-          }
-          break;
+            if (!empty($body)) {
+                $json = json_decode($body, true);
+                if (json_last_error() != JSON_ERROR_NONE) {
+                    throw new RuntimeException(sprintf(
+                        'Could not parse body: %s',
+                        json_last_error_msg()
+                    ));
+                }
+                $name = $json['name'] ?? $name;
+            }
+            break;
         // 'John', stored in a stream
         case 'application/octet-stream':
-          $name = $body;
-          break;
+            $name = $body;
+            break;
         // 'John'
         case 'text/plain':
-          $name = $body;
-          break;
+            $name = $body;
+            break;
         // 'name=John' in the body of a POST request (not the URL)
         case 'application/x-www-form-urlencoded':
-          parse_str($body, $data);
-          $name = $data['name'] ?? $name;
-          break;
+            parse_str($body, $data);
+            $name = $data['name'] ?? $name;
+            break;
     }
 
     return sprintf('Hello %s!', htmlspecialchars($name));

--- a/functions/http_form_data/index.php
+++ b/functions/http_form_data/index.php
@@ -29,7 +29,10 @@ function uploadFile(ServerRequestInterface $request): ResponseInterface
 
     $contentType = $request->getHeader('Content-Type')[0];
     if (strpos($contentType, 'multipart/form-data') !== 0) {
-        return new Response(400, [], 'Bad Request: content of type "multipart/form-data" not provided, found ' . $contentType);
+        return new Response(400, [], sprintf(
+            'Bad Request: content of type "multipart/form-data" not provided, found %s',
+            $contentType
+        ));
     }
 
     $fileList = [];

--- a/functions/tips_infinite_retries/test/IntegrationTest.php
+++ b/functions/tips_infinite_retries/test/IntegrationTest.php
@@ -74,8 +74,13 @@ class IntegrationTest extends TestCase
     /**
      * @dataProvider dataProvider
      */
-    public function testLimitInfiniteRetries(array $cloudevent, array $data, string $statusCode, string $expected, string $label): void
-    {
+    public function testLimitInfiniteRetries(
+        array $cloudevent,
+        array $data,
+        string $statusCode,
+        string $expected,
+        string $label
+    ): void {
         // Prepare the HTTP headers for a CloudEvent.
         $cloudEventHeaders = [];
         foreach ($cloudevent as $key => $value) {

--- a/iot/src/create_es_device.php
+++ b/iot/src/create_es_device.php
@@ -60,9 +60,11 @@ function create_es_device(
 
     $device = $deviceManager->createDevice($registryName, $device);
 
-    printf('Device: %s : %s' . PHP_EOL,
+    printf(
+        'Device: %s : %s' . PHP_EOL,
         $device->getNumId(),
-        $device->getId());
+        $device->getId()
+    );
 }
 # [END iot_create_es_device]
 

--- a/iot/src/create_gateway.php
+++ b/iot/src/create_gateway.php
@@ -74,9 +74,11 @@ function create_gateway(
 
     $gateway = $deviceManager->createDevice($registryName, $device);
 
-    printf('Gateway: %s : %s' . PHP_EOL,
+    printf(
+        'Gateway: %s : %s' . PHP_EOL,
         $gateway->getNumId(),
-        $gateway->getId());
+        $gateway->getId()
+    );
 }
 # [END iot_create_gateway]
 

--- a/iot/src/create_registry.php
+++ b/iot/src/create_registry.php
@@ -57,9 +57,11 @@ function create_registry(
 
     $registry = $deviceManager->createDeviceRegistry($locationName, $registry);
 
-    printf('Id: %s, Name: %s' . PHP_EOL,
+    printf(
+        'Id: %s, Name: %s' . PHP_EOL,
         $registry->getId(),
-        $registry->getName());
+        $registry->getName()
+    );
 }
 # [END iot_create_registry]
 

--- a/iot/src/create_rsa_device.php
+++ b/iot/src/create_rsa_device.php
@@ -60,9 +60,11 @@ function create_rsa_device(
 
     $device = $deviceManager->createDevice($registryName, $device);
 
-    printf('Device: %s : %s' . PHP_EOL,
+    printf(
+        'Device: %s : %s' . PHP_EOL,
         $device->getNumId(),
-        $device->getId());
+        $device->getId()
+    );
 }
 # [END iot_create_rsa_device]
 

--- a/iot/src/create_unauth_device.php
+++ b/iot/src/create_unauth_device.php
@@ -46,9 +46,11 @@ function create_unauth_device(
 
     $device = $deviceManager->createDevice($registryName, $device);
 
-    printf('Device: %s : %s' . PHP_EOL,
+    printf(
+        'Device: %s : %s' . PHP_EOL,
         $device->getNumId(),
-        $device->getId());
+        $device->getId()
+    );
 }
 # [END iot_create_unauth_device]
 

--- a/iot/src/get_device.php
+++ b/iot/src/get_device.php
@@ -55,15 +55,21 @@ function get_device(
     printf('Name: %s' . PHP_EOL, $device->getName());
     foreach ($device->getCredentials() as $credential) {
         print('Certificate:' . PHP_EOL);
-        printf('    Format: %s' . PHP_EOL,
-            $formats[$credential->getPublicKey()->getFormat()]);
-        printf('    Expiration: %s' . PHP_EOL,
-            $credential->getExpirationTime()->toDateTime()->format('Y-m-d H:i:s'));
+        printf(
+            '    Format: %s' . PHP_EOL,
+            $formats[$credential->getPublicKey()->getFormat()]
+        );
+        printf(
+            '    Expiration: %s' . PHP_EOL,
+            $credential->getExpirationTime()->toDateTime()->format('Y-m-d H:i:s')
+        );
     }
     printf('Data: %s' . PHP_EOL, $device->getConfig()->getBinaryData());
     printf('Version: %s' . PHP_EOL, $device->getConfig()->getVersion());
-    printf('Update Time: %s' . PHP_EOL,
-        $device->getConfig()->getCloudUpdateTime()->toDateTime()->format('Y-m-d H:i:s'));
+    printf(
+        'Update Time: %s' . PHP_EOL,
+        $device->getConfig()->getCloudUpdateTime()->toDateTime()->format('Y-m-d H:i:s')
+    );
 }
 # [END iot_get_device]
 

--- a/iot/src/get_device_configs.php
+++ b/iot/src/get_device_configs.php
@@ -46,8 +46,10 @@ function get_device_configs(
         print('Config:' . PHP_EOL);
         printf('    Version: %s' . PHP_EOL, $config->getVersion());
         printf('    Data: %s' . PHP_EOL, $config->getBinaryData());
-        printf('    Update Time: %s' . PHP_EOL,
-            $config->getCloudUpdateTime()->toDateTime()->format('Y-m-d H:i:s'));
+        printf(
+            '    Update Time: %s' . PHP_EOL,
+            $config->getCloudUpdateTime()->toDateTime()->format('Y-m-d H:i:s')
+        );
     }
 }
 # [END iot_get_device_configs]

--- a/iot/src/get_device_state.php
+++ b/iot/src/get_device_state.php
@@ -45,8 +45,10 @@ function get_device_state(
     foreach ($response->getDeviceStates() as $state) {
         print('State:' . PHP_EOL);
         printf('    Data: %s' . PHP_EOL, $state->getBinaryData());
-        printf('    Update Time: %s' . PHP_EOL,
-            $state->getUpdateTime()->toDateTime()->format('Y-m-d H:i:s'));
+        printf(
+            '    Update Time: %s' . PHP_EOL,
+            $state->getUpdateTime()->toDateTime()->format('Y-m-d H:i:s')
+        );
     }
 }
 # [END iot_get_device_state]

--- a/iot/src/get_registry.php
+++ b/iot/src/get_registry.php
@@ -40,9 +40,11 @@ function get_registry(
 
     $registry = $deviceManager->getDeviceRegistry($registryName);
 
-    printf('Id: %s, Name: %s' . PHP_EOL,
+    printf(
+        'Id: %s, Name: %s' . PHP_EOL,
         $registry->getId(),
-        $registry->getName());
+        $registry->getName()
+    );
 }
 # [END iot_get_registry]
 

--- a/iot/src/list_devices.php
+++ b/iot/src/list_devices.php
@@ -45,9 +45,11 @@ function list_devices(
 
     // Print the result
     foreach ($devices->iterateAllElements() as $device) {
-        printf('Device: %s : %s' . PHP_EOL,
+        printf(
+            'Device: %s : %s' . PHP_EOL,
             $device->getNumId(),
-            $device->getId());
+            $device->getId()
+        );
     }
 }
 # [END iot_list_devices]

--- a/iot/src/list_devices_for_gateway.php
+++ b/iot/src/list_devices_for_gateway.php
@@ -47,7 +47,8 @@ function list_devices_for_gateway(
     $gatewayListOptions = (new GatewayListOptions())->setAssociationsGatewayId($gatewayId);
 
     // Call the API
-    $devices = $deviceManager->listDevices($registryName,
+    $devices = $deviceManager->listDevices(
+        $registryName,
         ['gatewayListOptions' => $gatewayListOptions]
     );
 

--- a/iot/src/list_gateways.php
+++ b/iot/src/list_gateways.php
@@ -61,9 +61,11 @@ function list_gateways(
 
         if ($gatewayType == GatewayType::GATEWAY) {
             $foundGateway = true;
-            printf('Device: %s : %s' . PHP_EOL,
+            printf(
+                'Device: %s : %s' . PHP_EOL,
                 $device->getNumId(),
-                $device->getId());
+                $device->getId()
+            );
         }
     }
     if (!$foundGateway) {

--- a/iot/src/list_registries.php
+++ b/iot/src/list_registries.php
@@ -44,9 +44,11 @@ function list_registries(
     $response = $deviceManager->listDeviceRegistries($locationName);
 
     foreach ($response->iterateAllElements() as $registry) {
-        printf(' - Id: %s, Name: %s' . PHP_EOL,
+        printf(
+            ' - Id: %s, Name: %s' . PHP_EOL,
             $registry->getId(),
-            $registry->getName());
+            $registry->getName()
+        );
     }
 }
 # [END iot_list_registries]

--- a/iot/src/set_device_config.php
+++ b/iot/src/set_device_config.php
@@ -50,8 +50,10 @@ function set_device_config(
 
     printf('Version: %s' . PHP_EOL, $config->getVersion());
     printf('Data: %s' . PHP_EOL, $config->getBinaryData());
-    printf('Update Time: %s' . PHP_EOL,
-        $config->getCloudUpdateTime()->toDateTime()->format('Y-m-d H:i:s'));
+    printf(
+        'Update Time: %s' . PHP_EOL,
+        $config->getCloudUpdateTime()->toDateTime()->format('Y-m-d H:i:s')
+    );
 }
 # [END iot_set_device_config]
 

--- a/iot/src/set_device_state.php
+++ b/iot/src/set_device_state.php
@@ -53,8 +53,13 @@ function set_device_state(
     );
 
     // Format the device's URL
-    $deviceName = sprintf('projects/%s/locations/%s/registries/%s/devices/%s',
-        $projectId, $location, $registryId, $deviceId);
+    $deviceName = sprintf(
+        'projects/%s/locations/%s/registries/%s/devices/%s',
+        $projectId,
+        $location,
+        $registryId,
+        $deviceId
+    );
 
     $url = sprintf('https://cloudiotdevice.googleapis.com/v1/%s:setState', $deviceName);
 

--- a/kms/src/create_key_asymmetric_decrypt.php
+++ b/kms/src/create_key_asymmetric_decrypt.php
@@ -43,13 +43,11 @@ function create_key_asymmetric_decrypt(
     $key = (new CryptoKey())
         ->setPurpose(CryptoKeyPurpose::ASYMMETRIC_DECRYPT)
         ->setVersionTemplate((new CryptoKeyVersionTemplate())
-            ->setAlgorithm(CryptoKeyVersionAlgorithm::RSA_DECRYPT_OAEP_2048_SHA256)
-        )
+            ->setAlgorithm(CryptoKeyVersionAlgorithm::RSA_DECRYPT_OAEP_2048_SHA256))
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24 * 60 * 60)
-        );
+            ->setSeconds(24 * 60 * 60));
 
     // Call the API.
     $createdKey = $client->createCryptoKey($keyRingName, $id, $key);

--- a/kms/src/create_key_asymmetric_sign.php
+++ b/kms/src/create_key_asymmetric_sign.php
@@ -43,13 +43,11 @@ function create_key_asymmetric_sign(
     $key = (new CryptoKey())
         ->setPurpose(CryptoKeyPurpose::ASYMMETRIC_SIGN)
         ->setVersionTemplate((new CryptoKeyVersionTemplate())
-            ->setAlgorithm(CryptoKeyVersionAlgorithm::RSA_SIGN_PKCS1_2048_SHA256)
-        )
+            ->setAlgorithm(CryptoKeyVersionAlgorithm::RSA_SIGN_PKCS1_2048_SHA256))
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24 * 60 * 60)
-        );
+            ->setSeconds(24 * 60 * 60));
 
     // Call the API.
     $createdKey = $client->createCryptoKey($keyRingName, $id, $key);

--- a/kms/src/create_key_hsm.php
+++ b/kms/src/create_key_hsm.php
@@ -45,13 +45,11 @@ function create_key_hsm(
         ->setPurpose(CryptoKeyPurpose::ENCRYPT_DECRYPT)
         ->setVersionTemplate((new CryptoKeyVersionTemplate())
             ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION)
-            ->setProtectionLevel(ProtectionLevel::HSM)
-        )
+            ->setProtectionLevel(ProtectionLevel::HSM))
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24 * 60 * 60)
-        );
+            ->setSeconds(24 * 60 * 60));
 
     // Call the API.
     $createdKey = $client->createCryptoKey($keyRingName, $id, $key);

--- a/kms/src/create_key_labels.php
+++ b/kms/src/create_key_labels.php
@@ -42,8 +42,7 @@ function create_key_labels(
     $key = (new CryptoKey())
         ->setPurpose(CryptoKeyPurpose::ENCRYPT_DECRYPT)
         ->setVersionTemplate((new CryptoKeyVersionTemplate())
-            ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION)
-        )
+            ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION))
         ->setLabels([
             'team' => 'alpha',
             'cost_center' => 'cc1234',

--- a/kms/src/create_key_mac.php
+++ b/kms/src/create_key_mac.php
@@ -43,13 +43,11 @@ function create_key_mac(
     $key = (new CryptoKey())
         ->setPurpose(CryptoKeyPurpose::MAC)
         ->setVersionTemplate((new CryptoKeyVersionTemplate())
-            ->setAlgorithm(CryptoKeyVersionAlgorithm::HMAC_SHA256)
-        )
+            ->setAlgorithm(CryptoKeyVersionAlgorithm::HMAC_SHA256))
 
         // Optional: customize how long key versions should be kept before destroying.
         ->setDestroyScheduledDuration((new Duration())
-            ->setSeconds(24 * 60 * 60)
-        );
+            ->setSeconds(24 * 60 * 60));
 
     // Call the API.
     $createdKey = $client->createCryptoKey($keyRingName, $id, $key);

--- a/kms/src/create_key_rotation_schedule.php
+++ b/kms/src/create_key_rotation_schedule.php
@@ -48,13 +48,11 @@ function create_key_rotation_schedule(
 
         // Rotate the key every 30 days.
         ->setRotationPeriod((new Duration())
-            ->setSeconds(60 * 60 * 24 * 30)
-        )
+            ->setSeconds(60 * 60 * 24 * 30))
 
         // Start the first rotation in 24 hours.
         ->setNextRotationTime((new Timestamp())
-            ->setSeconds(time() + 60 * 60 * 24)
-        );
+            ->setSeconds(time() + 60 * 60 * 24));
 
     // Call the API.
     $createdKey = $client->createCryptoKey($keyRingName, $id, $key);

--- a/kms/src/create_key_symmetric_encrypt_decrypt.php
+++ b/kms/src/create_key_symmetric_encrypt_decrypt.php
@@ -42,8 +42,7 @@ function create_key_symmetric_encrypt_decrypt(
     $key = (new CryptoKey())
         ->setPurpose(CryptoKeyPurpose::ENCRYPT_DECRYPT)
         ->setVersionTemplate((new CryptoKeyVersionTemplate())
-            ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION)
-        );
+            ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION));
 
     // Call the API.
     $createdKey = $client->createCryptoKey($keyRingName, $id, $key);

--- a/kms/src/update_key_add_rotation.php
+++ b/kms/src/update_key_add_rotation.php
@@ -44,13 +44,11 @@ function update_key_add_rotation(
 
         // Rotate the key every 30 days.
         ->setRotationPeriod((new Duration())
-            ->setSeconds(60 * 60 * 24 * 30)
-        )
+            ->setSeconds(60 * 60 * 24 * 30))
 
         // Start the first rotation in 24 hours.
         ->setNextRotationTime((new Timestamp())
-            ->setSeconds(time() + 60 * 60 * 24)
-        );
+            ->setSeconds(time() + 60 * 60 * 24));
 
     // Create the field mask.
     $updateMask = (new FieldMask())

--- a/language/test/quickstartTest.php
+++ b/language/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Language\Test;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/logging/src/list_sinks.php
+++ b/logging/src/list_sinks.php
@@ -32,7 +32,8 @@ function list_sinks($projectId)
     foreach ($sinks as $sink) {
         /* @var $sink \Google\Cloud\Logging\Sink */
         foreach ($sink->info() as $key => $value) {
-            printf('%s:%s' . PHP_EOL,
+            printf(
+                '%s:%s' . PHP_EOL,
                 $key,
                 is_string($value) ? $value : var_export($value, true)
             );

--- a/logging/test/quickstartTest.php
+++ b/logging/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Logging\Tests;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/media/livestream/test/livestreamTest.php
+++ b/media/livestream/test/livestreamTest.php
@@ -62,7 +62,12 @@ class livestreamTest extends TestCase
     public function testCreateInput()
     {
         self::$inputId = sprintf('%s-%s-%s', self::$inputIdPrefix, uniqid(), time());
-        self::$inputName = sprintf('projects/%s/locations/%s/inputs/%s', self::$projectId, self::$location, self::$inputId);
+        self::$inputName = sprintf(
+            'projects/%s/locations/%s/inputs/%s',
+            self::$projectId,
+            self::$location,
+            self::$inputId
+        );
 
         $output = $this->runFunctionSnippet('create_input', [
             self::$projectId,
@@ -129,7 +134,12 @@ class livestreamTest extends TestCase
     {
         // Create a test input for the channel
         self::$inputId = sprintf('%s-%s-%s', self::$inputIdPrefix, uniqid(), time());
-        self::$inputName = sprintf('projects/%s/locations/%s/inputs/%s', self::$projectId, self::$location, self::$inputId);
+        self::$inputName = sprintf(
+            'projects/%s/locations/%s/inputs/%s',
+            self::$projectId,
+            self::$location,
+            self::$inputId
+        );
 
         $this->runFunctionSnippet('create_input', [
             self::$projectId,
@@ -138,7 +148,12 @@ class livestreamTest extends TestCase
         ]);
 
         self::$channelId = sprintf('%s-%s-%s', self::$channelIdPrefix, uniqid(), time());
-        self::$channelName = sprintf('projects/%s/locations/%s/channels/%s', self::$projectId, self::$location, self::$channelId);
+        self::$channelName = sprintf(
+            'projects/%s/locations/%s/channels/%s',
+            self::$projectId,
+            self::$location,
+            self::$channelId
+        );
 
         $output = $this->runFunctionSnippet('create_channel', [
             self::$projectId,
@@ -165,7 +180,12 @@ class livestreamTest extends TestCase
     {
         // Create a test input to update the channel
         self::$backupInputId = sprintf('%s-%s-%s', self::$inputIdPrefix, uniqid(), time());
-        self::$backupInputName = sprintf('projects/%s/locations/%s/inputs/%s', self::$projectId, self::$location, self::$backupInputId);
+        self::$backupInputName = sprintf(
+            'projects/%s/locations/%s/inputs/%s',
+            self::$projectId,
+            self::$location,
+            self::$backupInputId
+        );
 
         $this->runFunctionSnippet('create_input', [
             self::$projectId,
@@ -244,7 +264,12 @@ class livestreamTest extends TestCase
     public function testCreateChannelWithBackupInput()
     {
         self::$channelId = sprintf('%s-%s-%s', self::$channelIdPrefix, uniqid(), time());
-        self::$channelName = sprintf('projects/%s/locations/%s/channels/%s', self::$projectId, self::$location, self::$channelId);
+        self::$channelName = sprintf(
+            'projects/%s/locations/%s/channels/%s',
+            self::$projectId,
+            self::$location,
+            self::$channelId
+        );
 
         $output = $this->runFunctionSnippet('create_channel_with_backup_input', [
             self::$projectId,
@@ -287,7 +312,12 @@ class livestreamTest extends TestCase
     {
         // Create a test input for the channel
         self::$inputId = sprintf('%s-%s-%s', self::$inputIdPrefix, uniqid(), time());
-        self::$inputName = sprintf('projects/%s/locations/%s/inputs/%s', self::$projectId, self::$location, self::$inputId);
+        self::$inputName = sprintf(
+            'projects/%s/locations/%s/inputs/%s',
+            self::$projectId,
+            self::$location,
+            self::$inputId
+        );
 
         $this->runFunctionSnippet('create_input', [
             self::$projectId,
@@ -297,7 +327,12 @@ class livestreamTest extends TestCase
 
         // Create a test channel for the event
         self::$channelId = sprintf('%s-%s-%s', self::$channelIdPrefix, uniqid(), time());
-        self::$channelName = sprintf('projects/%s/locations/%s/channels/%s', self::$projectId, self::$location, self::$channelId);
+        self::$channelName = sprintf(
+            'projects/%s/locations/%s/channels/%s',
+            self::$projectId,
+            self::$location,
+            self::$channelId
+        );
 
         $this->runFunctionSnippet('create_channel', [
             self::$projectId,
@@ -314,7 +349,13 @@ class livestreamTest extends TestCase
         ]);
 
         self::$eventId = sprintf('%s-%s-%s', self::$eventIdPrefix, uniqid(), time());
-        self::$eventName = sprintf('projects/%s/locations/%s/channels/%s/events/%s', self::$projectId, self::$location, self::$channelId, self::$eventId);
+        self::$eventName = sprintf(
+            'projects/%s/locations/%s/channels/%s/events/%s',
+            self::$projectId,
+            self::$location,
+            self::$channelId,
+            self::$eventId
+        );
 
         $output = $this->runFunctionSnippet('create_channel_event', [
             self::$projectId,

--- a/media/transcoder/src/create_job_with_concatenated_inputs.php
+++ b/media/transcoder/src/create_job_with_concatenated_inputs.php
@@ -49,8 +49,17 @@ use Google\Protobuf\Duration;
  * @param float  $endTimeInput2 End time, in fractional seconds, relative to the second input video timeline.
  * @param string $outputUri Uri of the video output folder in the Cloud Storage bucket.
  */
-function create_job_with_concatenated_inputs($projectId, $location, $input1Uri, $startTimeInput1, $endTimeInput1, $input2Uri, $startTimeInput2, $endTimeInput2, $outputUri)
-{
+function create_job_with_concatenated_inputs(
+    $projectId,
+    $location,
+    $input1Uri,
+    $startTimeInput1,
+    $endTimeInput1,
+    $input2Uri,
+    $startTimeInput2,
+    $endTimeInput2,
+    $outputUri
+) {
     $startTimeInput1Sec = (int) floor(abs($startTimeInput1));
     $startTimeInput1Nanos = (int) (1000000000 * bcsub(abs($startTimeInput1), floor(abs($startTimeInput1)), 4));
     $endTimeInput1Sec = (int) floor(abs($endTimeInput1));

--- a/media/transcoder/test/transcoderTest.php
+++ b/media/transcoder/test/transcoderTest.php
@@ -100,8 +100,14 @@ class transcoderTest extends TestCase
         self::$outputUriForTemplate = sprintf('gs://%s/test-output-template/', $bucketName);
         self::$outputUriForAnimatedOverlay = sprintf('gs://%s/test-output-animated-overlay/', $bucketName);
         self::$outputUriForStaticOverlay = sprintf('gs://%s/test-output-static-overlay/', $bucketName);
-        self::$outputUriForPeriodicImagesSpritesheet = sprintf('gs://%s/test-output-periodic-spritesheet/', $bucketName);
-        self::$outputUriForSetNumberImagesSpritesheet = sprintf('gs://%s/test-output-set-number-spritesheet/', $bucketName);
+        self::$outputUriForPeriodicImagesSpritesheet = sprintf(
+            'gs://%s/test-output-periodic-spritesheet/',
+            $bucketName
+        );
+        self::$outputUriForSetNumberImagesSpritesheet = sprintf(
+            'gs://%s/test-output-set-number-spritesheet/',
+            $bucketName
+        );
         self::$outputUriForConcat = sprintf('gs://%s/test-output-concat/', $bucketName);
 
         self::$jobIdRegex = sprintf('~projects/%s/locations/%s/jobs/~', self::$projectNumber, self::$location);
@@ -129,7 +135,12 @@ class transcoderTest extends TestCase
     public function testJobTemplate()
     {
         $jobTemplateId = sprintf('php-test-template-%s', time());
-        $jobTemplateName = sprintf('projects/%s/locations/%s/jobTemplates/%s', self::$projectNumber, self::$location, $jobTemplateId);
+        $jobTemplateName = sprintf(
+            'projects/%s/locations/%s/jobTemplates/%s',
+            self::$projectNumber,
+            self::$location,
+            $jobTemplateId
+        );
 
         $output = $this->runFunctionSnippet('create_job_template', [
             self::$projectId,

--- a/media/videostitcher/test/videoStitcherTest.php
+++ b/media/videostitcher/test/videoStitcherTest.php
@@ -70,7 +70,9 @@ class videoStitcherTest extends TestCase
     private static $inputBucketName = 'cloud-samples-data';
     private static $inputVodFileName = '/media/hls-vod/manifest.m3u8';
     private static $vodUri;
-    private static $vodAgTagUri = 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonly&ciu_szs=300x250%2C728x90&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=';
+    private static $vodAgTagUri = 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples'
+        . '&sz=640x480&cust_params=sample_ar%3Dpreonly&ciu_szs=300x250%2C728x90&gdfp_req=1&ad_rule=1&output=vmap'
+        . '&unviewed_position_start=1&env=vp&impl=s&correlator=';
 
     private static $vodSessionId;
     private static $vodSessionName;
@@ -81,7 +83,10 @@ class videoStitcherTest extends TestCase
 
     private static $inputLiveFileName = '/media/hls-live/manifest.m3u8';
     private static $liveUri;
-    private static $liveAgTagUri = 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=';
+    private static $liveAgTagUri = 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/'
+        . 'single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&'
+        . 'unviewed_position_start=1&env=vp&impl=s&correlator=';
+
     private static $liveSessionId;
     private static $liveSessionName;
     private static $liveAdTagDetailId;
@@ -96,11 +101,23 @@ class videoStitcherTest extends TestCase
         self::deleteOldCdnKeys();
 
         self::$slateUri = sprintf('https://storage.googleapis.com/%s%s', self::$bucket, self::$slateFileName);
-        self::$updatedSlateUri = sprintf('https://storage.googleapis.com/%s%s', self::$bucket, self::$updatedSlateFileName);
+        self::$updatedSlateUri = sprintf(
+            'https://storage.googleapis.com/%s%s',
+            self::$bucket,
+            self::$updatedSlateFileName
+        );
 
-        self::$vodUri = sprintf('https://storage.googleapis.com/%s%s', self::$inputBucketName, self::$inputVodFileName);
+        self::$vodUri = sprintf(
+            'https://storage.googleapis.com/%s%s',
+            self::$inputBucketName,
+            self::$inputVodFileName
+        );
 
-        self::$liveUri = sprintf('https://storage.googleapis.com/%s%s', self::$inputBucketName, self::$inputLiveFileName);
+        self::$liveUri = sprintf(
+            'https://storage.googleapis.com/%s%s',
+            self::$inputBucketName,
+            self::$inputLiveFileName
+        );
     }
 
     public function testCreateSlate()
@@ -389,7 +406,11 @@ class videoStitcherTest extends TestCase
     /** @depends testGetVodSession */
     public function testListVodAdTagDetails()
     {
-        self::$vodAdTagDetailName = sprintf('/locations/%s/vodSessions/%s/vodAdTagDetails/', self::$location, self::$vodSessionId);
+        self::$vodAdTagDetailName = sprintf(
+            '/locations/%s/vodSessions/%s/vodAdTagDetails/',
+            self::$location,
+            self::$vodSessionId
+        );
         $output = $this->runFunctionSnippet('list_vod_ad_tag_details', [
             self::$projectId,
             self::$location,
@@ -398,7 +419,12 @@ class videoStitcherTest extends TestCase
         $this->assertStringContainsString(self::$vodAdTagDetailName, $output);
         self::$vodAdTagDetailId = explode('/', $output);
         self::$vodAdTagDetailId = trim(self::$vodAdTagDetailId[(count(self::$vodAdTagDetailId) - 1)]);
-        self::$vodAdTagDetailName = sprintf('/locations/%s/vodSessions/%s/vodAdTagDetails/%s', self::$location, self::$vodSessionId, self::$vodAdTagDetailId);
+        self::$vodAdTagDetailName = sprintf(
+            '/locations/%s/vodSessions/%s/vodAdTagDetails/%s',
+            self::$location,
+            self::$vodSessionId,
+            self::$vodAdTagDetailId
+        );
     }
 
     /** @depends testListVodAdTagDetails */
@@ -416,7 +442,11 @@ class videoStitcherTest extends TestCase
     /** @depends testCreateVodSession */
     public function testListVodStitchDetails()
     {
-        self::$vodStitchDetailName = sprintf('/locations/%s/vodSessions/%s/vodStitchDetails/', self::$location, self::$vodSessionId);
+        self::$vodStitchDetailName = sprintf(
+            '/locations/%s/vodSessions/%s/vodStitchDetails/',
+            self::$location,
+            self::$vodSessionId
+        );
         $output = $this->runFunctionSnippet('list_vod_stitch_details', [
             self::$projectId,
             self::$location,
@@ -425,7 +455,12 @@ class videoStitcherTest extends TestCase
         $this->assertStringContainsString(self::$vodStitchDetailName, $output);
         self::$vodStitchDetailId = explode('/', $output);
         self::$vodStitchDetailId = trim(self::$vodStitchDetailId[(count(self::$vodStitchDetailId) - 1)]);
-        self::$vodStitchDetailName = sprintf('/locations/%s/vodSessions/%s/vodStitchDetails/%s', self::$location, self::$vodSessionId, self::$vodStitchDetailId);
+        self::$vodStitchDetailName = sprintf(
+            '/locations/%s/vodSessions/%s/vodStitchDetails/%s',
+            self::$location,
+            self::$vodSessionId,
+            self::$vodStitchDetailId
+        );
     }
 
     /** @depends testListVodStitchDetails */
@@ -514,7 +549,11 @@ class videoStitcherTest extends TestCase
         $renditionsUri = sprintf('%s/%s', join('/', $tmp), $renditions);
         file_get_contents($renditionsUri);
 
-        self::$liveAdTagDetailName = sprintf('/locations/%s/liveSessions/%s/liveAdTagDetails/', self::$location, self::$liveSessionId);
+        self::$liveAdTagDetailName = sprintf(
+            '/locations/%s/liveSessions/%s/liveAdTagDetails/',
+            self::$location,
+            self::$liveSessionId
+        );
         $output = $this->runFunctionSnippet('list_live_ad_tag_details', [
             self::$projectId,
             self::$location,
@@ -523,7 +562,12 @@ class videoStitcherTest extends TestCase
         $this->assertStringContainsString(self::$liveAdTagDetailName, $output);
         self::$liveAdTagDetailId = explode('/', $output);
         self::$liveAdTagDetailId = trim(self::$liveAdTagDetailId[(count(self::$liveAdTagDetailId) - 1)]);
-        self::$liveAdTagDetailName = sprintf('/locations/%s/liveSessions/%s/liveAdTagDetails/%s', self::$location, self::$liveSessionId, self::$liveAdTagDetailId);
+        self::$liveAdTagDetailName = sprintf(
+            '/locations/%s/liveSessions/%s/liveAdTagDetails/%s',
+            self::$location,
+            self::$liveSessionId,
+            self::$liveAdTagDetailId
+        );
     }
 
     /** @depends testListLiveAdTagDetails */

--- a/monitoring/src/alert_create_policy.php
+++ b/monitoring/src/alert_create_policy.php
@@ -50,7 +50,11 @@ function alert_create_policy($projectId)
     $policy->setConditions([new Condition([
         'display_name' => 'condition-1',
         'condition_threshold' => new MetricThreshold([
-            'filter' => 'resource.type = "gce_instance" AND metric.type = "compute.googleapis.com/instance/cpu/utilization"',
+            'filter' => sprintf(
+                'resource.type = "%s" AND metric.type = "%s"',
+                'gce_instance',
+                'compute.googleapis.com/instance/cpu/utilization'
+            ),
             'duration' => new Duration(['seconds' => '60']),
             'comparison' => ComparisonType::COMPARISON_LT,
         ])

--- a/monitoring/src/alert_enable_policies.php
+++ b/monitoring/src/alert_enable_policies.php
@@ -48,7 +48,8 @@ function alert_enable_policies($projectId, $enable = true, $filter = null)
     foreach ($policies->iterateAllElements() as $policy) {
         $isEnabled = $policy->getEnabled()->getValue();
         if ($enable == $isEnabled) {
-            printf('Policy %s is already %s' . PHP_EOL,
+            printf(
+                'Policy %s is already %s' . PHP_EOL,
                 $policy->getName(),
                 $isEnabled ? 'enabled' : 'disabled'
             );
@@ -59,7 +60,8 @@ function alert_enable_policies($projectId, $enable = true, $filter = null)
             $alertClient->updateAlertPolicy($policy, [
                 'updateMask' => $mask
             ]);
-            printf('%s %s' . PHP_EOL,
+            printf(
+                '%s %s' . PHP_EOL,
                 $enable ? 'Enabled' : 'Disabled',
                 $policy->getName()
             );

--- a/monitoring/src/get_descriptor.php
+++ b/monitoring/src/get_descriptor.php
@@ -52,10 +52,12 @@ function get_descriptor($projectId, $metricId)
     printf('Unit: ' . $descriptor->getUnit() . PHP_EOL);
     printf('Labels:' . PHP_EOL);
     foreach ($descriptor->getLabels() as $labels) {
-        printf('  %s (%s) - %s' . PHP_EOL,
+        printf(
+            '  %s (%s) - %s' . PHP_EOL,
             $labels->getKey(),
             $labels->getValueType(),
-            $labels->getDescription());
+            $labels->getDescription()
+        );
     }
 }
 // [END monitoring_get_descriptor]

--- a/monitoring/src/get_resource.php
+++ b/monitoring/src/get_resource.php
@@ -50,10 +50,12 @@ function get_resource($projectId, $resourceType)
     printf('Description: %s' . PHP_EOL, $resource->getDescription());
     printf('Labels:' . PHP_EOL);
     foreach ($resource->getLabels() as $labels) {
-        printf('  %s (%s) - %s' . PHP_EOL,
+        printf(
+            '  %s (%s) - %s' . PHP_EOL,
             $labels->getKey(),
             $labels->getValueType(),
-            $labels->getDescription());
+            $labels->getDescription()
+        );
     }
 }
 // [END monitoring_get_resource]

--- a/monitoring/src/read_timeseries_align.php
+++ b/monitoring/src/read_timeseries_align.php
@@ -71,7 +71,8 @@ function read_timeseries_align($projectId, $minutesAgo = 20)
         $filter,
         $interval,
         $view,
-        ['aggregation' => $aggregation]);
+        ['aggregation' => $aggregation]
+    );
 
     printf('CPU utilization:' . PHP_EOL);
     foreach ($result->iterateAllElements() as $timeSeries) {

--- a/monitoring/src/read_timeseries_fields.php
+++ b/monitoring/src/read_timeseries_fields.php
@@ -61,7 +61,8 @@ function read_timeseries_fields($projectId, $minutesAgo = 20)
         $projectName,
         $filter,
         $interval,
-        $view);
+        $view
+    );
 
     printf('Found data points for the following instances:' . PHP_EOL);
     foreach ($result->iterateAllElements() as $timeSeries) {

--- a/monitoring/src/read_timeseries_reduce.php
+++ b/monitoring/src/read_timeseries_reduce.php
@@ -71,7 +71,8 @@ function read_timeseries_reduce($projectId, $minutesAgo = 20)
         $filter,
         $interval,
         $view,
-        ['aggregation' => $aggregation]);
+        ['aggregation' => $aggregation]
+    );
 
     printf('Average CPU utilization across all GCE instances:' . PHP_EOL);
     if ($timeSeries = $result->iterateAllElements()->current()) {

--- a/monitoring/src/read_timeseries_simple.php
+++ b/monitoring/src/read_timeseries_simple.php
@@ -62,7 +62,8 @@ function read_timeseries_simple($projectId, $minutesAgo = 20)
         $projectName,
         $filter,
         $interval,
-        $view);
+        $view
+    );
 
     printf('CPU utilization:' . PHP_EOL);
     foreach ($result->iterateAllElements() as $timeSeries) {

--- a/monitoring/src/write_timeseries.php
+++ b/monitoring/src/write_timeseries.php
@@ -79,7 +79,8 @@ function write_timeseries($projectId)
 
     $result = $metrics->createTimeSeries(
         $projectName,
-        [$timeSeries]);
+        [$timeSeries]
+    );
 
     printf('Done writing time series data.' . PHP_EOL);
 }

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruleset name="Google-Cloud-PHP-PSR2">
+  <rule ref="PSR2" />
+  <rule ref="PSR1">
+    <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+  </rule>
+  <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+    <exclude-pattern>**/test/*Test.php</exclude-pattern>
+  </rule>
+ <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis">
+    <exclude-pattern type="relative">compute/*-client/helloworld/app.php</exclude-pattern>
+ </rule>
+ <rule ref="Generic.Files.LineLength.TooLong">
+    <exclude-pattern>**/test/*</exclude-pattern>
+    <exclude-pattern>index.php</exclude-pattern>
+ </rule>
+  <file>.</file>
+  <exclude-pattern>**/vendor/*</exclude-pattern>
+  <exclude-pattern>run/laravel</exclude-pattern>
+  <exclude-pattern>appengine</exclude-pattern>
+  <arg name="extensions" value="php"/>
+</ruleset>

--- a/pubsub/app/app.php
+++ b/pubsub/app/app.php
@@ -82,8 +82,7 @@ $app->get('/fetch_messages', function (Request $request, Response $response, $ar
 $app->post('/receive_message', function (Request $request, Response $response, $args) use ($container) {
     // pull the message from the post body
     $json = json_decode($request->getContent(), true);
-    if (
-        !isset($json['message']['data'])
+    if (!isset($json['message']['data'])
         || !$message = base64_decode($json['message']['data'])
     ) {
         return new Response('', 400);

--- a/pubsub/app/test/DeployAppEngineFlexTest.php
+++ b/pubsub/app/test/DeployAppEngineFlexTest.php
@@ -36,8 +36,11 @@ class DeployAppEngineFlexTest extends TestCase
     {
         // Access the modules app top page.
         $resp = $this->client->get('/');
-        $this->assertEquals('200', $resp->getStatusCode(),
-            'top page status code');
+        $this->assertEquals(
+            '200',
+            $resp->getStatusCode(),
+            'top page status code'
+        );
     }
 
     public function testSendMessage()
@@ -48,17 +51,22 @@ class DeployAppEngineFlexTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals('204', $resp->getStatusCode(),
-            '/send_message status code');
+        $this->assertEquals(
+            '204',
+            $resp->getStatusCode(),
+            '/send_message status code'
+        );
     }
 
     public function testReceiveMessage()
     {
         $resp = $this->client->request('POST', '/receive_message', [
                 'body' => json_encode(['message' => ['data' => 'Bye.']]),
-            ]
+            ]);
+        $this->assertEquals(
+            '200',
+            $resp->getStatusCode(),
+            '/receive_message status code'
         );
-        $this->assertEquals('200', $resp->getStatusCode(),
-            '/receive_message status code');
     }
 }

--- a/pubsub/quickstart/test/quickstartTest.php
+++ b/pubsub/quickstart/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\PubSub\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 class quickstartTest extends TestCase

--- a/recaptcha/src/get_key.php
+++ b/recaptcha/src/get_key.php
@@ -49,8 +49,14 @@ function get_key(string $projectId, string $keyId): void
         // $key->getCreateTime() returns a Google\Protobuf\Timestamp object
         printf('Create time: %d' . PHP_EOL, $key->getCreateTime()->getSeconds());
         printf('Web platform settings: %s' . PHP_EOL, $key->hasWebSettings() ? 'Yes' : 'No');
-        printf('Allowed all domains: %s' . PHP_EOL, $key->hasWebSettings() && $webSettings->getAllowAllDomains() ? 'Yes' : 'No');
-        printf('Integration Type: %s' . PHP_EOL, $key->hasWebSettings() ? IntegrationType::name($webSettings->getIntegrationType()) : 'N/A');
+        printf(
+            'Allowed all domains: %s' . PHP_EOL,
+            $key->hasWebSettings() && $webSettings->getAllowAllDomains() ? 'Yes' : 'No'
+        );
+        printf(
+            'Integration Type: %s' . PHP_EOL,
+            $key->hasWebSettings() ? IntegrationType::name($webSettings->getIntegrationType()) : 'N/A'
+        );
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {
             printf('The key with Key ID: %s doesn\'t exist.' . PHP_EOL, $keyId);

--- a/recaptcha/src/update_key.php
+++ b/recaptcha/src/update_key.php
@@ -63,7 +63,7 @@ function update_key(
     $settings->setIntegrationType(IntegrationType::CHECKBOX);
 
     // Specify the possible challenge frequency and difficulty
-    // Read https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.keys#challengesecuritypreference
+    // https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.keys#challengesecuritypreference
     $settings->setChallengeSecurityPreference(ChallengeSecurityPreference::SECURITY);
 
     $key = new Key();

--- a/secretmanager/quickstart.php
+++ b/secretmanager/quickstart.php
@@ -43,7 +43,9 @@ $client = new SecretManagerServiceClient();
 $parent = $client->projectName($projectId);
 
 // Create the parent secret.
-$secret = $client->createSecret($parent, $secretId,
+$secret = $client->createSecret(
+    $parent,
+    $secretId,
     new Secret([
         'replication' => new Replication([
             'automatic' => new Automatic(),

--- a/secretmanager/src/create_secret.php
+++ b/secretmanager/src/create_secret.php
@@ -45,7 +45,9 @@ function create_secret(string $projectId, string $secretId): void
     $parent = $client->projectName($projectId);
 
     // Create the secret.
-    $secret = $client->createSecret($parent, $secretId,
+    $secret = $client->createSecret(
+        $parent,
+        $secretId,
         new Secret([
             'replication' => new Replication([
                 'automatic' => new Automatic(),

--- a/secretmanager/test/quickstartTest.php
+++ b/secretmanager/test/quickstartTest.php
@@ -17,6 +17,8 @@
 
 declare(strict_types=1);
 
+namespace Google\Cloud\Samples\SecretManager\Test;
+
 use Google\ApiCore\ApiException as GaxApiException;
 use Google\Cloud\SecretManager\V1\SecretManagerServiceClient;
 use Google\Cloud\TestUtils\TestTrait;

--- a/secretmanager/test/secretmanagerTest.php
+++ b/secretmanager/test/secretmanagerTest.php
@@ -82,7 +82,9 @@ class secretmanagerTest extends TestCase
         $parent = self::$client->projectName(self::$projectId);
         $secretId = self::randomSecretId();
 
-        return self::$client->createSecret($parent, $secretId,
+        return self::$client->createSecret(
+            $parent,
+            $secretId,
             new Secret([
                 'replication' => new Replication([
                     'automatic' => new Automatic(),

--- a/servicedirectory/src/delete_endpoint.php
+++ b/servicedirectory/src/delete_endpoint.php
@@ -39,7 +39,13 @@ function delete_endpoint(
     $client = new RegistrationServiceClient();
 
     // Run request.
-    $endpointName = RegistrationServiceClient::endpointName($projectId, $locationId, $namespaceId, $serviceId, $endpointId);
+    $endpointName = RegistrationServiceClient::endpointName(
+        $projectId,
+        $locationId,
+        $namespaceId,
+        $serviceId,
+        $endpointId
+    );
     $endpoint = $client->deleteEndpoint($endpointName);
 
     // Print results.

--- a/servicedirectory/test/quickstartTest.php
+++ b/servicedirectory/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Servicedirectory\Test;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/spanner/src/copy_backup.php
+++ b/spanner/src/copy_backup.php
@@ -39,8 +39,12 @@ use Google\Cloud\Spanner\SpannerClient;
  * @param string $sourceInstanceId The Spanner instance ID of the source backup.
  * @param string $sourceBackupId The Spanner backup ID of the source.
  */
-function copy_backup(string $destInstanceId, string $destBackupId, string $sourceInstanceId, string $sourceBackupId): void
-{
+function copy_backup(
+    string $destInstanceId,
+    string $destBackupId,
+    string $sourceInstanceId,
+    string $sourceBackupId
+): void {
     $spanner = new SpannerClient();
 
     $destInstance = $spanner->instance($destInstanceId);
@@ -63,7 +67,11 @@ function copy_backup(string $destInstanceId, string $destBackupId, string $sourc
         $info = $destBackup->info();
         printf(
             'Backup %s of size %d bytes was copied at %s from the source backup %s' . PHP_EOL,
-            basename($info['name']), $info['sizeBytes'], $info['createTime'], $sourceBackupId);
+            basename($info['name']),
+            $info['sizeBytes'],
+            $info['createTime'],
+            $sourceBackupId
+        );
         printf('Version time of the copied backup: %s' . PHP_EOL, $info['versionTime']);
     } else {
         printf('Unexpected state: %s' . PHP_EOL, $destBackup->state());

--- a/spanner/src/create_backup.php
+++ b/spanner/src/create_backup.php
@@ -62,7 +62,11 @@ function create_backup(string $instanceId, string $databaseId, string $backupId,
         $info = $backup->info();
         printf(
             'Backup %s of size %d bytes was created at %s for version of database at %s' . PHP_EOL,
-            basename($info['name']), $info['sizeBytes'], $info['createTime'], $info['versionTime']);
+            basename($info['name']),
+            $info['sizeBytes'],
+            $info['createTime'],
+            $info['versionTime']
+        );
     } else {
         printf('Unexpected state: %s' . PHP_EOL, $backup->state());
     }

--- a/spanner/src/create_backup_with_encryption_key.php
+++ b/spanner/src/create_backup_with_encryption_key.php
@@ -40,8 +40,12 @@ use Google\Cloud\Spanner\SpannerClient;
  * @param string $backupId The Spanner backup ID.
  * @param string $kmsKeyName The KMS key used for encryption.
  */
-function create_backup_with_encryption_key(string $instanceId, string $databaseId, string $backupId, string $kmsKeyName): void
-{
+function create_backup_with_encryption_key(
+    string $instanceId,
+    string $databaseId,
+    string $backupId,
+    string $kmsKeyName
+): void {
     $spanner = new SpannerClient();
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);
@@ -66,7 +70,11 @@ function create_backup_with_encryption_key(string $instanceId, string $databaseI
         $info = $backup->info();
         printf(
             'Backup %s of size %d bytes was created at %s using encryption key %s' . PHP_EOL,
-            basename($info['name']), $info['sizeBytes'], $info['createTime'], $kmsKeyName);
+            basename($info['name']),
+            $info['sizeBytes'],
+            $info['createTime'],
+            $kmsKeyName
+        );
     } else {
         print('Backup is not ready!' . PHP_EOL);
     }

--- a/spanner/src/create_client_with_query_options.php
+++ b/spanner/src/create_client_with_query_options.php
@@ -57,8 +57,12 @@ function create_client_with_query_options(string $instanceId, string $databaseId
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, LastUpdateTime: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'], $row['LastUpdateTime']);
+        printf(
+            'VenueId: %s, VenueName: %s, LastUpdateTime: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['LastUpdateTime']
+        );
     }
 }
 // [END spanner_create_client_with_query_options]

--- a/spanner/src/create_database.php
+++ b/spanner/src/create_database.php
@@ -63,8 +63,11 @@ function create_database(string $instanceId, string $databaseId): void
     print('Waiting for operation to complete...' . PHP_EOL);
     $operation->pollUntilComplete();
 
-    printf('Created database %s on instance %s' . PHP_EOL,
-        $databaseId, $instanceId);
+    printf(
+        'Created database %s on instance %s' . PHP_EOL,
+        $databaseId,
+        $instanceId
+    );
 }
 // [END spanner_create_database]
 

--- a/spanner/src/create_database_with_default_leader.php
+++ b/spanner/src/create_database_with_default_leader.php
@@ -67,8 +67,12 @@ function create_database_with_default_leader(string $instanceId, string $databas
     $operation->pollUntilComplete();
 
     $database = $instance->database($databaseId);
-    printf('Created database %s on instance %s with default leader %s' . PHP_EOL,
-        $databaseId, $instanceId, $database->info()['defaultLeader']);
+    printf(
+        'Created database %s on instance %s with default leader %s' . PHP_EOL,
+        $databaseId,
+        $instanceId,
+        $database->info()['defaultLeader']
+    );
 }
 // [END spanner_create_database_with_default_leader]
 

--- a/spanner/src/create_database_with_version_retention_period.php
+++ b/spanner/src/create_database_with_version_retention_period.php
@@ -37,8 +37,11 @@ use Google\Cloud\Spanner\SpannerClient;
  * @param string $databaseId The Spanner database ID.
  * @param string $retentionPeriod The data retention period for the database.
  */
-function create_database_with_version_retention_period(string $instanceId, string $databaseId, string $retentionPeriod): void
-{
+function create_database_with_version_retention_period(
+    string $instanceId,
+    string $databaseId,
+    string $retentionPeriod
+): void {
     $spanner = new SpannerClient();
     $instance = $spanner->instance($instanceId);
 
@@ -69,8 +72,12 @@ function create_database_with_version_retention_period(string $instanceId, strin
     $database = $instance->database($databaseId);
     $databaseInfo = $database->info();
 
-    printf('Database %s created with version retention period %s and earliest version time %s' . PHP_EOL,
-        $databaseId, $databaseInfo['versionRetentionPeriod'], $databaseInfo['earliestVersionTime']);
+    printf(
+        'Database %s created with version retention period %s and earliest version time %s' . PHP_EOL,
+        $databaseId,
+        $databaseInfo['versionRetentionPeriod'],
+        $databaseInfo['earliestVersionTime']
+    );
 }
 // [END spanner_create_database_with_version_retention_period]
 

--- a/spanner/src/create_table_with_datatypes.php
+++ b/spanner/src/create_table_with_datatypes.php
@@ -59,8 +59,11 @@ function create_table_with_datatypes(string $instanceId, string $databaseId): vo
     print('Waiting for operation to complete...' . PHP_EOL);
     $operation->pollUntilComplete();
 
-    printf('Created Venues table in database %s on instance %s' . PHP_EOL,
-        $databaseId, $instanceId);
+    printf(
+        'Created Venues table in database %s on instance %s' . PHP_EOL,
+        $databaseId,
+        $instanceId
+    );
 }
 // [END spanner_create_table_with_datatypes]
 

--- a/spanner/src/create_table_with_timestamp_column.php
+++ b/spanner/src/create_table_with_timestamp_column.php
@@ -56,8 +56,11 @@ function create_table_with_timestamp_column(string $instanceId, string $database
     print('Waiting for operation to complete...' . PHP_EOL);
     $operation->pollUntilComplete();
 
-    printf('Created Performances table in database %s on instance %s' . PHP_EOL,
-        $databaseId, $instanceId);
+    printf(
+        'Created Performances table in database %s on instance %s' . PHP_EOL,
+        $databaseId,
+        $instanceId
+    );
 }
 // [END spanner_create_table_with_timestamp_column]
 

--- a/spanner/src/delete_data_with_dml.php
+++ b/spanner/src/delete_data_with_dml.php
@@ -41,7 +41,8 @@ function delete_data_with_dml(string $instanceId, string $databaseId): void
 
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
-            "DELETE FROM Singers WHERE FirstName = 'Alice'");
+            "DELETE FROM Singers WHERE FirstName = 'Alice'"
+        );
         $t->commit();
         printf('Deleted %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/dml_batch_update_request_priority.php
+++ b/spanner/src/dml_batch_update_request_priority.php
@@ -71,8 +71,10 @@ function dml_batch_update_request_priority(string $instanceId, string $databaseI
         ], array('priority' => $priority));
         $t->commit();
         $rowCounts = count($result->rowCounts());
-        printf('Executed %s SQL statements using Batch DML with PRIORITY_LOW.' . PHP_EOL,
-            $rowCounts);
+        printf(
+            'Executed %s SQL statements using Batch DML with PRIORITY_LOW.' . PHP_EOL,
+            $rowCounts
+        );
     });
 }
 // [END spanner_dml_batch_update_request_priority]

--- a/spanner/src/get_instance_config.php
+++ b/spanner/src/get_instance_config.php
@@ -35,8 +35,10 @@ function get_instance_config(string $instanceConfig): void
 {
     $spanner = new SpannerClient();
     $config = $spanner->instanceConfiguration($instanceConfig);
-    printf('Available leader options for instance config %s: %s' . PHP_EOL,
-        $instanceConfig, $config->info()['leaderOptions']
+    printf(
+        'Available leader options for instance config %s: %s' . PHP_EOL,
+        $instanceConfig,
+        $config->info()['leaderOptions']
     );
 }
 // [END spanner_get_instance_config]

--- a/spanner/src/insert_data_with_dml.php
+++ b/spanner/src/insert_data_with_dml.php
@@ -49,7 +49,8 @@ function insert_data_with_dml(string $instanceId, string $databaseId): void
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
             'INSERT Singers (SingerId, FirstName, LastName) '
-            . " VALUES (10, 'Virginia', 'Watson')");
+            . " VALUES (10, 'Virginia', 'Watson')"
+        );
         $t->commit();
         printf('Inserted %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/insert_data_with_timestamp_column.php
+++ b/spanner/src/insert_data_with_timestamp_column.php
@@ -47,9 +47,25 @@ function insert_data_with_timestamp_column(string $instanceId, string $databaseI
 
     $operation = $database->transaction(['singleUse' => true])
         ->insertBatch('Performances', [
-            ['SingerId' => 1, 'VenueId' => 4, 'EventDate' => '2017-10-05', 'Revenue' => 11000, 'LastUpdateTime' => $spanner->commitTimestamp()],
-            ['SingerId' => 1, 'VenueId' => 19, 'EventDate' => '2017-11-02', 'Revenue' => 15000, 'LastUpdateTime' => $spanner->commitTimestamp()],
-            ['SingerId' => 2, 'VenueId' => 42, 'EventDate' => '2017-12-23', 'Revenue' => 7000, 'LastUpdateTime' => $spanner->commitTimestamp()],
+            [
+                'SingerId' => 1,
+                'VenueId' => 4,
+                'EventDate' => '2017-10-05',
+                'Revenue' => 11000,
+                'LastUpdateTime' => $spanner->commitTimestamp(),
+            ],[
+                'SingerId' => 1,
+                'VenueId' => 19,
+                'EventDate' => '2017-11-02',
+                'Revenue' => 15000,
+                'LastUpdateTime' => $spanner->commitTimestamp(),
+            ],[
+                'SingerId' => 2,
+                'VenueId' => 42,
+                'EventDate' => '2017-12-23',
+                'Revenue' => 7000,
+                'LastUpdateTime' => $spanner->commitTimestamp(),
+            ],
         ])
         ->commit();
 

--- a/spanner/src/list_backup_operations.php
+++ b/spanner/src/list_backup_operations.php
@@ -47,8 +47,8 @@ function list_backup_operations(
     $filter = '(metadata.@type:type.googleapis.com/' .
               'google.spanner.admin.database.v1.CreateBackupMetadata) AND ' . "(metadata.database:$databaseId)";
 
-    // See https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#listbackupoperationsrequest
-    // for the possible filter values
+    // For the possible filter values, see
+    // https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#listbackupoperationsrequest
     $operations = $instance->backupOperations(['filter' => $filter]);
 
     foreach ($operations as $operation) {

--- a/spanner/src/list_databases.php
+++ b/spanner/src/list_databases.php
@@ -42,8 +42,11 @@ function list_databases(string $instanceId): void
     printf('Databases for %s' . PHP_EOL, $instance->name());
     foreach ($instance->databases() as $database) {
         if (isset($database->info()['defaultLeader'])) {
-            printf("\t%s (default leader = %s)" . PHP_EOL,
-                $database->info()['name'], $database->info()['defaultLeader']);
+            printf(
+                "\t%s (default leader = %s)" . PHP_EOL,
+                $database->info()['name'],
+                $database->info()['defaultLeader']
+            );
         } else {
             printf("\t%s" . PHP_EOL, $database->info()['name']);
         }

--- a/spanner/src/list_instance_configs.php
+++ b/spanner/src/list_instance_configs.php
@@ -37,8 +37,10 @@ function list_instance_configs(): void
 {
     $spanner = new SpannerClient();
     foreach ($spanner->instanceConfigurations() as $config) {
-        printf('Available leader options for instance config %s: %s' . PHP_EOL,
-            $config->info()['displayName'], $config->info()['leaderOptions']
+        printf(
+            'Available leader options for instance config %s: %s' . PHP_EOL,
+            $config->info()['displayName'],
+            $config->info()['leaderOptions']
         );
     }
 }

--- a/spanner/src/pg_case_sensitivity.php
+++ b/spanner/src/pg_case_sensitivity.php
@@ -51,14 +51,20 @@ function pg_case_sensitivity(string $instanceId, string $databaseId, string $tab
                 -- references any of these columns must use double quotes.
                 "FirstName" varchar(1024) NOT NULL,
                 "LastName"  varchar(1024) NOT NULL
-            )', $tableName)
+            )',
+            $tableName
+        )
     );
 
     print('Waiting for operation to complete...' . PHP_EOL);
     $operation->pollUntilComplete();
 
-    printf('Created %s table in database %s on instance %s' . PHP_EOL,
-        $tableName, $databaseId, $instanceId);
+    printf(
+        'Created %s table in database %s on instance %s' . PHP_EOL,
+        $tableName,
+        $databaseId,
+        $instanceId
+    );
 }
 // [END spanner_postgresql_case_sensitivity]
 

--- a/spanner/src/pg_create_database.php
+++ b/spanner/src/pg_create_database.php
@@ -54,8 +54,12 @@ function pg_create_database(string $instanceId, string $databaseId): void
     $database = $instance->database($databaseId);
     $dialect = DatabaseDialect::name($database->info()['databaseDialect']);
 
-    printf('Created database %s with dialect %s on instance %s' . PHP_EOL,
-        $databaseId, $dialect, $instanceId);
+    printf(
+        'Created database %s with dialect %s on instance %s' . PHP_EOL,
+        $databaseId,
+        $dialect,
+        $instanceId
+    );
 
     $table1Query = 'CREATE TABLE Singers (
         SingerId   bigint NOT NULL PRIMARY KEY,

--- a/spanner/src/pg_information_schema.php
+++ b/spanner/src/pg_information_schema.php
@@ -66,7 +66,8 @@ function pg_information_schema(string $instanceId, string $databaseId): void
             user_defined_type_name
         FROM INFORMATION_SCHEMA.tables
         WHERE table_schema=\'public\'
-        ');
+        '
+    );
 
     printf('Details fetched.' . PHP_EOL);
     foreach ($results as $row) {

--- a/spanner/src/pg_interleaved_table.php
+++ b/spanner/src/pg_interleaved_table.php
@@ -34,8 +34,12 @@ use Google\Cloud\Spanner\SpannerClient;
  * @param string $parentTable The parent table to create. Defaults to 'Singers'
  * @param string $childTable The child table to create. Defaults to 'Albums'
  */
-function pg_interleaved_table(string $instanceId, string $databaseId, string $parentTable = 'Singers', string $childTable = 'Albums'): void
-{
+function pg_interleaved_table(
+    string $instanceId,
+    string $databaseId,
+    string $parentTable = 'Singers',
+    string $childTable = 'Albums'
+): void {
     $spanner = new SpannerClient();
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);

--- a/spanner/src/pg_jsonb_query_parameter.php
+++ b/spanner/src/pg_jsonb_query_parameter.php
@@ -54,7 +54,8 @@ function pg_jsonb_query_parameter(
         'types' => [
             'p1' => Database::TYPE_INT64
         ]
-    ]);
+        ]
+    );
 
     foreach ($results as $row) {
         printf('VenueId: %s, VenueDetails: %s' . PHP_EOL, $row['venueid'], $row['venuedetails']);

--- a/spanner/src/pg_query_parameter.php
+++ b/spanner/src/pg_query_parameter.php
@@ -50,11 +50,16 @@ function pg_query_parameter(string $instanceId, string $databaseId): void
         'parameters' => [
             'p1' => 'A%'
         ]
-    ]
+        ]
     );
 
     foreach ($results as $row) {
-        printf('SingerId: %s, Firstname: %s, LastName: %s' . PHP_EOL, $row['singerid'], $row['firstname'], $row['lastname']);
+        printf(
+            'SingerId: %s, Firstname: %s, LastName: %s' . PHP_EOL,
+            $row['singerid'],
+            $row['firstname'],
+            $row['lastname']
+        );
     }
 }
 // [END spanner_postgresql_query_parameter]

--- a/spanner/src/query_data.php
+++ b/spanner/src/query_data.php
@@ -47,8 +47,12 @@ function query_data(string $instanceId, string $databaseId): void
     );
 
     foreach ($results as $row) {
-        printf('SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['AlbumTitle']);
+        printf(
+            'SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['AlbumTitle']
+        );
     }
 }
 // [END spanner_query_data]

--- a/spanner/src/query_data_with_array_of_struct.php
+++ b/spanner/src/query_data_with_array_of_struct.php
@@ -82,8 +82,10 @@ function query_data_with_array_of_struct(string $instanceId, string $databaseId)
         ]
     );
     foreach ($results as $row) {
-        printf('SingerId: %s' . PHP_EOL,
-            $row['SingerId']);
+        printf(
+            'SingerId: %s' . PHP_EOL,
+            $row['SingerId']
+        );
     }
     // [END spanner_query_data_with_array_of_struct]
 }

--- a/spanner/src/query_data_with_array_parameter.php
+++ b/spanner/src/query_data_with_array_parameter.php
@@ -61,8 +61,12 @@ function query_data_with_array_parameter(string $instanceId, string $databaseId)
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, AvailableDate: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'], $row['AvailableDate']);
+        printf(
+            'VenueId: %s, VenueName: %s, AvailableDate: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['AvailableDate']
+        );
     }
 }
 // [END spanner_query_with_array_parameter]

--- a/spanner/src/query_data_with_bool_parameter.php
+++ b/spanner/src/query_data_with_bool_parameter.php
@@ -56,9 +56,12 @@ function query_data_with_bool_parameter(string $instanceId, string $databaseId):
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, OutdoorVenue: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'],
-            $row['OutdoorVenue'] ? 'True' : 'False');
+        printf(
+            'VenueId: %s, VenueName: %s, OutdoorVenue: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['OutdoorVenue'] ? 'True' : 'False'
+        );
     }
 }
 // [END spanner_query_with_bool_parameter]

--- a/spanner/src/query_data_with_bytes_parameter.php
+++ b/spanner/src/query_data_with_bytes_parameter.php
@@ -59,8 +59,11 @@ function query_data_with_bytes_parameter(string $instanceId, string $databaseId)
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName']);
+        printf(
+            'VenueId: %s, VenueName: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName']
+        );
     }
 }
 // [END spanner_query_with_bytes_parameter]

--- a/spanner/src/query_data_with_date_parameter.php
+++ b/spanner/src/query_data_with_date_parameter.php
@@ -56,8 +56,12 @@ function query_data_with_date_parameter(string $instanceId, string $databaseId):
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, LastContactDate: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'], $row['LastContactDate']);
+        printf(
+            'VenueId: %s, VenueName: %s, LastContactDate: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['LastContactDate']
+        );
     }
 }
 // [END spanner_query_with_date_parameter]

--- a/spanner/src/query_data_with_float_parameter.php
+++ b/spanner/src/query_data_with_float_parameter.php
@@ -56,8 +56,12 @@ function query_data_with_float_parameter(string $instanceId, string $databaseId)
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, PopularityScore: %f' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'], $row['PopularityScore']);
+        printf(
+            'VenueId: %s, VenueName: %s, PopularityScore: %f' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['PopularityScore']
+        );
     }
 }
 // [END spanner_query_with_float_parameter]

--- a/spanner/src/query_data_with_index.php
+++ b/spanner/src/query_data_with_index.php
@@ -68,8 +68,12 @@ function query_data_with_index(
     );
 
     foreach ($results as $row) {
-        printf('AlbumId: %s, AlbumTitle: %s, MarketingBudget: %d' . PHP_EOL,
-            $row['AlbumId'], $row['AlbumTitle'], $row['MarketingBudget']);
+        printf(
+            'AlbumId: %s, AlbumTitle: %s, MarketingBudget: %d' . PHP_EOL,
+            $row['AlbumId'],
+            $row['AlbumTitle'],
+            $row['MarketingBudget']
+        );
     }
 }
 // [END spanner_query_data_with_index]

--- a/spanner/src/query_data_with_int_parameter.php
+++ b/spanner/src/query_data_with_int_parameter.php
@@ -56,8 +56,12 @@ function query_data_with_int_parameter(string $instanceId, string $databaseId): 
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, Capacity: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'], $row['Capacity']);
+        printf(
+            'VenueId: %s, VenueName: %s, Capacity: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['Capacity']
+        );
     }
 }
 // [END spanner_query_with_int_parameter]

--- a/spanner/src/query_data_with_nested_struct_field.php
+++ b/spanner/src/query_data_with_nested_struct_field.php
@@ -77,8 +77,11 @@ function query_data_with_nested_struct_field(string $instanceId, string $databas
         ]
     );
     foreach ($results as $row) {
-        printf('SingerId: %s SongName: %s' . PHP_EOL,
-            $row['SingerId'], $row['SongName']);
+        printf(
+            'SingerId: %s SongName: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['SongName']
+        );
     }
 }
 // [END spanner_field_access_on_nested_struct_parameters]

--- a/spanner/src/query_data_with_new_column.php
+++ b/spanner/src/query_data_with_new_column.php
@@ -53,8 +53,12 @@ function query_data_with_new_column(string $instanceId, string $databaseId): voi
     );
 
     foreach ($results as $row) {
-        printf('SingerId: %s, AlbumId: %s, MarketingBudget: %d' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['MarketingBudget']);
+        printf(
+            'SingerId: %s, AlbumId: %s, MarketingBudget: %d' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['MarketingBudget']
+        );
     }
 }
 // [END spanner_query_data_with_new_column]

--- a/spanner/src/query_data_with_numeric_parameter.php
+++ b/spanner/src/query_data_with_numeric_parameter.php
@@ -56,8 +56,11 @@ function query_data_with_numeric_parameter(string $instanceId, string $databaseI
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, Revenue: %s' . PHP_EOL,
-            $row['VenueId'], $row['Revenue']);
+        printf(
+            'VenueId: %s, Revenue: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['Revenue']
+        );
     }
 }
 // [END spanner_query_with_numeric_parameter]

--- a/spanner/src/query_data_with_parameter.php
+++ b/spanner/src/query_data_with_parameter.php
@@ -49,8 +49,12 @@ function query_data_with_parameter(string $instanceId, string $databaseId): void
     );
 
     foreach ($results as $row) {
-        printf('SingerId: %s, FirstName: %s, LastName: %s' . PHP_EOL,
-            $row['SingerId'], $row['FirstName'], $row['LastName']);
+        printf(
+            'SingerId: %s, FirstName: %s, LastName: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['FirstName'],
+            $row['LastName']
+        );
     }
 }
 // [END spanner_query_with_parameter]

--- a/spanner/src/query_data_with_query_options.php
+++ b/spanner/src/query_data_with_query_options.php
@@ -56,8 +56,12 @@ function query_data_with_query_options(string $instanceId, string $databaseId): 
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, LastUpdateTime: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'], $row['LastUpdateTime']);
+        printf(
+            'VenueId: %s, VenueName: %s, LastUpdateTime: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['LastUpdateTime']
+        );
     }
 }
 // [END spanner_query_with_query_options]

--- a/spanner/src/query_data_with_string_parameter.php
+++ b/spanner/src/query_data_with_string_parameter.php
@@ -56,8 +56,11 @@ function query_data_with_string_parameter(string $instanceId, string $databaseId
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName']);
+        printf(
+            'VenueId: %s, VenueName: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName']
+        );
     }
 }
 // [END spanner_query_with_string_parameter]

--- a/spanner/src/query_data_with_struct.php
+++ b/spanner/src/query_data_with_struct.php
@@ -68,8 +68,10 @@ function query_data_with_struct(string $instanceId, string $databaseId): void
         ]
     );
     foreach ($results as $row) {
-        printf('SingerId: %s' . PHP_EOL,
-            $row['SingerId']);
+        printf(
+            'SingerId: %s' . PHP_EOL,
+            $row['SingerId']
+        );
     }
     // [END spanner_query_data_with_struct]
 }

--- a/spanner/src/query_data_with_struct_field.php
+++ b/spanner/src/query_data_with_struct_field.php
@@ -62,8 +62,10 @@ function query_data_with_struct_field(string $instanceId, string $databaseId): v
         ]
     );
     foreach ($results as $row) {
-        printf('SingerId: %s' . PHP_EOL,
-            $row['SingerId']);
+        printf(
+            'SingerId: %s' . PHP_EOL,
+            $row['SingerId']
+        );
     }
 }
 // [END spanner_field_access_on_struct_parameters]

--- a/spanner/src/query_data_with_timestamp_column.php
+++ b/spanner/src/query_data_with_timestamp_column.php
@@ -39,7 +39,7 @@ use Google\Cloud\Spanner\SpannerClient;
  * add the column by running the `add_timestamp_column` sample or by running
  * this DDL statement against your database:
  *
- * 		ALTER TABLE Albums ADD COLUMN LastUpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp=true)
+ *      ALTER TABLE Albums ADD COLUMN LastUpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp=true)
  *
  * Example:
  * ```
@@ -67,8 +67,13 @@ function query_data_with_timestamp_column(string $instanceId, string $databaseId
         if ($row['LastUpdateTime'] == null) {
             $row['LastUpdateTime'] = 'NULL';
         }
-        printf('SingerId: %s, AlbumId: %s, MarketingBudget: %s, LastUpdateTime: %s' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['MarketingBudget'], $row['LastUpdateTime']);
+        printf(
+            'SingerId: %s, AlbumId: %s, MarketingBudget: %s, LastUpdateTime: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['MarketingBudget'],
+            $row['LastUpdateTime']
+        );
     }
 }
 // [END spanner_query_data_with_timestamp_column]

--- a/spanner/src/query_data_with_timestamp_parameter.php
+++ b/spanner/src/query_data_with_timestamp_parameter.php
@@ -56,8 +56,12 @@ function query_data_with_timestamp_parameter(string $instanceId, string $databas
     );
 
     foreach ($results as $row) {
-        printf('VenueId: %s, VenueName: %s, LastUpdateTime: %s' . PHP_EOL,
-            $row['VenueId'], $row['VenueName'], $row['LastUpdateTime']);
+        printf(
+            'VenueId: %s, VenueName: %s, LastUpdateTime: %s' . PHP_EOL,
+            $row['VenueId'],
+            $row['VenueName'],
+            $row['LastUpdateTime']
+        );
     }
 }
 // [END spanner_query_with_timestamp_parameter]

--- a/spanner/src/read_data.php
+++ b/spanner/src/read_data.php
@@ -50,8 +50,12 @@ function read_data(string $instanceId, string $databaseId): void
     );
 
     foreach ($results->rows() as $row) {
-        printf('SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['AlbumTitle']);
+        printf(
+            'SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['AlbumTitle']
+        );
     }
 }
 // [END spanner_read_data]

--- a/spanner/src/read_data_with_database_role.php
+++ b/spanner/src/read_data_with_database_role.php
@@ -45,7 +45,12 @@ function read_data_with_database_role(string $instanceId, string $databaseId): v
     $results = $database->execute('SELECT * FROM Singers');
 
     foreach ($results as $row) {
-        printf('SingerId: %s, Firstname: %s, LastName: %s' . PHP_EOL, $row['SingerId'], $row['FirstName'], $row['LastName']);
+        printf(
+            'SingerId: %s, Firstname: %s, LastName: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['FirstName'],
+            $row['LastName']
+        );
     }
 }
 // [END spanner_read_data_with_database_role]

--- a/spanner/src/read_data_with_index.php
+++ b/spanner/src/read_data_with_index.php
@@ -58,8 +58,11 @@ function read_data_with_index(string $instanceId, string $databaseId): void
     );
 
     foreach ($results->rows() as $row) {
-        printf('AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
-            $row['AlbumId'], $row['AlbumTitle']);
+        printf(
+            'AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['AlbumId'],
+            $row['AlbumTitle']
+        );
     }
 }
 // [END spanner_read_data_with_index]

--- a/spanner/src/read_data_with_storing_index.php
+++ b/spanner/src/read_data_with_storing_index.php
@@ -64,8 +64,12 @@ function read_data_with_storing_index(string $instanceId, string $databaseId): v
     );
 
     foreach ($results->rows() as $row) {
-        printf('AlbumId: %s, AlbumTitle: %s, MarketingBudget: %d' . PHP_EOL,
-            $row['AlbumId'], $row['AlbumTitle'], $row['MarketingBudget']);
+        printf(
+            'AlbumId: %s, AlbumTitle: %s, MarketingBudget: %d' . PHP_EOL,
+            $row['AlbumId'],
+            $row['AlbumTitle'],
+            $row['MarketingBudget']
+        );
     }
 }
 // [END spanner_read_data_with_storing_index]

--- a/spanner/src/read_only_transaction.php
+++ b/spanner/src/read_only_transaction.php
@@ -51,8 +51,12 @@ function read_only_transaction(string $instanceId, string $databaseId): void
     );
     print('Results from the first read:' . PHP_EOL);
     foreach ($results as $row) {
-        printf('SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['AlbumTitle']);
+        printf(
+            'SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['AlbumTitle']
+        );
     }
 
     // Perform another read using the `read` method. Even if the data
@@ -67,8 +71,12 @@ function read_only_transaction(string $instanceId, string $databaseId): void
 
     print('Results from the second read:' . PHP_EOL);
     foreach ($results->rows() as $row) {
-        printf('SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['AlbumTitle']);
+        printf(
+            'SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['AlbumTitle']
+        );
     }
 }
 // [END spanner_read_only_transaction]

--- a/spanner/src/read_stale_data.php
+++ b/spanner/src/read_stale_data.php
@@ -53,8 +53,12 @@ function read_stale_data(string $instanceId, string $databaseId): void
     );
 
     foreach ($results->rows() as $row) {
-        printf('SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['AlbumTitle']);
+        printf(
+            'SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['AlbumTitle']
+        );
     }
 }
 // [END spanner_read_stale_data]

--- a/spanner/src/restore_backup.php
+++ b/spanner/src/restore_backup.php
@@ -56,7 +56,10 @@ function restore_backup(string $instanceId, string $databaseId, string $backupId
 
     printf(
         'Database %s restored from backup %s with version time %s' . PHP_EOL,
-        $sourceDatabase, $sourceBackup, $versionTime);
+        $sourceDatabase,
+        $sourceBackup,
+        $versionTime
+    );
 }
 // [END spanner_restore_backup]
 

--- a/spanner/src/restore_backup_with_encryption_key.php
+++ b/spanner/src/restore_backup_with_encryption_key.php
@@ -38,8 +38,12 @@ use Google\Cloud\Spanner\SpannerClient;
  * @param string $backupId The Spanner backup ID.
  * @param string $kmsKeyName The KMS key used for encryption.
  */
-function restore_backup_with_encryption_key(string $instanceId, string $databaseId, string $backupId, string $kmsKeyName): void
-{
+function restore_backup_with_encryption_key(
+    string $instanceId,
+    string $databaseId,
+    string $backupId,
+    string $kmsKeyName
+): void {
     $spanner = new SpannerClient();
     $instance = $spanner->instance($instanceId);
     $database = $instance->database($databaseId);
@@ -63,7 +67,10 @@ function restore_backup_with_encryption_key(string $instanceId, string $database
 
     printf(
         'Database %s restored from backup %s using encryption key %s' . PHP_EOL,
-        $sourceDatabase, $sourceBackup, $encryptionConfig['kmsKeyName']);
+        $sourceDatabase,
+        $sourceBackup,
+        $encryptionConfig['kmsKeyName']
+    );
 }
 // [END spanner_restore_backup_with_encryption_key]
 

--- a/spanner/src/set_request_tag.php
+++ b/spanner/src/set_request_tag.php
@@ -52,8 +52,12 @@ function set_request_tag(string $instanceId, string $databaseId): void
         ]
     );
     foreach ($results as $row) {
-        printf('SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
-            $row['SingerId'], $row['AlbumId'], $row['AlbumTitle']);
+        printf(
+            'SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['SingerId'],
+            $row['AlbumId'],
+            $row['AlbumTitle']
+        );
     }
 }
 // [END spanner_set_request_tag]

--- a/spanner/src/update_data_with_batch_dml.php
+++ b/spanner/src/update_data_with_batch_dml.php
@@ -65,8 +65,10 @@ function update_data_with_batch_dml(string $instanceId, string $databaseId): voi
         ]);
         $t->commit();
         $rowCounts = count($result->rowCounts());
-        printf('Executed %s SQL statements using Batch DML.' . PHP_EOL,
-            $rowCounts);
+        printf(
+            'Executed %s SQL statements using Batch DML.' . PHP_EOL,
+            $rowCounts
+        );
     });
 }
 // [END spanner_dml_batch_update]

--- a/spanner/src/update_data_with_dml.php
+++ b/spanner/src/update_data_with_dml.php
@@ -54,7 +54,8 @@ function update_data_with_dml(string $instanceId, string $databaseId): void
         $rowCount = $t->executeUpdate(
             'UPDATE Albums '
             . 'SET MarketingBudget = MarketingBudget * 2 '
-            . 'WHERE SingerId = 1 and AlbumId = 1');
+            . 'WHERE SingerId = 1 and AlbumId = 1'
+        );
         $t->commit();
         printf('Updated %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/update_data_with_dml_structs.php
+++ b/spanner/src/update_data_with_dml_structs.php
@@ -68,7 +68,8 @@ function update_data_with_dml_structs(string $instanceId, string $databaseId): v
                 'types' => [
                     'name' => $nameType
                 ]
-            ]);
+            ]
+        );
         $t->commit();
         printf('Updated %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/update_data_with_dml_timestamp.php
+++ b/spanner/src/update_data_with_dml_timestamp.php
@@ -49,7 +49,8 @@ function update_data_with_dml_timestamp(string $instanceId, string $databaseId):
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
             'UPDATE Albums '
-            . 'SET LastUpdateTime = PENDING_COMMIT_TIMESTAMP() WHERE SingerId = 1');
+            . 'SET LastUpdateTime = PENDING_COMMIT_TIMESTAMP() WHERE SingerId = 1'
+        );
         $t->commit();
         printf('Updated %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/update_data_with_timestamp_column.php
+++ b/spanner/src/update_data_with_timestamp_column.php
@@ -51,8 +51,17 @@ function update_data_with_timestamp_column(string $instanceId, string $databaseI
 
     $operation = $database->transaction(['singleUse' => true])
         ->updateBatch('Albums', [
-            ['SingerId' => 1, 'AlbumId' => 1, 'MarketingBudget' => 1000000, 'LastUpdateTime' => $spanner->commitTimestamp()],
-            ['SingerId' => 2, 'AlbumId' => 2, 'MarketingBudget' => 750000, 'LastUpdateTime' => $spanner->commitTimestamp()],
+            [
+                'SingerId' => 1,
+                'AlbumId' => 1,
+                'MarketingBudget' => 1000000,
+                'LastUpdateTime' => $spanner->commitTimestamp()
+            ], [
+                'SingerId' => 2,
+                'AlbumId' => 2,
+                'MarketingBudget' => 750000,
+                'LastUpdateTime' => $spanner->commitTimestamp()
+            ],
         ])
         ->commit();
 

--- a/spanner/src/update_database_with_default_leader.php
+++ b/spanner/src/update_database_with_default_leader.php
@@ -44,7 +44,8 @@ function update_database_with_default_leader(string $instanceId, string $databas
     $database = $instance->database($databaseId);
 
     $database->updateDdl(
-        "ALTER DATABASE `$databaseId` SET OPTIONS (default_leader = '$defaultLeader')");
+        "ALTER DATABASE `$databaseId` SET OPTIONS (default_leader = '$defaultLeader')"
+    );
 
     printf('Updated the default leader to %d' . PHP_EOL, $database->info()['defaultLeader']);
 }

--- a/spanner/src/write_data_with_dml.php
+++ b/spanner/src/write_data_with_dml.php
@@ -52,7 +52,8 @@ function write_data_with_dml(string $instanceId, string $databaseId): void
             . "(12, 'Melissa', 'Garcia'), "
             . "(13, 'Russell', 'Morales'), "
             . "(14, 'Jacqueline', 'Long'), "
-            . "(15, 'Dylan', 'Shaw')");
+            . "(15, 'Dylan', 'Shaw')"
+        );
         $t->commit();
         printf('Inserted %d row(s).' . PHP_EOL, $rowCount);
     });

--- a/spanner/src/write_read_with_dml.php
+++ b/spanner/src/write_read_with_dml.php
@@ -49,7 +49,8 @@ function write_read_with_dml(string $instanceId, string $databaseId): void
     $database->runTransaction(function (Transaction $t) use ($spanner) {
         $rowCount = $t->executeUpdate(
             'INSERT Singers (SingerId, FirstName, LastName) '
-            . " VALUES (11, 'Timothy', 'Campbell')");
+            . " VALUES (11, 'Timothy', 'Campbell')"
+        );
 
         printf('Inserted %d row(s).' . PHP_EOL, $rowCount);
 

--- a/spanner/test/spannerBackupTest.php
+++ b/spanner/test/spannerBackupTest.php
@@ -89,8 +89,10 @@ class spannerBackupTest extends TestCase
         self::$encryptedRestoredDatabaseId = self::$databaseId . '-en-r';
         self::$instance = $spanner->instance(self::$instanceId);
 
-        self::$kmsKeyName =
-            'projects/' . self::$projectId . '/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek';
+        self::$kmsKeyName = sprintf(
+            'projects/%s/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek',
+            self::$projectId
+        );
     }
 
     public function testCreateDatabaseWithVersionRetentionPeriod()

--- a/spanner/test/spannerPgTest.php
+++ b/spanner/test/spannerPgTest.php
@@ -68,8 +68,11 @@ class spannerPgTest extends TestCase
     {
         $output = $this->runFunctionSnippet('pg_create_database');
         self::$lastUpdateDataTimestamp = time();
-        $expected = sprintf('Created database %s with dialect POSTGRESQL on instance %s',
-            self::$databaseId, self::$instanceId);
+        $expected = sprintf(
+            'Created database %s with dialect POSTGRESQL on instance %s',
+            self::$databaseId,
+            self::$instanceId
+        );
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -98,7 +101,10 @@ class spannerPgTest extends TestCase
         $output = $this->runFunctionSnippet('pg_functions');
         self::$lastUpdateDataTimestamp = time();
 
-        $this->assertStringContainsString('1284352323 seconds after epoch is 2010-09-13T04:32:03.000000Z', $output);
+        $this->assertStringContainsString(
+            '1284352323 seconds after epoch is 2010-09-13T04:32:03.000000Z',
+            $output
+        );
     }
 
     /*
@@ -111,8 +117,12 @@ class spannerPgTest extends TestCase
             self::$instanceId, self::$databaseId, $tableName
         ]);
         self::$lastUpdateDataTimestamp = time();
-        $expected = sprintf('Created %s table in database %s on instance %s',
-            $tableName, self::$databaseId, self::$instanceId);
+        $expected = sprintf(
+            'Created %s table in database %s on instance %s',
+            $tableName,
+            self::$databaseId,
+            self::$instanceId
+        );
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -181,7 +191,8 @@ class spannerPgTest extends TestCase
         $op->pollUntilComplete();
 
         $db->runTransaction(function (Transaction $t) {
-            $t->executeUpdate('INSERT INTO users (id, name, active)'
+            $t->executeUpdate(
+                'INSERT INTO users (id, name, active)'
                 . ' VALUES ($1, $2, $3), ($4, $5, $6)',
                 [
                     'parameters' => [
@@ -192,7 +203,8 @@ class spannerPgTest extends TestCase
                         'p5' => 'Bruce',
                         'p6' => false,
                     ]
-                ]);
+                ]
+            );
             $t->commit();
         });
 
@@ -266,7 +278,10 @@ class spannerPgTest extends TestCase
         ]);
         self::$lastUpdateDataTimestamp = time();
 
-        $this->assertStringContainsString(sprintf('Added column VenueDetails on table %s.', self::$jsonbTable), $output);
+        $this->assertStringContainsString(
+            sprintf('Added column VenueDetails on table %s.', self::$jsonbTable),
+            $output
+        );
     }
 
     /**

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -122,8 +122,10 @@ class spannerTest extends TestCase
         self::$encryptedDatabaseId = 'en-test-' . time() . rand();
         self::$backupId = 'backup-' . self::$databaseId;
         self::$instance = $spanner->instance(self::$instanceId);
-        self::$kmsKeyName =
-            'projects/' . self::$projectId . '/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek';
+        self::$kmsKeyName = sprintf(
+            'projects/%s/locations/us-central1/keyRings/spanner-test-keyring/cryptoKeys/spanner-test-cmek',
+            self::$projectId
+        );
         self::$lowCostInstance = $spanner->instance(self::$lowCostInstanceId);
 
         self::$multiInstanceId = 'kokoro-multi-instance';
@@ -162,7 +164,10 @@ class spannerTest extends TestCase
             self::$customInstanceConfigId, self::$baseConfigId
         ]);
 
-        $this->assertStringContainsString(sprintf('Created instance configuration %s', self::$customInstanceConfigId), $output);
+        $this->assertStringContainsString(
+            sprintf('Created instance configuration %s', self::$customInstanceConfigId),
+            $output
+        );
     }
 
     /**
@@ -174,7 +179,10 @@ class spannerTest extends TestCase
             self::$customInstanceConfigId
         ]);
 
-        $this->assertStringContainsString(sprintf('Updated instance configuration %s', self::$customInstanceConfigId), $output);
+        $this->assertStringContainsString(
+            sprintf('Updated instance configuration %s', self::$customInstanceConfigId),
+            $output
+        );
     }
 
     /**
@@ -185,7 +193,10 @@ class spannerTest extends TestCase
         $output = $this->runFunctionSnippet('delete_instance_config', [
             self::$customInstanceConfigId
         ]);
-        $this->assertStringContainsString(sprintf('Deleted instance configuration %s', self::$customInstanceConfigId), $output);
+        $this->assertStringContainsString(
+            sprintf('Deleted instance configuration %s', self::$customInstanceConfigId),
+            $output
+        );
     }
 
     /**
@@ -203,7 +214,8 @@ class spannerTest extends TestCase
                 self::$customInstanceConfigId,
                 'type.googleapis.com/google.spanner.admin.instance.v1.CreateInstanceConfigMetadata'
             ),
-            $output);
+            $output
+        );
 
         $this->assertStringContainsString(
             sprintf(
@@ -211,7 +223,8 @@ class spannerTest extends TestCase
                 self::$customInstanceConfigId,
                 'type.googleapis.com/google.spanner.admin.instance.v1.UpdateInstanceConfigMetadata'
             ),
-            $output);
+            $output
+        );
     }
 
     /**
@@ -353,7 +366,10 @@ class spannerTest extends TestCase
     {
         $this->runFunctionSnippet('update_data');
         $output = $this->runFunctionSnippet('read_write_transaction');
-        $this->assertStringContainsString('Setting first album\'s budget to 300000 and the second album\'s budget to 300000', $output);
+        $this->assertStringContainsString(
+            'Setting first album\'s budget to 300000 and the second album\'s budget to 300000',
+            $output
+        );
         $this->assertStringContainsString('Transaction complete.', $output);
     }
 
@@ -489,12 +505,12 @@ class spannerTest extends TestCase
      */
     public function testQueryDataTimestamp()
     {
-        $output = $this->runFunctionSnippet('query_data_with_timestamp_column');
-        $this->assertStringContainsString('SingerId: 1, AlbumId: 1, MarketingBudget: 1000000, LastUpdateTime: 20', $output);
-        $this->assertStringContainsString('SingerId: 2, AlbumId: 2, MarketingBudget: 750000, LastUpdateTime: 20', $output);
-        $this->assertStringContainsString('SingerId: 1, AlbumId: 2, MarketingBudget: NULL, LastUpdateTime: NULL', $output);
-        $this->assertStringContainsString('SingerId: 2, AlbumId: 1, MarketingBudget: NULL, LastUpdateTime: NULL', $output);
-        $this->assertStringContainsString('SingerId: 2, AlbumId: 3, MarketingBudget: NULL, LastUpdateTime: NULL', $output);
+        $o = $this->runFunctionSnippet('query_data_with_timestamp_column');
+        $this->assertStringContainsString('SingerId: 1, AlbumId: 1, MarketingBudget: 1000000, LastUpdateTime: 20', $o);
+        $this->assertStringContainsString('SingerId: 2, AlbumId: 2, MarketingBudget: 750000, LastUpdateTime: 20', $o);
+        $this->assertStringContainsString('SingerId: 1, AlbumId: 2, MarketingBudget: NULL, LastUpdateTime: NULL', $o);
+        $this->assertStringContainsString('SingerId: 2, AlbumId: 1, MarketingBudget: NULL, LastUpdateTime: NULL', $o);
+        $this->assertStringContainsString('SingerId: 2, AlbumId: 3, MarketingBudget: NULL, LastUpdateTime: NULL', $o);
     }
 
     /**
@@ -942,10 +958,22 @@ class spannerTest extends TestCase
     public function testAddDropDatabaseRole()
     {
         $output = $this->runFunctionSnippet('add_drop_database_role');
-        $this->assertStringContainsString('Waiting for create role and grant operation to complete...' . PHP_EOL, $output);
-        $this->assertStringContainsString('Created roles new_parent and new_child and granted privileges' . PHP_EOL, $output);
-        $this->assertStringContainsString('Waiting for revoke role and drop role operation to complete...' . PHP_EOL, $output);
-        $this->assertStringContainsString('Revoked privileges and dropped role new_child' . PHP_EOL, $output);
+        $this->assertStringContainsString(
+            'Waiting for create role and grant operation to complete...' . PHP_EOL,
+            $output
+        );
+        $this->assertStringContainsString(
+            'Created roles new_parent and new_child and granted privileges' . PHP_EOL,
+            $output
+        );
+        $this->assertStringContainsString(
+            'Waiting for revoke role and drop role operation to complete...' . PHP_EOL,
+            $output
+        );
+        $this->assertStringContainsString(
+            'Revoked privileges and dropped role new_child' . PHP_EOL,
+            $output
+        );
     }
 
     /**

--- a/speech/src/transcribe_async_words.php
+++ b/speech/src/transcribe_async_words.php
@@ -78,10 +78,12 @@ function transcribe_async_words(string $audioFile)
             foreach ($mostLikely->getWords() as $wordInfo) {
                 $startTime = $wordInfo->getStartTime();
                 $endTime = $wordInfo->getEndTime();
-                printf('  Word: %s (start: %s, end: %s)' . PHP_EOL,
+                printf(
+                    '  Word: %s (start: %s, end: %s)' . PHP_EOL,
                     $wordInfo->getWord(),
                     $startTime->serializeToJsonString(),
-                    $endTime->serializeToJsonString());
+                    $endTime->serializeToJsonString()
+                );
             }
         }
     } else {

--- a/speech/test/quickstartTest.php
+++ b/speech/test/quickstartTest.php
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+namespace Google\Cloud\Samples\Speech\Test;
+
 use PHPUnit\Framework\TestCase;
 use Google\Cloud\TestUtils\TestTrait;
 

--- a/storage/src/add_bucket_conditional_iam_binding.php
+++ b/storage/src/add_bucket_conditional_iam_binding.php
@@ -44,8 +44,14 @@ use Google\Cloud\Storage\StorageClient;
  * To see how to express a condition in CEL, visit:
  * @see https://cloud.google.com/storage/docs/access-control/iam#conditions.
  */
-function add_bucket_conditional_iam_binding(string $bucketName, string $role, array $members, string $title, string $description, string $expression): void
-{
+function add_bucket_conditional_iam_binding(
+    string $bucketName,
+    string $role,
+    array $members,
+    string $title,
+    string $description,
+    string $expression
+): void {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 

--- a/storage/src/compose_file.php
+++ b/storage/src/compose_file.php
@@ -38,8 +38,12 @@ use Google\Cloud\Storage\StorageClient;
  * @param string $targetObjectName The name of the object to be created.
  *        (e.g. 'composed-my-object-1-my-object-2')
  */
-function compose_file(string $bucketName, string $firstObjectName, string $secondObjectName, string $targetObjectName): void
-{
+function compose_file(
+    string $bucketName,
+    string $firstObjectName,
+    string $secondObjectName,
+    string $targetObjectName
+): void {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 

--- a/storage/src/copy_file_archived_generation.php
+++ b/storage/src/copy_file_archived_generation.php
@@ -38,8 +38,12 @@ use Google\Cloud\Storage\StorageClient;
  * @param string $newObjectName The name of the target object.
  *        (e.g. 'my-object-1579287380533984')
  */
-function copy_file_archived_generation(string $bucketName, string $objectToCopy, string $generationToCopy, string $newObjectName): void
-{
+function copy_file_archived_generation(
+    string $bucketName,
+    string $objectToCopy,
+    string $generationToCopy,
+    string $newObjectName
+): void {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 

--- a/storage/src/copy_object.php
+++ b/storage/src/copy_object.php
@@ -44,8 +44,13 @@ function copy_object(string $bucketName, string $objectName, string $newBucketNa
     $bucket = $storage->bucket($bucketName);
     $object = $bucket->object($objectName);
     $object->copy($newBucketName, ['name' => $newObjectName]);
-    printf('Copied gs://%s/%s to gs://%s/%s' . PHP_EOL,
-        $bucketName, $objectName, $newBucketName, $newObjectName);
+    printf(
+        'Copied gs://%s/%s to gs://%s/%s' . PHP_EOL,
+        $bucketName,
+        $objectName,
+        $newBucketName,
+        $newObjectName
+    );
 }
 # [END storage_copy_file]
 

--- a/storage/src/cors_configuration.php
+++ b/storage/src/cors_configuration.php
@@ -40,8 +40,13 @@ use Google\Cloud\Storage\StorageClient;
  *        (e.g. 3600)
  *     requests before it must repeat preflighted requests.
  */
-function cors_configuration(string $bucketName, string $method, string $origin, string $responseHeader, int $maxAgeSeconds): void
-{
+function cors_configuration(
+    string $bucketName,
+    string $method,
+    string $origin,
+    string $responseHeader,
+    int $maxAgeSeconds
+): void {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 

--- a/storage/src/define_bucket_website_configuration.php
+++ b/storage/src/define_bucket_website_configuration.php
@@ -38,8 +38,11 @@ use Google\Cloud\Storage\StorageClient;
  *        (e.g. '404.html')
  *     as the 404 Not Found page.
  */
-function define_bucket_website_configuration(string $bucketName, string $indexPageObject, string $notFoundPageObject): void
-{
+function define_bucket_website_configuration(
+    string $bucketName,
+    string $indexPageObject,
+    string $notFoundPageObject
+): void {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 

--- a/storage/src/download_encrypted_object.php
+++ b/storage/src/download_encrypted_object.php
@@ -39,16 +39,24 @@ use Google\Cloud\Storage\StorageClient;
  *        (e.g. 'TIbv/fjexq+VmtXzAlc63J4z5kFmWJ6NdAPQulQBT7g=')
  *     be the same key originally used to encrypt the object.
  */
-function download_encrypted_object(string $bucketName, string $objectName, string $destination, string $base64EncryptionKey): void
-{
+function download_encrypted_object(
+    string $bucketName,
+    string $objectName,
+    string $destination,
+    string $base64EncryptionKey
+): void {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
     $object = $bucket->object($objectName);
     $object->downloadToFile($destination, [
         'encryptionKey' => $base64EncryptionKey,
     ]);
-    printf('Encrypted object gs://%s/%s downloaded to %s' . PHP_EOL,
-        $bucketName, $objectName, basename($destination));
+    printf(
+        'Encrypted object gs://%s/%s downloaded to %s' . PHP_EOL,
+        $bucketName,
+        $objectName,
+        basename($destination)
+    );
 }
 # [END storage_download_encrypted_file]
 

--- a/storage/src/download_file_requester_pays.php
+++ b/storage/src/download_file_requester_pays.php
@@ -38,8 +38,12 @@ use Google\Cloud\Storage\StorageClient;
  * @param string $destination The local destination to save the object.
  *        (e.g. '/path/to/your/file')
  */
-function download_file_requester_pays(string $projectId, string $bucketName, string $objectName, string $destination): void
-{
+function download_file_requester_pays(
+    string $projectId,
+    string $bucketName,
+    string $objectName,
+    string $destination
+): void {
     $storage = new StorageClient([
         'projectId' => $projectId
     ]);
@@ -47,8 +51,12 @@ function download_file_requester_pays(string $projectId, string $bucketName, str
     $bucket = $storage->bucket($bucketName, $userProject);
     $object = $bucket->object($objectName);
     $object->downloadToFile($destination);
-    printf('Downloaded gs://%s/%s to %s using requester-pays requests.' . PHP_EOL,
-        $bucketName, $objectName, basename($destination));
+    printf(
+        'Downloaded gs://%s/%s to %s using requester-pays requests.' . PHP_EOL,
+        $bucketName,
+        $objectName,
+        basename($destination)
+    );
 }
 # [END storage_download_file_requester_pays]
 

--- a/storage/src/enable_default_kms_key.php
+++ b/storage/src/enable_default_kms_key.php
@@ -44,9 +44,11 @@ function enable_default_kms_key(string $bucketName, string $kmsKeyName): void
             'defaultKmsKeyName' => $kmsKeyName
         ]
     ]);
-    printf('Default KMS key for %s was set to %s' . PHP_EOL,
+    printf(
+        'Default KMS key for %s was set to %s' . PHP_EOL,
         $bucketName,
-        $bucket->info()['encryption']['defaultKmsKeyName']);
+        $bucket->info()['encryption']['defaultKmsKeyName']
+    );
 }
 # [END storage_set_bucket_default_kms_key]
 

--- a/storage/src/get_bucket_autoclass.php
+++ b/storage/src/get_bucket_autoclass.php
@@ -39,11 +39,13 @@ function get_bucket_autoclass(string $bucketName): void
     $info = $bucket->info();
 
     if (isset($info['autoclass'])) {
-        printf('Bucket %s has autoclass enabled: %s' . PHP_EOL,
+        printf(
+            'Bucket %s has autoclass enabled: %s' . PHP_EOL,
             $bucketName,
             $info['autoclass']['enabled']
         );
-        printf('Bucket %s has autoclass toggle time: %s' . PHP_EOL,
+        printf(
+            'Bucket %s has autoclass toggle time: %s' . PHP_EOL,
             $bucketName,
             $info['autoclass']['toggleTime']
         );

--- a/storage/src/move_object.php
+++ b/storage/src/move_object.php
@@ -45,11 +45,13 @@ function move_object(string $bucketName, string $objectName, string $newBucketNa
     $object = $bucket->object($objectName);
     $object->copy($newBucketName, ['name' => $newObjectName]);
     $object->delete();
-    printf('Moved gs://%s/%s to gs://%s/%s' . PHP_EOL,
+    printf(
+        'Moved gs://%s/%s to gs://%s/%s' . PHP_EOL,
         $bucketName,
         $objectName,
         $newBucketName,
-        $newObjectName);
+        $newObjectName
+    );
 }
 # [END storage_move_file]
 

--- a/storage/src/print_bucket_website_configuration.php
+++ b/storage/src/print_bucket_website_configuration.php
@@ -41,9 +41,9 @@ function print_bucket_website_configuration(string $bucketName): void
         printf('Bucket website configuration not set' . PHP_EOL);
     } else {
         printf(
-          'Index page: %s' . PHP_EOL . '404 page: %s' . PHP_EOL,
-          $info['website']['mainPageSuffix'],
-          $info['website']['notFoundPage'],
+            'Index page: %s' . PHP_EOL . '404 page: %s' . PHP_EOL,
+            $info['website']['mainPageSuffix'],
+            $info['website']['notFoundPage'],
         );
     }
 }

--- a/storage/src/remove_bucket_conditional_iam_binding.php
+++ b/storage/src/remove_bucket_conditional_iam_binding.php
@@ -42,8 +42,13 @@ use Google\Cloud\Storage\StorageClient;
  * @param string $expression Te condition specified in CEL expression language.
  *        (e.g. 'resource.name.startsWith("projects/_/buckets/bucket-name/objects/prefix-a-")')
  */
-function remove_bucket_conditional_iam_binding(string $bucketName, string $role, string $title, string $description, string $expression): void
-{
+function remove_bucket_conditional_iam_binding(
+    string $bucketName,
+    string $role,
+    string $title,
+    string $description,
+    string $expression
+): void {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 

--- a/storage/src/rotate_encryption_key.php
+++ b/storage/src/rotate_encryption_key.php
@@ -55,8 +55,11 @@ function rotate_encryption_key(
         'destinationEncryptionKey' => $newBase64EncryptionKey,
     ]);
 
-    printf('Rotated encryption key for object gs://%s/%s' . PHP_EOL,
-        $bucketName, $objectName);
+    printf(
+        'Rotated encryption key for object gs://%s/%s' . PHP_EOL,
+        $bucketName,
+        $objectName
+    );
 }
 # [END storage_rotate_encryption_key]
 

--- a/storage/src/set_retention_policy.php
+++ b/storage/src/set_retention_policy.php
@@ -42,8 +42,11 @@ function set_retention_policy(string $bucketName, int $retentionPeriod): void
         'retentionPolicy' => [
             'retentionPeriod' => $retentionPeriod
         ]]);
-    printf('Bucket %s retention period set to %s seconds' . PHP_EOL, $bucketName,
-        $retentionPeriod);
+    printf(
+        'Bucket %s retention period set to %s seconds' . PHP_EOL,
+        $bucketName,
+        $retentionPeriod
+    );
 }
 # [END storage_set_retention_policy]
 

--- a/storage/src/upload_encrypted_object.php
+++ b/storage/src/upload_encrypted_object.php
@@ -38,8 +38,12 @@ use Google\Cloud\Storage\StorageClient;
  * @param string $base64EncryptionKey The base64 encoded encryption key.
  *        (e.g. 'TIbv/fjexq+VmtXzAlc63J4z5kFmWJ6NdAPQulQBT7g=')
  */
-function upload_encrypted_object(string $bucketName, string $objectName, string $source, string $base64EncryptionKey): void
-{
+function upload_encrypted_object(
+    string $bucketName,
+    string $objectName,
+    string $source,
+    string $base64EncryptionKey
+): void {
     $storage = new StorageClient();
     $file = fopen($source, 'r');
     $bucket = $storage->bucket($bucketName);
@@ -47,8 +51,12 @@ function upload_encrypted_object(string $bucketName, string $objectName, string 
         'name' => $objectName,
         'encryptionKey' => $base64EncryptionKey,
     ]);
-    printf('Uploaded encrypted %s to gs://%s/%s' . PHP_EOL,
-        basename($source), $bucketName, $objectName);
+    printf(
+        'Uploaded encrypted %s to gs://%s/%s' . PHP_EOL,
+        basename($source),
+        $bucketName,
+        $objectName
+    );
 }
 # [END storage_upload_encrypted_file]
 

--- a/storage/src/upload_with_kms_key.php
+++ b/storage/src/upload_with_kms_key.php
@@ -48,11 +48,13 @@ function upload_with_kms_key(string $bucketName, string $objectName, string $sou
         'name' => $objectName,
         'destinationKmsKeyName' => $kmsKeyName,
     ]);
-    printf('Uploaded %s to gs://%s/%s using encryption key %s' . PHP_EOL,
+    printf(
+        'Uploaded %s to gs://%s/%s using encryption key %s' . PHP_EOL,
         basename($source),
         $bucketName,
         $objectName,
-        $kmsKeyName);
+        $kmsKeyName
+    );
 }
 # [END storage_upload_with_kms_key]
 

--- a/storage/test/BucketLockTest.php
+++ b/storage/test/BucketLockTest.php
@@ -76,8 +76,10 @@ class BucketLockTest extends TestCase
         $this->bucket->reload();
         $effectiveTime = $this->bucket->info()['retentionPolicy']['effectiveTime'];
 
-        $this->assertFalse(array_key_exists('isLocked',
-            $this->bucket->info()['retentionPolicy']));
+        $this->assertFalse(array_key_exists(
+            'isLocked',
+            $this->bucket->info()['retentionPolicy']
+        ));
         $this->assertNotNull($effectiveTime);
         $this->assertEquals($this->bucket->info()['retentionPolicy']['retentionPeriod'], $retentionPeriod);
 

--- a/storage/test/IamTest.php
+++ b/storage/test/IamTest.php
@@ -58,8 +58,7 @@ class IamTest extends TestCase
         $policy = $iam->policy(['requestedPolicyVersion' => 3]);
 
         foreach ($policy['bindings'] as $i => $binding) {
-            if (
-                $binding['role'] == self::$role &&
+            if ($binding['role'] == self::$role &&
                 in_array(self::$user, $binding['members'])
             ) {
                 unset($policy['bindings'][$i]);
@@ -120,7 +119,14 @@ with condition:
     Title: %s
     Description: %s
     Expression: %s
-', self::$role, self::$bucket, self::$user, $title, $description, $expression);
+',
+            self::$role,
+            self::$bucket,
+            self::$user,
+            $title,
+            $description,
+            $expression
+        );
 
         $this->assertEquals($outputString, $output);
 
@@ -175,7 +181,9 @@ Members:
     Title: always true
     Description: this condition is always true
     Expression: 1 < 2
-', self::$user);
+',
+            self::$user
+        );
         $this->assertStringContainsString($bindingWithCondition, $output);
     }
 
@@ -206,8 +214,7 @@ Members:
             'requestedPolicyVersion' => 3
         ]);
         foreach ($policy['bindings'] as $binding) {
-            if (
-                $binding['role'] == self::$role
+            if ($binding['role'] == self::$role
                 && empty($binding['condition'])
             ) {
                 $foundRoleMember = in_array(self::$user, $binding['members']);
@@ -245,8 +252,7 @@ Members:
             'requestedPolicyVersion' => 3
         ]);
         foreach ($policy['bindings'] as $binding) {
-            if (
-                $binding['role'] == self::$role
+            if ($binding['role'] == self::$role
                 && isset($binding['condition'])
             ) {
                 $condition = $binding['condition'];

--- a/storage/test/quickstartTest.php
+++ b/storage/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Storage\Test;
+
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;

--- a/storagetransfer/src/quickstart.php
+++ b/storagetransfer/src/quickstart.php
@@ -49,7 +49,12 @@ function quickstart($projectId, $sourceGcsBucketName, $sinkGcsBucketName)
     $response = $client->createTransferJob($transferJob);
     $client->runTransferJob($response->getName(), $projectId);
 
-    printf('Created and ran transfer job from %s to %s with name %s ' . PHP_EOL, $sourceGcsBucketName, $sinkGcsBucketName, $response->getName());
+    printf(
+        'Created and ran transfer job from %s to %s with name %s ' . PHP_EOL,
+        $sourceGcsBucketName,
+        $sinkGcsBucketName,
+        $response->getName()
+    );
 }
 # [END storagetransfer_quickstart]
 

--- a/tasks/test/tasksTest.php
+++ b/tasks/test/tasksTest.php
@@ -69,7 +69,8 @@ class TasksTest extends TestCase
 
     private function getTaskNamePrefix()
     {
-        $taskNamePrefix = sprintf('projects/%s/locations/%s/queues/%s/tasks/',
+        $taskNamePrefix = sprintf(
+            'projects/%s/locations/%s/queues/%s/tasks/',
             self::$projectId,
             self::$location,
             self::$queue

--- a/testing/sample_helpers.php
+++ b/testing/sample_helpers.php
@@ -22,8 +22,7 @@ function execute_sample(string $file, string $namespace, ?array $argv)
 
     // Verify the user has supplied the correct number of arguments
     $functionReflection = new ReflectionFunction($functionName);
-    if (
-        count($argv) < $functionReflection->getNumberOfRequiredParameters()
+    if (count($argv) < $functionReflection->getNumberOfRequiredParameters()
         || count($argv) > $functionReflection->getNumberOfParameters()
     ) {
         print(get_usage(basename($file), $functionReflection));

--- a/texttospeech/src/list_voices.php
+++ b/texttospeech/src/list_voices.php
@@ -53,8 +53,10 @@ function list_voices(): void
         printf('SSML voice gender: %s' . PHP_EOL, $ssmlVoiceGender[$gender]);
 
         // display the natural hertz rate for this voice
-        printf('Natural Sample Rate Hertz: %d' . PHP_EOL,
-            $voice->getNaturalSampleRateHertz());
+        printf(
+            'Natural Sample Rate Hertz: %d' . PHP_EOL,
+            $voice->getNaturalSampleRateHertz()
+        );
     }
 
     $client->close();

--- a/texttospeech/test/quickstartTest.php
+++ b/texttospeech/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\TextToSpeech\Tests;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -26,8 +28,11 @@ class quickstartTest extends TestCase
     {
         $file = sys_get_temp_dir() . '/tts_quickstart.php';
         $contents = file_get_contents(__DIR__ . '/../quickstart.php');
-        $contents = str_replace('__DIR__', sprintf('"%s/.."', __DIR__),
-            $contents);
+        $contents = str_replace(
+            '__DIR__',
+            sprintf('"%s/.."', __DIR__),
+            $contents
+        );
         file_put_contents($file, $contents);
         // invoke quickstart.php
         $audioContent = include $file;

--- a/trace/test/TraceTest.php
+++ b/trace/test/TraceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../trace-sample.php';
+namespace OpenCensus\Trace;
 
 use PHPUnit\Framework\TestCase;
 
@@ -8,6 +8,8 @@ class TraceTest extends TestCase
 {
     public function testTraceSample()
     {
+        require_once __DIR__ . '/../trace-sample.php';
+
         trace_callable();
         $reflection = new \ReflectionProperty('\OpenCensus\Trace\Tracer', 'instance');
         $reflection->setAccessible(true);

--- a/translate/test/quickstartTest.php
+++ b/translate/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Translate\Test;
+
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/translate/test/translateTest.php
+++ b/translate/test/translateTest.php
@@ -112,7 +112,8 @@ class translateTest extends TestCase
         $option2 = 'Pozdrav svijetu';
         $option3 = 'Zdravo svijete';
         $option4 = 'Здраво Свете';
-        $this->assertThat($output,
+        $this->assertThat(
+            $output,
             $this->logicalOr(
                 $this->stringContains($option1),
                 $this->stringContains($option2),
@@ -179,7 +180,8 @@ class translateTest extends TestCase
         );
         $option1 = 'アカウント';
         $option2 = '口座';
-        $this->assertThat($output,
+        $this->assertThat(
+            $output,
             $this->logicalOr(
                 $this->stringContains($option1),
                 $this->stringContains($option2)

--- a/video/quickstart.php
+++ b/video/quickstart.php
@@ -48,7 +48,8 @@ if ($operation->operationSucceeded()) {
         foreach ($label->getSegments() as $segment) {
             $start = $segment->getSegment()->getStartTimeOffset();
             $end = $segment->getSegment()->getEndTimeOffset();
-            printf('  Segment: %ss to %ss' . PHP_EOL,
+            printf(
+                '  Segment: %ss to %ss' . PHP_EOL,
                 $start->getSeconds() + $start->getNanos() / 1000000000.0,
                 $end->getSeconds() + $end->getNanos() / 1000000000.0
             );

--- a/video/src/analyze_labels_file.php
+++ b/video/src/analyze_labels_file.php
@@ -59,9 +59,11 @@ function analyze_labels_file(string $path, int $pollingIntervalSeconds = 0)
             foreach ($label->getSegments() as $segment) {
                 $start = $segment->getSegment()->getStartTimeOffset();
                 $end = $segment->getSegment()->getEndTimeOffset();
-                printf('  Segment: %ss to %ss' . PHP_EOL,
+                printf(
+                    '  Segment: %ss to %ss' . PHP_EOL,
                     $start->getSeconds() + $start->getNanos() / 1000000000.0,
-                    $end->getSeconds() + $end->getNanos() / 1000000000.0);
+                    $end->getSeconds() + $end->getNanos() / 1000000000.0
+                );
                 printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
             }
         }
@@ -76,9 +78,11 @@ function analyze_labels_file(string $path, int $pollingIntervalSeconds = 0)
             foreach ($label->getSegments() as $shot) {
                 $start = $shot->getSegment()->getStartTimeOffset();
                 $end = $shot->getSegment()->getEndTimeOffset();
-                printf('  Shot: %ss to %ss' . PHP_EOL,
+                printf(
+                    '  Shot: %ss to %ss' . PHP_EOL,
                     $start->getSeconds() + $start->getNanos() / 1000000000.0,
-                    $end->getSeconds() + $end->getNanos() / 1000000000.0);
+                    $end->getSeconds() + $end->getNanos() / 1000000000.0
+                );
                 printf('  Confidence: %f' . PHP_EOL, $shot->getConfidence());
             }
         }

--- a/video/src/analyze_labels_gcs.php
+++ b/video/src/analyze_labels_gcs.php
@@ -56,9 +56,11 @@ function analyze_labels_gcs(string $uri, int $pollingIntervalSeconds = 0)
             foreach ($label->getSegments() as $segment) {
                 $start = $segment->getSegment()->getStartTimeOffset();
                 $end = $segment->getSegment()->getEndTimeOffset();
-                printf('  Segment: %ss to %ss' . PHP_EOL,
+                printf(
+                    '  Segment: %ss to %ss' . PHP_EOL,
                     $start->getSeconds() + $start->getNanos() / 1000000000.0,
-                    $end->getSeconds() + $end->getNanos() / 1000000000.0);
+                    $end->getSeconds() + $end->getNanos() / 1000000000.0
+                );
                 printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
             }
         }
@@ -73,9 +75,11 @@ function analyze_labels_gcs(string $uri, int $pollingIntervalSeconds = 0)
             foreach ($label->getSegments() as $shot) {
                 $start = $shot->getSegment()->getStartTimeOffset();
                 $end = $shot->getSegment()->getEndTimeOffset();
-                printf('  Shot: %ss to %ss' . PHP_EOL,
+                printf(
+                    '  Shot: %ss to %ss' . PHP_EOL,
                     $start->getSeconds() + $start->getNanos() / 1000000000.0,
-                    $end->getSeconds() + $end->getNanos() / 1000000000.0);
+                    $end->getSeconds() + $end->getNanos() / 1000000000.0
+                );
                 printf('  Confidence: %f' . PHP_EOL, $shot->getConfidence());
             }
         }

--- a/video/src/analyze_object_tracking.php
+++ b/video/src/analyze_object_tracking.php
@@ -54,16 +54,20 @@ function analyze_object_tracking(string $uri, int $pollingIntervalSeconds = 0)
 
         $start = $objectEntity->getSegment()->getStartTimeOffset();
         $end = $objectEntity->getSegment()->getEndTimeOffset();
-        printf('  Segment: %ss to %ss' . PHP_EOL,
+        printf(
+            '  Segment: %ss to %ss' . PHP_EOL,
             $start->getSeconds() + $start->getNanos() / 1000000000.0,
-            $end->getSeconds() + $end->getNanos() / 1000000000.0);
+            $end->getSeconds() + $end->getNanos() / 1000000000.0
+        );
         printf('  Confidence: %f' . PHP_EOL, $objectEntity->getConfidence());
 
         foreach ($objectEntity->getFrames() as $objectEntityFrame) {
             $offset = $objectEntityFrame->getTimeOffset();
             $boundingBox = $objectEntityFrame->getNormalizedBoundingBox();
-            printf('  Time offset: %ss' . PHP_EOL,
-                $offset->getSeconds() + $offset->getNanos() / 1000000000.0);
+            printf(
+                '  Time offset: %ss' . PHP_EOL,
+                $offset->getSeconds() + $offset->getNanos() / 1000000000.0
+            );
             printf('  Bounding box position:' . PHP_EOL);
             printf('   Left: %s', $boundingBox->getLeft());
             printf('   Top: %s', $boundingBox->getTop());

--- a/video/src/analyze_object_tracking_file.php
+++ b/video/src/analyze_object_tracking_file.php
@@ -57,16 +57,20 @@ function analyze_object_tracking_file(string $path, int $pollingIntervalSeconds 
 
         $start = $objectEntity->getSegment()->getStartTimeOffset();
         $end = $objectEntity->getSegment()->getEndTimeOffset();
-        printf('  Segment: %ss to %ss' . PHP_EOL,
+        printf(
+            '  Segment: %ss to %ss' . PHP_EOL,
             $start->getSeconds() + $start->getNanos() / 1000000000.0,
-            $end->getSeconds() + $end->getNanos() / 1000000000.0);
+            $end->getSeconds() + $end->getNanos() / 1000000000.0
+        );
         printf('  Confidence: %f' . PHP_EOL, $objectEntity->getConfidence());
 
         foreach ($objectEntity->getFrames() as $objectEntityFrame) {
             $offset = $objectEntityFrame->getTimeOffset();
             $boundingBox = $objectEntityFrame->getNormalizedBoundingBox();
-            printf('  Time offset: %ss' . PHP_EOL,
-                $offset->getSeconds() + $offset->getNanos() / 1000000000.0);
+            printf(
+                '  Time offset: %ss' . PHP_EOL,
+                $offset->getSeconds() + $offset->getNanos() / 1000000000.0
+            );
             printf('  Bounding box position:' . PHP_EOL);
             printf('   Left: %s', $boundingBox->getLeft());
             printf('   Top: %s', $boundingBox->getTop());

--- a/video/src/analyze_shots.php
+++ b/video/src/analyze_shots.php
@@ -49,9 +49,11 @@ function analyze_shots(string $uri, int $pollingIntervalSeconds = 0)
         foreach ($results->getShotAnnotations() as $shot) {
             $start = $shot->getStartTimeOffset();
             $end = $shot->getEndTimeOffset();
-            printf('Shot: %ss to %ss' . PHP_EOL,
+            printf(
+                'Shot: %ss to %ss' . PHP_EOL,
                 $start->getSeconds() + $start->getNanos() / 1000000000.0,
-                $end->getSeconds() + $end->getNanos() / 1000000000.0);
+                $end->getSeconds() + $end->getNanos() / 1000000000.0
+            );
         }
     } else {
         print_r($operation->getError());

--- a/video/src/analyze_text_detection.php
+++ b/video/src/analyze_text_detection.php
@@ -53,9 +53,11 @@ function analyze_text_detection(string $uri, int $pollingIntervalSeconds = 0)
             foreach ($text->getSegments() as $segment) {
                 $start = $segment->getSegment()->getStartTimeOffset();
                 $end = $segment->getSegment()->getEndTimeOffset();
-                printf('  Segment: %ss to %ss' . PHP_EOL,
+                printf(
+                    '  Segment: %ss to %ss' . PHP_EOL,
                     $start->getSeconds() + $start->getNanos() / 1000000000.0,
-                    $end->getSeconds() + $end->getNanos() / 1000000000.0);
+                    $end->getSeconds() + $end->getNanos() / 1000000000.0
+                );
                 printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
             }
         }

--- a/video/src/analyze_text_detection_file.php
+++ b/video/src/analyze_text_detection_file.php
@@ -56,9 +56,11 @@ function analyze_text_detection_file(string $path, int $pollingIntervalSeconds =
             foreach ($text->getSegments() as $segment) {
                 $start = $segment->getSegment()->getStartTimeOffset();
                 $end = $segment->getSegment()->getEndTimeOffset();
-                printf('  Segment: %ss to %ss' . PHP_EOL,
+                printf(
+                    '  Segment: %ss to %ss' . PHP_EOL,
                     $start->getSeconds() + $start->getNanos() / 1000000000.0,
-                    $end->getSeconds() + $end->getNanos() / 1000000000.0);
+                    $end->getSeconds() + $end->getNanos() / 1000000000.0
+                );
                 printf('  Confidence: %f' . PHP_EOL, $segment->getConfidence());
             }
         }

--- a/video/test/quickstartTest.php
+++ b/video/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Video\Test;
+
 use PHPUnit\Framework\TestCase;
 use Google\Cloud\TestUtils\TestTrait;
 

--- a/vision/src/detect_document_text.php
+++ b/vision/src/detect_document_text.php
@@ -47,15 +47,20 @@ function detect_document_text(string $path)
                     $block_text .= "\n";
                 }
                 printf('Block content: %s', $block_text);
-                printf('Block confidence: %f' . PHP_EOL,
-                    $block->getConfidence());
+                printf(
+                    'Block confidence: %f' . PHP_EOL,
+                    $block->getConfidence()
+                );
 
                 # get bounds
                 $vertices = $block->getBoundingBox()->getVertices();
                 $bounds = [];
                 foreach ($vertices as $vertex) {
-                    $bounds[] = sprintf('(%d,%d)', $vertex->getX(),
-                        $vertex->getY());
+                    $bounds[] = sprintf(
+                        '(%d,%d)',
+                        $vertex->getX(),
+                        $vertex->getY()
+                    );
                 }
                 print('Bounds: ' . join(', ', $bounds) . PHP_EOL);
                 print(PHP_EOL);

--- a/vision/src/detect_document_text_gcs.php
+++ b/vision/src/detect_document_text_gcs.php
@@ -46,15 +46,20 @@ function detect_document_text_gcs(string $path)
                     $block_text .= "\n";
                 }
                 printf('Block content: %s', $block_text);
-                printf('Block confidence: %f' . PHP_EOL,
-                    $block->getConfidence());
+                printf(
+                    'Block confidence: %f' . PHP_EOL,
+                    $block->getConfidence()
+                );
 
                 # get bounds
                 $vertices = $block->getBoundingBox()->getVertices();
                 $bounds = [];
                 foreach ($vertices as $vertex) {
-                    $bounds[] = sprintf('(%d,%d)', $vertex->getX(),
-                        $vertex->getY());
+                    $bounds[] = sprintf(
+                        '(%d,%d)',
+                        $vertex->getX(),
+                        $vertex->getY()
+                    );
                 }
                 print('Bounds: ' . join(', ', $bounds) . PHP_EOL);
 

--- a/vision/src/detect_web.php
+++ b/vision/src/detect_web.php
@@ -33,52 +33,66 @@ function detect_web(string $path)
     $web = $response->getWebDetection();
 
     // Print best guess labels
-    printf('%d best guess labels found' . PHP_EOL,
-        count($web->getBestGuessLabels()));
+    printf(
+        '%d best guess labels found' . PHP_EOL,
+        count($web->getBestGuessLabels())
+    );
     foreach ($web->getBestGuessLabels() as $label) {
         printf('Best guess label: %s' . PHP_EOL, $label->getLabel());
     }
     print(PHP_EOL);
 
     // Print pages with matching images
-    printf('%d pages with matching images found' . PHP_EOL,
-        count($web->getPagesWithMatchingImages()));
+    printf(
+        '%d pages with matching images found' . PHP_EOL,
+        count($web->getPagesWithMatchingImages())
+    );
     foreach ($web->getPagesWithMatchingImages() as $page) {
         printf('URL: %s' . PHP_EOL, $page->getUrl());
     }
     print(PHP_EOL);
 
     // Print full matching images
-    printf('%d full matching images found' . PHP_EOL,
-        count($web->getFullMatchingImages()));
+    printf(
+        '%d full matching images found' . PHP_EOL,
+        count($web->getFullMatchingImages())
+    );
     foreach ($web->getFullMatchingImages() as $fullMatchingImage) {
         printf('URL: %s' . PHP_EOL, $fullMatchingImage->getUrl());
     }
     print(PHP_EOL);
 
     // Print partial matching images
-    printf('%d partial matching images found' . PHP_EOL,
-        count($web->getPartialMatchingImages()));
+    printf(
+        '%d partial matching images found' . PHP_EOL,
+        count($web->getPartialMatchingImages())
+    );
     foreach ($web->getPartialMatchingImages() as $partialMatchingImage) {
         printf('URL: %s' . PHP_EOL, $partialMatchingImage->getUrl());
     }
     print(PHP_EOL);
 
     // Print visually similar images
-    printf('%d visually similar images found' . PHP_EOL,
-        count($web->getVisuallySimilarImages()));
+    printf(
+        '%d visually similar images found' . PHP_EOL,
+        count($web->getVisuallySimilarImages())
+    );
     foreach ($web->getVisuallySimilarImages() as $visuallySimilarImage) {
         printf('URL: %s' . PHP_EOL, $visuallySimilarImage->getUrl());
     }
     print(PHP_EOL);
 
     // Print web entities
-    printf('%d web entities found' . PHP_EOL,
-        count($web->getWebEntities()));
+    printf(
+        '%d web entities found' . PHP_EOL,
+        count($web->getWebEntities())
+    );
     foreach ($web->getWebEntities() as $entity) {
-        printf('Description: %s, Score %s' . PHP_EOL,
+        printf(
+            'Description: %s, Score %s' . PHP_EOL,
             $entity->getDescription(),
-            $entity->getScore());
+            $entity->getScore()
+        );
     }
 
     $imageAnnotator->close();

--- a/vision/src/detect_web_gcs.php
+++ b/vision/src/detect_web_gcs.php
@@ -32,52 +32,66 @@ function detect_web_gcs(string $path)
     $web = $response->getWebDetection();
 
     if ($web) {
-        printf('%d best guess labels found' . PHP_EOL,
-            count($web->getPagesWithMatchingImages()));
+        printf(
+            '%d best guess labels found' . PHP_EOL,
+            count($web->getPagesWithMatchingImages())
+        );
         foreach ($web->getBestGuessLabels() as $label) {
             printf('Best guess label: %s' . PHP_EOL, $label->getLabel());
         }
         print(PHP_EOL);
 
         // Print pages with matching images
-        printf('%d pages with matching images found' . PHP_EOL,
-            count($web->getPagesWithMatchingImages()));
+        printf(
+            '%d pages with matching images found' . PHP_EOL,
+            count($web->getPagesWithMatchingImages())
+        );
         foreach ($web->getPagesWithMatchingImages() as $page) {
             printf('URL: %s' . PHP_EOL, $page->getUrl());
         }
         print(PHP_EOL);
 
         // Print full matching images
-        printf('%d full matching images found' . PHP_EOL,
-            count($web->getFullMatchingImages()));
+        printf(
+            '%d full matching images found' . PHP_EOL,
+            count($web->getFullMatchingImages())
+        );
         foreach ($web->getFullMatchingImages() as $fullMatchingImage) {
             printf('URL: %s' . PHP_EOL, $fullMatchingImage->getUrl());
         }
         print(PHP_EOL);
 
         // Print partial matching images
-        printf('%d partial matching images found' . PHP_EOL,
-            count($web->getPartialMatchingImages()));
+        printf(
+            '%d partial matching images found' . PHP_EOL,
+            count($web->getPartialMatchingImages())
+        );
         foreach ($web->getPartialMatchingImages() as $partialMatchingImage) {
             printf('URL: %s' . PHP_EOL, $partialMatchingImage->getUrl());
         }
         print(PHP_EOL);
 
         // Print visually similar images
-        printf('%d visually similar images found' . PHP_EOL,
-            count($web->getVisuallySimilarImages()));
+        printf(
+            '%d visually similar images found' . PHP_EOL,
+            count($web->getVisuallySimilarImages())
+        );
         foreach ($web->getVisuallySimilarImages() as $visuallySimilarImage) {
             printf('URL: %s' . PHP_EOL, $visuallySimilarImage->getUrl());
         }
         print(PHP_EOL);
 
         // Print web entities
-        printf('%d web entities found' . PHP_EOL,
-            count($web->getWebEntities()));
+        printf(
+            '%d web entities found' . PHP_EOL,
+            count($web->getWebEntities())
+        );
         foreach ($web->getWebEntities() as $entity) {
-            printf('Description: %s, Score: %f' . PHP_EOL,
+            printf(
+                'Description: %s, Score: %f' . PHP_EOL,
                 $entity->getDescription(),
-                $entity->getScore());
+                $entity->getScore()
+            );
         }
     } else {
         print('No Results.' . PHP_EOL);

--- a/vision/src/detect_web_with_geo_metadata.php
+++ b/vision/src/detect_web_with_geo_metadata.php
@@ -44,8 +44,10 @@ function detect_web_with_geo_metadata(string $path)
     $web = $response->getWebDetection();
 
     if ($web && $web->getWebEntities()) {
-        printf('%d web entities found:' . PHP_EOL,
-            count($web->getWebEntities()));
+        printf(
+            '%d web entities found:' . PHP_EOL,
+            count($web->getWebEntities())
+        );
         foreach ($web->getWebEntities() as $entity) {
             printf('Description: %s ' . PHP_EOL, $entity->getDescription());
             printf('Score: %f' . PHP_EOL, $entity->getScore());

--- a/vision/src/detect_web_with_geo_metadata_gcs.php
+++ b/vision/src/detect_web_with_geo_metadata_gcs.php
@@ -43,8 +43,10 @@ function detect_web_with_geo_metadata_gcs(string $path)
     $web = $response->getWebDetection();
 
     if ($web) {
-        printf('%d web entities found:' . PHP_EOL,
-            count($web->getWebEntities()));
+        printf(
+            '%d web entities found:' . PHP_EOL,
+            count($web->getWebEntities())
+        );
         foreach ($web->getWebEntities() as $entity) {
             printf('Description: %s ' . PHP_EOL, $entity->getDescription());
             printf('Score: %f' . PHP_EOL, $entity->getScore());

--- a/vision/test/quickstartTest.php
+++ b/vision/test/quickstartTest.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Samples\Vision\Test;
+
 use PHPUnit\Framework\TestCase;
 
 class quickstartTest extends TestCase


### PR DESCRIPTION
Add linter for PHPCS, which checks for line lengths and found multiple other whitespace issues.

PHP CS Fixer (the existing checker) does not do a good job with whitespace (and in some cases, doesn't do the job at all). For this reason, it's better to run both linters.