### PR TITLE
fix: removed abandoned package from composer

### DIFF
--- a/pubsub/api/composer.json
+++ b/pubsub/api/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
         "google/cloud-pubsub": "^1.39",
-        "wikimedia/avro": "^1.9"
+        "rg/avro-php": "^2.0.1||^3.0.0"
     }
 }


### PR DESCRIPTION
This change has already been done in client library, https://github.com/googleapis/google-cloud-php/pull/5685. 
Backporting to samples now.

With this change, the lint errors are fixed.