### PR TITLE
Added sample for DLP : De-identify table data using masking and conditional logic.

### DIFF
--- a/dlp/src/deidentify_table_condition_masking.php
+++ b/dlp/src/deidentify_table_condition_masking.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_table_condition_masking]
+use Google\Cloud\Dlp\V2\CharacterMaskConfig;
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\Value;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\FieldTransformation;
+use Google\Cloud\Dlp\V2\RecordCondition;
+use Google\Cloud\Dlp\V2\RecordCondition\Condition;
+use Google\Cloud\Dlp\V2\RecordCondition\Conditions;
+use Google\Cloud\Dlp\V2\RecordCondition\Expressions;
+use Google\Cloud\Dlp\V2\RecordTransformations;
+use Google\Cloud\Dlp\V2\RelationalOperator;
+
+/**
+ * De-identify table data using masking and conditional logic.
+ * Transform a column based on the value of another column.
+ *
+ * @param string $callingProjectId      The Google Cloud project id to use as a parent resource.
+ * @param string $inputCsvFile          The input file(csv) path  to deidentify
+ * @param string $outputCsvFile         The oupt file path to save deidentify content
+ */
+
+function deidentify_table_condition_masking(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $inputCsvFile = './test/data/table2.csv',
+    string $outputCsvFile = './test/data/deidentify_table_condition_masking_output.csv',
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$callingProjectId/locations/global";
+
+    // Read a CSV file
+    $csvLines = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+    $csvHeaders = explode(',', $csvLines[0]);
+    $csvRows = array_slice($csvLines, 1);
+
+    // Convert CSV file into protobuf objects
+    $tableHeaders = array_map(function ($csvHeader) {
+        return (new FieldId)
+            ->setName($csvHeader);
+    }, $csvHeaders);
+
+    $tableRows = array_map(function ($csvRow) {
+        $rowValues = array_map(function ($csvValue) {
+            return (new Value())
+                ->setStringValue($csvValue);
+        }, explode(',', $csvRow));
+        return (new Row())
+            ->setValues($rowValues);
+    }, $csvRows);
+
+    // Construct the table object
+    $tableToDeIdentify = (new Table())
+        ->setHeaders($tableHeaders)
+        ->setRows($tableRows);
+
+    // Specify what content you want the service to de-identify.
+    $content = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Specify how the content should be de-identified.
+    $characterMaskConfig = (new CharacterMaskConfig())
+        ->setMaskingCharacter('*');
+    $primitiveTransformation = (new PrimitiveTransformation())
+        ->setCharacterMaskConfig($characterMaskConfig);
+
+    // Specify field to be de-identified.
+    $fieldId = (new FieldId())
+        ->setName('HAPPINESS_SCORE');
+
+    // Specify when the above fields should be de-identified.
+    $condition = (new Condition())
+        ->setField((new FieldId())
+            ->setName('AGE'))
+        ->setOperator(RelationalOperator::GREATER_THAN)
+        ->setValue((new Value())
+            ->setIntegerValue(89));
+
+    // Apply the condition to records
+    $recordCondition = (new RecordCondition())
+        ->setExpressions((new Expressions())
+                ->setConditions((new Conditions())
+                        ->setConditions([$condition])
+                )
+        );
+
+    // Associate the de-identification and conditions with the specified fields.
+    $fieldTransformation = (new FieldTransformation())
+        ->setPrimitiveTransformation($primitiveTransformation)
+        ->setFields([$fieldId])
+        ->setCondition($recordCondition);
+
+    $recordtransformations = (new RecordTransformations())
+        ->setFieldTransformations([$fieldTransformation]);
+
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setRecordTransformations($recordtransformations);
+
+    // Run request
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'item' => $content
+    ]);
+
+    // Print results
+    $csvRef = fopen($outputCsvFile, 'w');
+    fputcsv($csvRef, $csvHeaders);
+    foreach ($response->getItem()->getTable()->getRows() as $tableRow) {
+        $values = array_map(function ($tableValue) {
+            return $tableValue->getStringValue();
+        }, iterator_to_array($tableRow->getValues()));
+        fputcsv($csvRef, $values);
+    };
+    printf('After de-identify the table data (Output File Location): %s', $outputCsvFile);
+}
+# [END dlp_deidentify_table_condition_masking]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_string_multiple_rules.php
+++ b/dlp/src/inspect_string_multiple_rules.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_inspect_string_multiple_rules]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType\DetectionRule\HotwordRule;
+use Google\Cloud\Dlp\V2\CustomInfoType\DetectionRule\LikelihoodAdjustment;
+use Google\Cloud\Dlp\V2\CustomInfoType\DetectionRule\Proximity;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary\WordList;
+use Google\Cloud\Dlp\V2\CustomInfoType\Regex;
+use Google\Cloud\Dlp\V2\ExclusionRule;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\InspectionRule;
+use Google\Cloud\Dlp\V2\InspectionRuleSet;
+use Google\Cloud\Dlp\V2\Likelihood;
+use Google\Cloud\Dlp\V2\MatchingType;
+
+/**
+ * Inspect a string for sensitive data by using multiple rules
+ * Illustrates applying both exclusion and hotword rules. This snippet's rule set includes both hotword rules and dictionary and regex exclusion rules. Notice that the four rules are specified in an array within the rules element.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ * @param string $textToInspect     The string to inspect.
+ */
+function inspect_string_multiple_rules(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $projectId,
+    string $textToInspect = 'patient: Jane Doe'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify what content you want the service to Inspect.
+    $item = (new ContentItem())
+        ->setValue($textToInspect);
+
+    // Construct hotword rules
+    $patientRule = (new HotwordRule())
+        ->setHotwordRegex((new Regex())
+            ->setPattern('patient'))
+        ->setProximity((new Proximity())
+            ->setWindowBefore(10))
+        ->setLikelihoodAdjustment((new LikelihoodAdjustment())
+            ->setFixedLikelihood(Likelihood::VERY_LIKELY));
+
+    $doctorRule = (new HotwordRule())
+        ->setHotwordRegex((new Regex())
+            ->setPattern('doctor'))
+        ->setProximity((new Proximity())
+            ->setWindowBefore(10))
+        ->setLikelihoodAdjustment((new LikelihoodAdjustment())
+            ->setFixedLikelihood(Likelihood::VERY_UNLIKELY));
+
+    // Construct exclusion rules
+    $wordList = (new Dictionary())
+        ->setWordList((new WordList())
+            ->setWords(['Quasimodo']));
+
+    $quasimodoRule = (new ExclusionRule())
+        ->setMatchingType(MatchingType::MATCHING_TYPE_PARTIAL_MATCH)
+        ->setDictionary($wordList);
+
+    $redactedRule = (new ExclusionRule())
+        ->setMatchingType(MatchingType::MATCHING_TYPE_PARTIAL_MATCH)
+        ->setRegex((new Regex())
+            ->setPattern('REDACTED'));
+
+    // Specify the exclusion rule and build-in info type the inspection will look for.
+    $personName = (new InfoType())
+        ->setName('PERSON_NAME');
+    $inspectionRuleSet = (new InspectionRuleSet())
+        ->setInfoTypes([$personName])
+        ->setRules([
+            (new InspectionRule())
+                ->setHotwordRule($patientRule),
+            (new InspectionRule())
+                ->setHotwordRule($doctorRule),
+            (new InspectionRule())
+                ->setExclusionRule($quasimodoRule),
+            (new InspectionRule())
+                ->setExclusionRule($redactedRule),
+        ]);
+
+    // Construct the configuration for the Inspect request, including the ruleset.
+    $inspectConfig = (new InspectConfig())
+        ->setInfoTypes([$personName])
+        ->setIncludeQuote(true)
+        ->setRuleSet([$inspectionRuleSet]);
+
+    // Run request
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        printf('No findings.' . PHP_EOL);
+    } else {
+        printf('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            printf('  Quote: %s' . PHP_EOL, $finding->getQuote());
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
+        }
+    }
+}
+# [END dlp_inspect_string_multiple_rules]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/test/data/table2.csv
+++ b/dlp/test/data/table2.csv
@@ -1,0 +1,4 @@
+AGE,PATIENT,HAPPINESS_SCORE
+101,Charles Dickens,95
+22,Jane Austen,21
+55,Mark Twain,75

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -357,4 +357,44 @@ class dlpTest extends TestCase
         $this->assertStringContainsString('Quote: gary@example.com', $output);
         $this->assertStringNotContainsString('Quote: example@example.com', $output);
     }
+
+    public function testInspectStringMultipleRulesPatientRule()
+    {
+        $output = $this->runFunctionSnippet('inspect_string_multiple_rules', [
+            self::$projectId,
+            'patient: Jane Doe'
+        ]);
+
+        $this->assertStringContainsString('Info type: PERSON_NAME', $output);
+    }
+
+    public function testInspectStringMultipleRulesDoctorRule()
+    {
+        $output = $this->runFunctionSnippet('inspect_string_multiple_rules', [
+            self::$projectId,
+            'doctor: Jane Doe'
+        ]);
+
+        $this->assertStringContainsString('No findings.', $output);
+    }
+
+    public function testInspectStringMultipleRulesQuasimodoRule()
+    {
+        $output = $this->runFunctionSnippet('inspect_string_multiple_rules', [
+            self::$projectId,
+            'patient: Quasimodo'
+        ]);
+
+        $this->assertStringContainsString('No findings.', $output);
+    }
+
+    public function testInspectStringMultipleRulesRedactedRule()
+    {
+        $output = $this->runFunctionSnippet('inspect_string_multiple_rules', [
+            self::$projectId,
+            'name of patient: REDACTED'
+        ]);
+
+        $this->assertStringContainsString('No findings.', $output);
+    }
 }

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -397,4 +397,25 @@ class dlpTest extends TestCase
 
         $this->assertStringContainsString('No findings.', $output);
     }
+
+    public function testDeidentifyTableConditionMasking()
+    {
+        $inputCsvFile = __DIR__ . '/data/table2.csv';
+        $outputCsvFile = __DIR__ . '/data/deidentify_table_condition_masking_output_unittest.csv';
+
+        $output = $this->runFunctionSnippet('deidentify_table_condition_masking', [
+            self::$projectId,
+            $inputCsvFile,
+            $outputCsvFile
+        ]);
+        $this->assertFileNotEquals($outputCsvFile, $inputCsvFile);
+
+        $csvLines_input = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+        $csvLines_ouput = file($outputCsvFile, FILE_IGNORE_NEW_LINES);
+
+        $this->assertEquals($csvLines_input[0], $csvLines_ouput[0]);
+        $this->assertStringContainsString('**', $csvLines_ouput[1]);
+
+        unlink($outputCsvFile);
+    }
 }

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -448,7 +448,10 @@ class dlpTest extends TestCase
             $inputCsvFile,
             $outputCsvFile
         ]);
-        $this->assertFileNotEquals($outputCsvFile, $inputCsvFile);
+        $this->assertNotEquals(
+            sha1_file($outputCsvFile),
+            sha1_file($inputCsvFile)
+        );
 
         $csvLines_input = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
         $csvLines_ouput = file($outputCsvFile, FILE_IGNORE_NEW_LINES);


### PR DESCRIPTION
Implemented sample for De-identify table data using masking and conditional logic.
Added test cases for the same

Reference: https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_a_column_based_on_the_value_of_another_column