### PR TITLE
chore(bigquery): prefer env var to arguments

### DIFF
--- a/bigquery/stackoverflow/stackoverflow.php
+++ b/bigquery/stackoverflow/stackoverflow.php
@@ -32,9 +32,9 @@ use Google\Cloud\BigQuery\BigQueryClient;
 # [END bigquery_simple_app_deps]
 
 // get the project ID as the first argument
-$projectId = getenv('GOOGLE_PROJECT_ID');
+$projectId = getenv('GOOGLE_CLOUD_PROJECT');
 if (!$projectId) {
-    die("Usage: GOOGLE_PROJECT_ID env var must be set.\n");
+    die("Usage: GOOGLE_CLOUD_PROJECT env var must be set.\n");
 }
 
 # [START bigquery_simple_app_client]

--- a/bigquery/stackoverflow/stackoverflow.php
+++ b/bigquery/stackoverflow/stackoverflow.php
@@ -32,11 +32,10 @@ use Google\Cloud\BigQuery\BigQueryClient;
 # [END bigquery_simple_app_deps]
 
 // get the project ID as the first argument
-if (2 != count($argv)) {
-    die("Usage: php stackoverflow.php YOUR_PROJECT_ID\n");
+$projectId = getenv('GOOGLE_PROJECT_ID');
+if (!$projectId) {
+    die("Usage: GOOGLE_PROJECT_ID env var must be set.\n");
 }
-
-$projectId = $argv[1];
 
 # [START bigquery_simple_app_client]
 $bigQuery = new BigQueryClient([

--- a/bigquery/stackoverflow/stackoverflow.php
+++ b/bigquery/stackoverflow/stackoverflow.php
@@ -31,16 +31,8 @@ use Google\Cloud\BigQuery\BigQueryClient;
 
 # [END bigquery_simple_app_deps]
 
-// get the project ID as the first argument
-$projectId = getenv('GOOGLE_CLOUD_PROJECT');
-if (!$projectId) {
-    die("Usage: GOOGLE_CLOUD_PROJECT env var must be set.\n");
-}
-
 # [START bigquery_simple_app_client]
-$bigQuery = new BigQueryClient([
-    'projectId' => $projectId,
-]);
+$bigQuery = new BigQueryClient();
 # [END bigquery_simple_app_client]
 # [START bigquery_simple_app_query]
 $query = <<<ENDSQL

--- a/bigquery/stackoverflow/test/stackoverflowTest.php
+++ b/bigquery/stackoverflow/test/stackoverflowTest.php
@@ -21,10 +21,6 @@ class stackoverflowTest extends TestCase
 {
     public function testStackoverflow()
     {
-        if (!getenv('GOOGLE_CLOUD_PROJECT')) {
-            $this->markTestSkipped('GOOGLE_CLOUD_PROJECT must be set.');
-        }
-
         // Invoke stackoverflow.php
         include __DIR__ . '/../stackoverflow.php';
 

--- a/bigquery/stackoverflow/test/stackoverflowTest.php
+++ b/bigquery/stackoverflow/test/stackoverflowTest.php
@@ -21,8 +21,8 @@ class stackoverflowTest extends TestCase
 {
     public function testStackoverflow()
     {
-        if (!getenv('GOOGLE_PROJECT_ID')) {
-            $this->markTestSkipped('GOOGLE_PROJECT_ID must be set.');
+        if (!getenv('GOOGLE_CLOUD_PROJECT')) {
+            $this->markTestSkipped('GOOGLE_CLOUD_PROJECT must be set.');
         }
 
         // Invoke stackoverflow.php

--- a/bigquery/stackoverflow/test/stackoverflowTest.php
+++ b/bigquery/stackoverflow/test/stackoverflowTest.php
@@ -21,11 +21,9 @@ class stackoverflowTest extends TestCase
 {
     public function testStackoverflow()
     {
-        global $argv;
-        if (!$projectId = getenv('GOOGLE_PROJECT_ID')) {
+        if (!getenv('GOOGLE_PROJECT_ID')) {
             $this->markTestSkipped('GOOGLE_PROJECT_ID must be set.');
         }
-        $argv[1] = $projectId;
 
         // Invoke stackoverflow.php
         include __DIR__ . '/../stackoverflow.php';


### PR DESCRIPTION
[Relevant cgc website](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-client-libraries#complete_source_code)
[Relevant region tag](https://devrel.corp.google.com/snippets/bigquery_simple_app_all)

# Change
1. Remove the use of env var `GOOGLE_CLOUD_PROJECT` or command line args for running `bigquery/stackoverflow/stackoverflow.php`.
2. Relevant changes in test.

# Tests
1. Tests are passing in php74.
```
bigquery/stackoverflow % ../../testing/vendor/bin/phpunit -c phpunit.xml.dist            (git)-[chore_show_click_to_copy_code]-
PHPUnit 8.5.26 #StandWithUkraine

Error:         XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

.                                                                   1 / 1 (100%)

Time: 1.82 seconds, Memory: 8.00 MB

OK (1 test, 1 assertion)
bigquery/stackoverflow %
```

2. Tested that this samples executes without errors in cloudshell env:

<img width="766" alt="Screenshot 2023-02-21 at 12 24 17" src="https://user-images.githubusercontent.com/7369612/220269870-d65bc9e2-ea99-4338-86f2-a0cd8cf0f22b.png">


 _In continuation with: https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1776_
