### PR TITLE
Added sample for DLP : Inspect a string for sensitive data, excluding a custom substring

### DIFF
--- a/dlp/src/inspect_string_custom_excluding_substring.php
+++ b/dlp/src/inspect_string_custom_excluding_substring.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_inspect_string_custom_excluding_substring]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary\WordList;
+use Google\Cloud\Dlp\V2\CustomInfoType\Regex;
+use Google\Cloud\Dlp\V2\ExclusionRule;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\InspectionRule;
+use Google\Cloud\Dlp\V2\InspectionRuleSet;
+use Google\Cloud\Dlp\V2\Likelihood;
+use Google\Cloud\Dlp\V2\MatchingType;
+
+/**
+ * Inspect a string for sensitive data, excluding a custom substring
+ * Illustrates how to use an InspectConfig to instruct Cloud DLP to avoid matching on the name "Jimmy" in a scan that uses the specified custom regular expression detector.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ * @param string $textToInspect     The string to inspect.
+ */
+function inspect_string_custom_excluding_substring(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $projectId,
+    string $textToInspect = 'Name: Doe, John. Name: Example, Jimmy'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+    $customDetectorPattern = '[A-Z][a-z]{1,15}, [A-Z][a-z]{1,15}';
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify what content you want the service to Inspect.
+    $item = (new ContentItem())
+        ->setValue($textToInspect);
+
+    // Specify the type of info the inspection will look for.
+    $customerNameDetector = (new InfoType())
+        ->setName('CUSTOM_NAME_DETECTOR');
+    $customInfoType = (new CustomInfoType())
+        ->setInfoType($customerNameDetector)
+        ->setRegex((new Regex())
+            ->setPattern($customDetectorPattern));
+
+    // Exclude partial matches from the specified excludedSubstringList.
+    $excludedSubstringList = (new Dictionary())
+        ->setWordList((new WordList())
+            ->setWords(['Jimmy']));
+
+    $exclusionRule = (new ExclusionRule())
+        ->setMatchingType(MatchingType::MATCHING_TYPE_PARTIAL_MATCH)
+        ->setDictionary($excludedSubstringList);
+
+    // Construct a ruleset that applies the exclusion rule.
+    $inspectionRuleSet = (new InspectionRuleSet())
+        ->setInfoTypes([$customerNameDetector])
+        ->setRules([
+            (new InspectionRule())
+                ->setExclusionRule($exclusionRule),
+        ]);
+
+    // Construct the configuration for the Inspect request, including the ruleset.
+    $inspectConfig = (new InspectConfig())
+        ->setCustomInfoTypes([$customInfoType])
+        ->setIncludeQuote(true)
+        ->setRuleSet([$inspectionRuleSet]);
+
+    // Run request
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        printf('No findings.' . PHP_EOL);
+    } else {
+        printf('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            printf('  Quote: %s' . PHP_EOL, $finding->getQuote());
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
+        }
+    }
+}
+# [END dlp_inspect_string_custom_excluding_substring]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -357,4 +357,18 @@ class dlpTest extends TestCase
         $this->assertStringContainsString('Quote: gary@example.com', $output);
         $this->assertStringNotContainsString('Quote: example@example.com', $output);
     }
+
+    public function testInspectStringCustomExcludingSubstring()
+    {
+        $output = $this->runFunctionSnippet('inspect_string_custom_excluding_substring', [
+            self::$projectId,
+            'Name: Doe, John. Name: Example, Jimmy'
+        ]);
+
+        $this->assertStringContainsString('Info type: CUSTOM_NAME_DETECTOR', $output);
+        $this->assertStringContainsString('Doe', $output);
+        $this->assertStringContainsString('John', $output);
+        $this->assertStringNotContainsString('Jimmy', $output);
+        $this->assertStringNotContainsString('Example', $output);
+    }
 }


### PR DESCRIPTION
Implemented sample for Inspect a string for sensitive data, excluding a custom substring
Added test cases for the same

Reference: https://cloud.google.com/dlp/docs/samples/dlp-inspect-string-custom-excluding-substring