### PR TITLE
chore(bigquery): show php tag in quickstart sample

### DIFF
--- a/bigquery/stackoverflow/stackoverflow.php
+++ b/bigquery/stackoverflow/stackoverflow.php
@@ -1,4 +1,6 @@
+# [START bigquery_simple_app_all]
 <?php
+# [START_EXCLUDE]
 /**
  * Copyright 2016 Google Inc.
  *
@@ -20,8 +22,8 @@
  *
  * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
  */
+# [END_EXCLUDE]
 
-# [START bigquery_simple_app_all]
 require __DIR__ . '/vendor/autoload.php';
 
 # [START bigquery_simple_app_deps]


### PR DESCRIPTION
[Relevant cgc website](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-client-libraries#complete_source_code)
[Relevant region tag](https://devrel.corp.google.com/snippets/bigquery_simple_app_all)

# Change
1. Show `<?php` tag in quickstart pages coz without this tag, the contents of the file is printed rather than getting executed. User needs to know about the tag else they cannot use the quickstart guide.
2. Exclude license and file description.

