### PR TITLE
chore: make lint logs easier to read

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
         composer global require phpstan/phpstan
         for dir in $(find * -type d -name src -not -path 'appengine/*' -not -path '*/vendor/*' -exec dirname {} \;);
         do
+          echo -e "\n RUNNING for => $dir\n"
           composer install --working-dir=$dir --ignore-platform-reqs
           echo "<?php require_once 'testing/sample_helpers.php';require_once '$dir/vendor/autoload.php';" > autoload.php
           ~/.composer/vendor/bin/phpstan analyse $dir/src --autoload-file=autoload.php


### PR DESCRIPTION
While building an unrelated PR in this repo, I got lint errors, [link](https://github.com/GoogleCloudPlatform/php-docs-samples/actions/runs/4170853588/jobs/7220204731). Its a required workflow, so I need to fix the errors. But the lint logs are not very readable, it loops over all product folders and checks each of them.

# Change 
1. Added a log statement which prints the product folder it it checking.

# Test
I do not have a workflow test repo, so I tested in local as a bash script.



