### PR TITLE
Added sample for DLP : create an exception list for de-identification

### DIFF
--- a/dlp/src/deidentify_exception_list.php
+++ b/dlp/src/deidentify_exception_list.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_exception_list]
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary\WordList;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\ExclusionRule;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\ReplaceWithInfoTypeConfig;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations\InfoTypeTransformation;
+use Google\Cloud\Dlp\V2\InspectionRule;
+use Google\Cloud\Dlp\V2\InspectionRuleSet;
+use Google\Cloud\Dlp\V2\MatchingType;
+
+/**
+ * Create an exception list for de-identification
+ * Create an exception list for a regular custom dictionary detector.
+ *
+ * @param string $callingProjectId  The project ID to run the API call under
+ * @param string $textToDeIdentify  The String you want the service to DeIdentify
+ */
+function deidentify_exception_list(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $textToDeIdentify = 'jack@example.org accessed customer record of user5@example.com'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    // Specify what content you want the service to DeIdentify.
+    $contentItem = (new ContentItem())->setValue($textToDeIdentify);
+
+    // Construct the custom word list to be detected.
+    $wordList = (new Dictionary())
+        ->setWordList((new WordList())
+            ->setWords(['jack@example.org', 'jill@example.org']));
+
+    // Specify the exclusion rule and build-in info type the inspection will look for.
+    $matchingType = MatchingType::MATCHING_TYPE_FULL_MATCH;
+
+    $exclusionRule = (new ExclusionRule())
+        ->setMatchingType($matchingType)
+        ->setDictionary($wordList);
+
+    $emailAddress = (new InfoType())->setName('EMAIL_ADDRESS');
+    $inspectionRuleSet = (new InspectionRuleSet())
+        ->setInfoTypes([$emailAddress])
+        ->setRules([(new InspectionRule())->setExclusionRule($exclusionRule)]);
+
+    $inspectConfig = (new InspectConfig())
+        ->setInfoTypes([$emailAddress])
+        ->setRuleSet([$inspectionRuleSet]);
+
+    // Define type of deidentification as replacement.
+    $primitiveTransformation = (new PrimitiveTransformation())
+        ->setReplaceWithInfoTypeConfig(new ReplaceWithInfoTypeConfig());
+
+    // Associate de-identification type with info type.
+    $transformation = (new InfoTypeTransformation())
+        ->setInfoTypes([$emailAddress])
+        ->setPrimitiveTransformation($primitiveTransformation);
+
+    // Construct the configuration for the de-id request and list all desired transformations.
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setInfoTypeTransformations(
+            (new InfoTypeTransformations())->setTransformations([$transformation])
+        );
+
+    // Send the request and receive response from the service
+    $parent = "projects/$callingProjectId/locations/global";
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'inspectConfig' => $inspectConfig,
+        'item' => $contentItem
+    ]);
+
+    // Print the results
+    print('Text after replace with infotype config: ' . $response->getItem()->getValue());
+}
+# [END dlp_deidentify_exception_list]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/deidentify_exception_list.php
+++ b/dlp/src/deidentify_exception_list.php
@@ -57,7 +57,8 @@ function deidentify_exception_list(
     $dlp = new DlpServiceClient();
 
     // Specify what content you want the service to DeIdentify.
-    $contentItem = (new ContentItem())->setValue($textToDeIdentify);
+    $contentItem = (new ContentItem())
+        ->setValue($textToDeIdentify);
 
     // Construct the custom word list to be detected.
     $wordList = (new Dictionary())
@@ -65,16 +66,18 @@ function deidentify_exception_list(
             ->setWords(['jack@example.org', 'jill@example.org']));
 
     // Specify the exclusion rule and build-in info type the inspection will look for.
-    $matchingType = MatchingType::MATCHING_TYPE_FULL_MATCH;
-
     $exclusionRule = (new ExclusionRule())
-        ->setMatchingType($matchingType)
+        ->setMatchingType(MatchingType::MATCHING_TYPE_FULL_MATCH)
         ->setDictionary($wordList);
 
-    $emailAddress = (new InfoType())->setName('EMAIL_ADDRESS');
+    $emailAddress = (new InfoType())
+        ->setName('EMAIL_ADDRESS');
     $inspectionRuleSet = (new InspectionRuleSet())
         ->setInfoTypes([$emailAddress])
-        ->setRules([(new InspectionRule())->setExclusionRule($exclusionRule)]);
+        ->setRules([
+            (new InspectionRule())
+                ->setExclusionRule($exclusionRule)
+        ]);
 
     $inspectConfig = (new InspectConfig())
         ->setInfoTypes([$emailAddress])
@@ -92,7 +95,8 @@ function deidentify_exception_list(
     // Construct the configuration for the de-id request and list all desired transformations.
     $deidentifyConfig = (new DeidentifyConfig())
         ->setInfoTypeTransformations(
-            (new InfoTypeTransformations())->setTransformations([$transformation])
+            (new InfoTypeTransformations())
+                ->setTransformations([$transformation])
         );
 
     // Send the request and receive response from the service
@@ -105,7 +109,7 @@ function deidentify_exception_list(
     ]);
 
     // Print the results
-    print('Text after replace with infotype config: ' . $response->getItem()->getValue());
+    printf('Text after replace with infotype config: %s', $response->getItem()->getValue());
 }
 # [END dlp_deidentify_exception_list]
 

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 namespace Google\Cloud\Samples\Dlp;
 
 use Google\Cloud\TestUtils\TestTrait;

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace Google\Cloud\Samples\Dlp;
 
 use Google\Cloud\TestUtils\TestTrait;
@@ -257,5 +258,16 @@ class dlpTest extends TestCase
             [$jobId]
         );
         $this->assertStringContainsString('Successfully deleted job ' . $jobId, $output);
+    }
+
+    public function testDeIdentifyExceptionList()
+    {
+        $output = $this->runFunctionSnippet('deidentify_exception_list', [
+            self::$projectId,
+            'jack@example.org accessed customer record of user5@example.com'
+        ]);
+        $this->assertStringContainsString('[EMAIL_ADDRESS]', $output);
+        $this->assertStringContainsString('jack@example.org', $output);
+        $this->assertStringNotContainsString('user5@example.com', $output);
     }
 }


### PR DESCRIPTION
Added sample for create an exception list for de-identification
Added test cases for the same

Reference: https://cloud.google.com/dlp/docs/creating-custom-infotypes-dictionary#exception_list