### PR TITLE
fix: Add missing product region tags for Cloud CDN snippets

### DIFF
--- a/cdn/signUrl.php
+++ b/cdn/signUrl.php
@@ -16,6 +16,7 @@
  */
 
 # [START signed_url]
+# [START cloudcdn_sign_url]
 /**
  * Decodes base64url (RFC4648 Section 5) string
  *
@@ -81,4 +82,5 @@ function sign_url($url, $keyName, $base64UrlKey, $expirationTime)
     // Concatenate the URL and encoded signature
     return "{$url}&Signature={$encodedSignature}";
 }
-// [END signed_url]
+# [END cloudcdn_sign_url]
+# [END signed_url]


### PR DESCRIPTION
Cloud CDN Snippets are missing product's specific region tags. In this PR, we are only adding region tags. No code changes. For more details, refer to [b/264905390](b/264905390).