### PR TITLE
Added sample for DLP :  Inspect a string for sensitive data, using exclusion dictionary

### DIFF
--- a/dlp/src/inspect_string_with_exclusion_dict.php
+++ b/dlp/src/inspect_string_with_exclusion_dict.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+// [START dlp_inspect_string_with_exclusion_dict]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary\WordList;
+use Google\Cloud\Dlp\V2\ExclusionRule;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\InspectionRule;
+use Google\Cloud\Dlp\V2\InspectionRuleSet;
+use Google\Cloud\Dlp\V2\Likelihood;
+use Google\Cloud\Dlp\V2\MatchingType;
+
+/**
+ * Inspect a string for sensitive data, using exclusion dictionary
+ * Omit a specific email address from an EMAIL_ADDRESS detector scan with an exclusion dictionary.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ * @param string $textToInspect     The string to inspect.
+ */
+function inspect_string_with_exclusion_dict(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $projectId,
+    string $textToInspect = 'Some email addresses: gary@example.com, example@example.com'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify what content you want the service to Inspect.
+    $item = (new ContentItem())
+        ->setValue($textToInspect);
+
+    // Specify the type of info the inspection will look for.
+    $infotypes = [];
+    $infonames = ['PHONE_NUMBER', 'EMAIL_ADDRESS', 'CREDIT_CARD_NUMBER'];
+    foreach ($infonames as $key => $value) {
+        array_push($infotypes, (new InfoType())->setName($value));
+    }
+
+    // Exclude matches from the specified excludedMatchList.
+    $excludedMatchList = (new Dictionary())
+        ->setWordList((new WordList())
+            ->setWords(['example@example.com']));
+    $matchingType = MatchingType::MATCHING_TYPE_FULL_MATCH;
+    $exclusionRule = (new ExclusionRule())
+        ->setMatchingType($matchingType)
+        ->setDictionary($excludedMatchList);
+
+    // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.
+    $emailAddress = (new InfoType())->setName('EMAIL_ADDRESS');
+    $inspectionRuleSet = (new InspectionRuleSet())
+        ->setInfoTypes([$emailAddress])
+        ->setRules([
+            (new InspectionRule())->setExclusionRule($exclusionRule),
+        ]);
+
+    // Construct the configuration for the Inspect request, including the ruleset.
+    $inspectConfig = (new InspectConfig())
+        ->setInfoTypes($infotypes)
+        ->setIncludeQuote(true)
+        ->setRuleSet([$inspectionRuleSet]);
+
+    // Run request
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        print('No findings.' . PHP_EOL);
+    } else {
+        print('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            print('  Quote: ' . $finding->getQuote() . PHP_EOL);
+            print('  Info type: ' . $finding->getInfoType()->getName() . PHP_EOL);
+            $likelihoodString = Likelihood::name($finding->getLikelihood());
+            print('  Likelihood: ' . $likelihoodString . PHP_EOL);
+        }
+    }
+}
+// [END dlp_inspect_string_with_exclusion_dict]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_string_with_exclusion_dict.php
+++ b/dlp/src/inspect_string_with_exclusion_dict.php
@@ -59,11 +59,11 @@ function inspect_string_with_exclusion_dict(
         ->setValue($textToInspect);
 
     // Specify the type of info the inspection will look for.
-    $infotypes = [];
-    $infonames = ['PHONE_NUMBER', 'EMAIL_ADDRESS', 'CREDIT_CARD_NUMBER'];
-    foreach ($infonames as $key => $value) {
-        array_push($infotypes, (new InfoType())->setName($value));
-    }
+    $infotypes = [
+        (new InfoType())->setName('PHONE_NUMBER'),
+        (new InfoType())->setName('EMAIL_ADDRESS'),
+        (new InfoType())->setName('CREDIT_CARD_NUMBER'),
+    ];
 
     // Exclude matches from the specified excludedMatchList.
     $excludedMatchList = (new Dictionary())
@@ -75,11 +75,13 @@ function inspect_string_with_exclusion_dict(
         ->setDictionary($excludedMatchList);
 
     // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.
-    $emailAddress = (new InfoType())->setName('EMAIL_ADDRESS');
+    $emailAddress = (new InfoType())
+        ->setName('EMAIL_ADDRESS');
     $inspectionRuleSet = (new InspectionRuleSet())
         ->setInfoTypes([$emailAddress])
         ->setRules([
-            (new InspectionRule())->setExclusionRule($exclusionRule),
+            (new InspectionRule())
+                ->setExclusionRule($exclusionRule),
         ]);
 
     // Construct the configuration for the Inspect request, including the ruleset.
@@ -98,14 +100,13 @@ function inspect_string_with_exclusion_dict(
     // Print the results
     $findings = $response->getResult()->getFindings();
     if (count($findings) == 0) {
-        print('No findings.' . PHP_EOL);
+        printf('No findings.' . PHP_EOL);
     } else {
-        print('Findings:' . PHP_EOL);
+        printf('Findings:' . PHP_EOL);
         foreach ($findings as $finding) {
-            print('  Quote: ' . $finding->getQuote() . PHP_EOL);
-            print('  Info type: ' . $finding->getInfoType()->getName() . PHP_EOL);
-            $likelihoodString = Likelihood::name($finding->getLikelihood());
-            print('  Likelihood: ' . $likelihoodString . PHP_EOL);
+            printf('  Quote: %s' . PHP_EOL, $finding->getQuote());
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
         }
     }
 }

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -258,4 +258,15 @@ class dlpTest extends TestCase
         );
         $this->assertStringContainsString('Successfully deleted job ' . $jobId, $output);
     }
+
+    public function testInspectStringWithExclusionDict()
+    {
+        $output = $this->runFunctionSnippet('inspect_string_with_exclusion_dict', [
+            self::$projectId,
+            'Some email addresses: gary@example.com, example@example.com'
+        ]);
+
+        $this->assertStringContainsString('Quote: gary@example.com', $output);
+        $this->assertStringNotContainsString('Quote: example@example.com', $output);
+    }
 }


### PR DESCRIPTION
Implemented sample for Inspect a string for sensitive data, using exclusion dictionary
Added test cases for the same 

Reference: https://cloud.google.com/dlp/docs/creating-custom-infotypes-rules#omit_specific_email_address_from_email_address_detector_scan