### PR TITLE
Added sample for DLP: Inspect a string for sensitive data, omitting custom matches

### DIFF
--- a/dlp/src/inspect_string_custom_omit_overlap.php
+++ b/dlp/src/inspect_string_custom_omit_overlap.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+// [START dlp_inspect_string_custom_omit_overlap]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType\ExclusionType;
+use Google\Cloud\Dlp\V2\CustomInfoType\Regex;
+use Google\Cloud\Dlp\V2\ExcludeInfoTypes;
+use Google\Cloud\Dlp\V2\ExclusionRule;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\InspectionRule;
+use Google\Cloud\Dlp\V2\InspectionRuleSet;
+use Google\Cloud\Dlp\V2\Likelihood;
+use Google\Cloud\Dlp\V2\MatchingType;
+
+/**
+ * Inspect a string for sensitive data, omitting custom matches
+ * Omit scan matches from a PERSON_NAME detector scan that overlap with a custom detector.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ * @param string $textToInspect     The string to inspect.
+ */
+function inspect_string_custom_omit_overlap(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $projectId,
+    string $textToInspect = 'Name: Jane Doe. Name: Larry Page.'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify what content you want the service to Inspect.
+    $item = (new ContentItem())
+        ->setValue($textToInspect);
+
+    // Specify the type of info the inspection will look for.
+    $vipDetector = (new InfoType())->setName('VIP_DETECTOR');
+    $pattern = 'Larry Page|Sergey Brin';
+    $customInfoType = (new CustomInfoType())
+        ->setInfoType($vipDetector)
+        ->setRegex((new Regex())->setPattern($pattern))
+        ->setExclusionType(ExclusionType::EXCLUSION_TYPE_EXCLUDE);
+
+    // Exclude matches that also match the custom infotype.
+    $matchingType = MatchingType::MATCHING_TYPE_FULL_MATCH;
+
+    $exclusionRule = (new ExclusionRule())
+        ->setMatchingType($matchingType)
+        ->setExcludeInfoTypes((new ExcludeInfoTypes())
+                ->setInfoTypes([$customInfoType->getInfoType()])
+        );
+
+    // Construct a ruleset that applies the exclusion rule to the PERSON_NAME infotype.
+    $personName = (new InfoType())->setName('PERSON_NAME');
+    $inspectionRuleSet = (new InspectionRuleSet())
+        ->setInfoTypes([$personName])
+        ->setRules([
+            (new InspectionRule())->setExclusionRule($exclusionRule),
+        ]);
+
+    // Construct the configuration for the Inspect request, including the ruleset.
+    $inspectConfig = (new InspectConfig())
+        ->setInfoTypes([$personName])
+        ->setCustomInfoTypes([$customInfoType])
+        ->setIncludeQuote(true)
+        ->setRuleSet([$inspectionRuleSet]);
+
+    // Run request
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        print('No findings.' . PHP_EOL);
+    } else {
+        print('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            print('  Quote: ' . $finding->getQuote() . PHP_EOL);
+            print('  Info type: ' . $finding->getInfoType()->getName() . PHP_EOL);
+            $likelihoodString = Likelihood::name($finding->getLikelihood());
+            print('  Likelihood: ' . $likelihoodString . PHP_EOL);
+        }
+    }
+}
+// [END dlp_inspect_string_custom_omit_overlap]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_string_custom_omit_overlap.php
+++ b/dlp/src/inspect_string_custom_omit_overlap.php
@@ -61,28 +61,30 @@ function inspect_string_custom_omit_overlap(
         ->setValue($textToInspect);
 
     // Specify the type of info the inspection will look for.
-    $vipDetector = (new InfoType())->setName('VIP_DETECTOR');
+    $vipDetector = (new InfoType())
+        ->setName('VIP_DETECTOR');
     $pattern = 'Larry Page|Sergey Brin';
     $customInfoType = (new CustomInfoType())
         ->setInfoType($vipDetector)
-        ->setRegex((new Regex())->setPattern($pattern))
+        ->setRegex((new Regex())
+            ->setPattern($pattern))
         ->setExclusionType(ExclusionType::EXCLUSION_TYPE_EXCLUDE);
 
     // Exclude matches that also match the custom infotype.
-    $matchingType = MatchingType::MATCHING_TYPE_FULL_MATCH;
-
     $exclusionRule = (new ExclusionRule())
-        ->setMatchingType($matchingType)
+        ->setMatchingType(MatchingType::MATCHING_TYPE_FULL_MATCH)
         ->setExcludeInfoTypes((new ExcludeInfoTypes())
                 ->setInfoTypes([$customInfoType->getInfoType()])
         );
 
     // Construct a ruleset that applies the exclusion rule to the PERSON_NAME infotype.
-    $personName = (new InfoType())->setName('PERSON_NAME');
+    $personName = (new InfoType())
+        ->setName('PERSON_NAME');
     $inspectionRuleSet = (new InspectionRuleSet())
         ->setInfoTypes([$personName])
         ->setRules([
-            (new InspectionRule())->setExclusionRule($exclusionRule),
+            (new InspectionRule())
+                ->setExclusionRule($exclusionRule),
         ]);
 
     // Construct the configuration for the Inspect request, including the ruleset.
@@ -102,14 +104,13 @@ function inspect_string_custom_omit_overlap(
     // Print the results
     $findings = $response->getResult()->getFindings();
     if (count($findings) == 0) {
-        print('No findings.' . PHP_EOL);
+        printf('No findings.' . PHP_EOL);
     } else {
-        print('Findings:' . PHP_EOL);
+        printf('Findings:' . PHP_EOL);
         foreach ($findings as $finding) {
-            print('  Quote: ' . $finding->getQuote() . PHP_EOL);
-            print('  Info type: ' . $finding->getInfoType()->getName() . PHP_EOL);
-            $likelihoodString = Likelihood::name($finding->getLikelihood());
-            print('  Likelihood: ' . $likelihoodString . PHP_EOL);
+            printf('  Quote: %s' . PHP_EOL, $finding->getQuote());
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
         }
     }
 }

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -258,4 +258,16 @@ class dlpTest extends TestCase
         );
         $this->assertStringContainsString('Successfully deleted job ' . $jobId, $output);
     }
+
+    public function testInspectStringCustomOmitOverlap()
+    {
+        $output = $this->runFunctionSnippet('inspect_string_custom_omit_overlap', [
+            self::$projectId,
+            'Name: Jane Doe. Name: Larry Page.'
+        ]);
+
+        $this->assertStringContainsString('Info type: PERSON_NAME', $output);
+        $this->assertStringContainsString('Jane Doe', $output);
+        $this->assertStringNotContainsString('Larry Page', $output);
+    }
 }


### PR DESCRIPTION
Added sample for DLP: Inspect a string for sensitive data, omitting custom matches.
Added test cases for the same.

Reference: https://cloud.google.com/dlp/docs/samples/dlp-inspect-string-custom-omit-overlap#dlp_inspect_string_custom_omit_overlap-java