### PR TITLE
Added sample for DLP : De-identify Table Samples

### DIFF
--- a/dlp/src/deidentify_table_bucketing.php
+++ b/dlp/src/deidentify_table_bucketing.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_table_bucketing]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\FieldTransformation;
+use Google\Cloud\Dlp\V2\FixedSizeBucketingConfig;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\RecordTransformations;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\Value;
+
+/**
+ * De-identify data using table bucketing
+ * Transform a column without inspection. To transform a column in which the content is
+ * already known, you can skip inspection and specify a transformation directly.
+ *
+ * @param string $callingProjectId      The Google Cloud project id to use as a parent resource.
+ * @param string $inputCsvFile          The input file(csv) path  to deidentify
+ * @param string $outputCsvFile         The oupt file path to save deidentify content
+ *
+ */
+function deidentify_table_bucketing(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $inputCsvFile = './test/data/table2.csv',
+    string $outputCsvFile = './test/data/deidentify_table_bucketing_output.csv'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    // Read a CSV file
+    $csvLines = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+    $csvHeaders = explode(',', $csvLines[0]);
+    $csvRows = array_slice($csvLines, 1);
+
+    // Convert CSV file into protobuf objects
+    $tableHeaders = array_map(function ($csvHeader) {
+        return (new FieldId)
+            ->setName($csvHeader);
+    }, $csvHeaders);
+
+    $tableRows = array_map(function ($csvRow) {
+        $rowValues = array_map(function ($csvValue) {
+            return (new Value())
+                ->setStringValue($csvValue);
+        }, explode(',', $csvRow));
+        return (new Row())
+            ->setValues($rowValues);
+    }, $csvRows);
+
+    // Construct the table object
+    $tableToDeIdentify = (new Table())
+        ->setHeaders($tableHeaders)
+        ->setRows($tableRows);
+
+    // Specify what content you want the service to de-identify.
+    $contentItem = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Specify how the content should be de-identified.
+    $fixedSizeBucketingConfig = (new FixedSizeBucketingConfig())
+        ->setBucketSize(10)
+        ->setLowerBound((new Value())
+            ->setIntegerValue(10))
+        ->setUpperBound((new Value())
+            ->setIntegerValue(100));
+
+    $primitiveTransformation = (new PrimitiveTransformation())
+        ->setFixedSizeBucketingConfig($fixedSizeBucketingConfig);
+
+    // Specify field to be encrypted.
+    $fieldId = (new FieldId())
+        ->setName('HAPPINESS_SCORE');
+
+    // Associate the encryption with the specified field.
+    $fieldTransformation = (new FieldTransformation())
+        ->setPrimitiveTransformation($primitiveTransformation)
+        ->setFields([$fieldId]);
+
+    $recordTransformations = (new RecordTransformations())
+        ->setFieldTransformations([$fieldTransformation]);
+
+    // Create the deidentification configuration object
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setRecordTransformations($recordTransformations);
+
+    $parent = "projects/$callingProjectId/locations/global";
+
+    // Run request
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'item' => $contentItem
+    ]);
+
+    // Print results
+    $csvRef = fopen($outputCsvFile, 'w');
+    fputcsv($csvRef, $csvHeaders);
+    foreach ($response->getItem()->getTable()->getRows() as $tableRow) {
+        $values = array_map(function ($tableValue) {
+            return $tableValue->getStringValue();
+        }, iterator_to_array($tableRow->getValues()));
+        fputcsv($csvRef, $values);
+    };
+    printf($outputCsvFile);
+}
+# [END dlp_deidentify_table_bucketing]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/deidentify_table_bucketing.php
+++ b/dlp/src/deidentify_table_bucketing.php
@@ -96,7 +96,7 @@ function deidentify_table_bucketing(
     $primitiveTransformation = (new PrimitiveTransformation())
         ->setFixedSizeBucketingConfig($fixedSizeBucketingConfig);
 
-    // Specify field to be encrypted.
+    // Specify the field to to apply bucketing transform on
     $fieldId = (new FieldId())
         ->setName('HAPPINESS_SCORE');
 

--- a/dlp/src/deidentify_table_condition_infotypes.php
+++ b/dlp/src/deidentify_table_condition_infotypes.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_table_condition_infotypes]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations\InfoTypeTransformation;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\Value;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\ReplaceWithInfoTypeConfig;
+use Google\Cloud\Dlp\V2\FieldTransformation;
+use Google\Cloud\Dlp\V2\RecordCondition;
+use Google\Cloud\Dlp\V2\RecordCondition\Condition;
+use Google\Cloud\Dlp\V2\RecordCondition\Conditions;
+use Google\Cloud\Dlp\V2\RecordCondition\Expressions;
+use Google\Cloud\Dlp\V2\RecordTransformations;
+use Google\Cloud\Dlp\V2\RelationalOperator;
+
+/**
+ * De-identify table data using conditional logic and replace with infoTypes.
+ * Transform findings only when specific conditions are met on another field.
+ *
+ * @param string $callingProjectId      The Google Cloud project id to use as a parent resource.
+ * @param string $inputCsvFile          The input file(csv) path  to deidentify
+ * @param string $outputCsvFile         The oupt file path to save deidentify content
+ */
+
+function deidentify_table_condition_infotypes(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $inputCsvFile = './test/data/table1.csv',
+    string $outputCsvFile = './test/data/deidentify_table_condition_infotypes_output.csv'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$callingProjectId/locations/global";
+
+    // Read a CSV file
+    $csvLines = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+    $csvHeaders = explode(',', $csvLines[0]);
+    $csvRows = array_slice($csvLines, 1);
+
+    // Convert CSV file into protobuf objects
+    $tableHeaders = array_map(function ($csvHeader) {
+        return (new FieldId)
+            ->setName($csvHeader);
+    }, $csvHeaders);
+
+    $tableRows = array_map(function ($csvRow) {
+        $rowValues = array_map(function ($csvValue) {
+            return (new Value())
+                ->setStringValue($csvValue);
+        }, explode(',', $csvRow));
+        return (new Row())
+            ->setValues($rowValues);
+    }, $csvRows);
+
+    // Construct the table object
+    $tableToDeIdentify = (new Table())
+        ->setHeaders($tableHeaders)
+        ->setRows($tableRows);
+
+    // Specify what content you want the service to de-identify.
+    $content = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Specify the type of info the inspection will look for.
+    $personNameInfoType = (new InfoType())
+        ->setName('PERSON_NAME');
+
+    // Specify that findings should be replaced with corresponding info type name.
+    $primitiveTransformation = (new PrimitiveTransformation())
+        ->setReplaceWithInfoTypeConfig(new ReplaceWithInfoTypeConfig());
+
+    // Associate info type with the replacement strategy
+    $infoTypeTransformation = (new InfoTypeTransformation())
+        ->setPrimitiveTransformation($primitiveTransformation)
+        ->setInfoTypes([$personNameInfoType]);
+
+    $infoTypeTransformations = (new InfoTypeTransformations())
+        ->setTransformations([$infoTypeTransformation]);
+
+    // Specify fields to be de-identified.
+    $fieldIds = [
+        (new FieldId())->setName('PATIENT'),
+        (new FieldId())->setName('FACTOID'),
+    ];
+
+    // Specify when the above fields should be de-identified.
+    $condition = (new Condition())
+        ->setField((new FieldId())
+            ->setName('AGE'))
+        ->setOperator(RelationalOperator::GREATER_THAN)
+        ->setValue((new Value())
+            ->setIntegerValue(89));
+
+    // Apply the condition to records
+    $recordCondition = (new RecordCondition())
+        ->setExpressions((new Expressions())
+                ->setConditions((new Conditions())
+                        ->setConditions([$condition])
+                )
+        );
+
+    // Associate the de-identification and conditions with the specified fields.
+    $fieldTransformation = (new FieldTransformation())
+        ->setInfoTypeTransformations($infoTypeTransformations)
+        ->setFields($fieldIds)
+        ->setCondition($recordCondition);
+
+    $recordtransformations = (new RecordTransformations())
+        ->setFieldTransformations([$fieldTransformation]);
+
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setRecordTransformations($recordtransformations);
+
+    // Run request
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'item' => $content
+    ]);
+
+    // Print results
+    $csvRef = fopen($outputCsvFile, 'w');
+    fputcsv($csvRef, $csvHeaders);
+    foreach ($response->getItem()->getTable()->getRows() as $tableRow) {
+        $values = array_map(function ($tableValue) {
+            return $tableValue->getStringValue();
+        }, iterator_to_array($tableRow->getValues()));
+        fputcsv($csvRef, $values);
+    };
+    printf($outputCsvFile);
+}
+# [END dlp_deidentify_table_condition_infotypes]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/deidentify_table_condition_masking.php
+++ b/dlp/src/deidentify_table_condition_masking.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_table_condition_masking]
+use Google\Cloud\Dlp\V2\CharacterMaskConfig;
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\Value;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\FieldTransformation;
+use Google\Cloud\Dlp\V2\RecordCondition;
+use Google\Cloud\Dlp\V2\RecordCondition\Condition;
+use Google\Cloud\Dlp\V2\RecordCondition\Conditions;
+use Google\Cloud\Dlp\V2\RecordCondition\Expressions;
+use Google\Cloud\Dlp\V2\RecordTransformations;
+use Google\Cloud\Dlp\V2\RelationalOperator;
+
+/**
+ * De-identify table data using masking and conditional logic.
+ * Transform a column based on the value of another column.
+ *
+ * @param string $callingProjectId      The Google Cloud project id to use as a parent resource.
+ * @param string $inputCsvFile          The input file(csv) path  to deidentify
+ * @param string $outputCsvFile         The oupt file path to save deidentify content
+ */
+
+function deidentify_table_condition_masking(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $inputCsvFile = './test/data/table2.csv',
+    string $outputCsvFile = './test/data/deidentify_table_condition_masking_output.csv'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$callingProjectId/locations/global";
+
+    // Read a CSV file
+    $csvLines = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+    $csvHeaders = explode(',', $csvLines[0]);
+    $csvRows = array_slice($csvLines, 1);
+
+    // Convert CSV file into protobuf objects
+    $tableHeaders = array_map(function ($csvHeader) {
+        return (new FieldId)
+            ->setName($csvHeader);
+    }, $csvHeaders);
+
+    $tableRows = array_map(function ($csvRow) {
+        $rowValues = array_map(function ($csvValue) {
+            return (new Value())
+                ->setStringValue($csvValue);
+        }, explode(',', $csvRow));
+        return (new Row())
+            ->setValues($rowValues);
+    }, $csvRows);
+
+    // Construct the table object
+    $tableToDeIdentify = (new Table())
+        ->setHeaders($tableHeaders)
+        ->setRows($tableRows);
+
+    // Specify what content you want the service to de-identify.
+    $content = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Specify how the content should be de-identified.
+    $characterMaskConfig = (new CharacterMaskConfig())
+        ->setMaskingCharacter('*');
+    $primitiveTransformation = (new PrimitiveTransformation())
+        ->setCharacterMaskConfig($characterMaskConfig);
+
+    // Specify field to be de-identified.
+    $fieldId = (new FieldId())
+        ->setName('HAPPINESS_SCORE');
+
+    // Specify when the above fields should be de-identified.
+    $condition = (new Condition())
+        ->setField((new FieldId())
+            ->setName('AGE'))
+        ->setOperator(RelationalOperator::GREATER_THAN)
+        ->setValue((new Value())
+            ->setIntegerValue(89));
+
+    // Apply the condition to records
+    $recordCondition = (new RecordCondition())
+        ->setExpressions((new Expressions())
+                ->setConditions((new Conditions())
+                        ->setConditions([$condition])
+                )
+        );
+
+    // Associate the de-identification and conditions with the specified fields.
+    $fieldTransformation = (new FieldTransformation())
+        ->setPrimitiveTransformation($primitiveTransformation)
+        ->setFields([$fieldId])
+        ->setCondition($recordCondition);
+
+    $recordtransformations = (new RecordTransformations())
+        ->setFieldTransformations([$fieldTransformation]);
+
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setRecordTransformations($recordtransformations);
+
+    // Run request
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'item' => $content
+    ]);
+
+    // Print results
+    $csvRef = fopen($outputCsvFile, 'w');
+    fputcsv($csvRef, $csvHeaders);
+    foreach ($response->getItem()->getTable()->getRows() as $tableRow) {
+        $values = array_map(function ($tableValue) {
+            return $tableValue->getStringValue();
+        }, iterator_to_array($tableRow->getValues()));
+        fputcsv($csvRef, $values);
+    };
+    printf('After de-identify the table data (Output File Location): %s', $outputCsvFile);
+}
+# [END dlp_deidentify_table_condition_masking]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/deidentify_table_infotypes.php
+++ b/dlp/src/deidentify_table_infotypes.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_table_infotypes]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations\InfoTypeTransformation;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\Value;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\ReplaceWithInfoTypeConfig;
+use Google\Cloud\Dlp\V2\FieldTransformation;
+use Google\Cloud\Dlp\V2\RecordTransformations;
+
+/**
+ * De-identify table data with infoTypes
+ *
+ * @param string $callingProjectId      The Google Cloud project id to use as a parent resource.
+ * @param string $inputCsvFile          The input file(csv) path  to deidentify
+ * @param string $outputCsvFile         The oupt file path to save deidentify content
+ */
+
+function deidentify_table_infotypes(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $inputCsvFile = './test/data/table1.csv',
+    string $outputCsvFile = './test/data/deidentify_table_infotypes_output.csv'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$callingProjectId/locations/global";
+
+    // Read a CSV file
+    $csvLines = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+    $csvHeaders = explode(',', $csvLines[0]);
+    $csvRows = array_slice($csvLines, 1);
+
+    // Convert CSV file into protobuf objects
+    $tableHeaders = array_map(function ($csvHeader) {
+        return (new FieldId)
+            ->setName($csvHeader);
+    }, $csvHeaders);
+
+    $tableRows = array_map(function ($csvRow) {
+        $rowValues = array_map(function ($csvValue) {
+            return (new Value())
+                ->setStringValue($csvValue);
+        }, explode(',', $csvRow));
+        return (new Row())
+            ->setValues($rowValues);
+    }, $csvRows);
+
+    // Construct the table object
+    $tableToDeIdentify = (new Table())
+        ->setHeaders($tableHeaders)
+        ->setRows($tableRows);
+
+    // Specify the content to be inspected.
+    $content = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Specify the type of info the inspection will look for.
+    $personNameInfoType = (new InfoType())
+        ->setName('PERSON_NAME');
+
+    // Specify that findings should be replaced with corresponding info type name.
+    $primitiveTransformation = (new PrimitiveTransformation())
+        ->setReplaceWithInfoTypeConfig(new ReplaceWithInfoTypeConfig());
+
+    // Associate info type with the replacement strategy
+    $infoTypeTransformation = (new InfoTypeTransformation())
+        ->setPrimitiveTransformation($primitiveTransformation)
+        ->setInfoTypes([$personNameInfoType]);
+
+    $infoTypeTransformations = (new InfoTypeTransformations())
+        ->setTransformations([$infoTypeTransformation]);
+
+    // Specify fields to be de-identified.
+    $fieldIds = [
+        (new FieldId())->setName('PATIENT'),
+        (new FieldId())->setName('FACTOID'),
+    ];
+
+    // Associate the de-identification and transformation with the specified fields.
+    $fieldTransformation = (new FieldTransformation())
+        ->setInfoTypeTransformations($infoTypeTransformations)
+        ->setFields($fieldIds);
+
+    $recordtransformations = (new RecordTransformations())
+        ->setFieldTransformations([$fieldTransformation]);
+
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setRecordTransformations($recordtransformations);
+
+    // Run request
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'item' => $content
+    ]);
+
+    // Print the results
+    $csvRef = fopen($outputCsvFile, 'w');
+    fputcsv($csvRef, $csvHeaders);
+    foreach ($response->getItem()->getTable()->getRows() as $tableRow) {
+        $values = array_map(function ($tableValue) {
+            return $tableValue->getStringValue();
+        }, iterator_to_array($tableRow->getValues()));
+        fputcsv($csvRef, $values);
+    };
+    printf('After de-identify the table data (Output File Location): %s', $outputCsvFile);
+}
+# [END dlp_deidentify_table_infotypes]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/deidentify_table_row_suppress.php
+++ b/dlp/src/deidentify_table_row_suppress.php
@@ -84,11 +84,11 @@ function deidentify_table_row_suppress(
         ->setHeaders($tableHeaders)
         ->setRows($tableRows);
 
-    // Specify the content to be inspected.
+    // Specify what content you want the service to de-identify.
     $content = (new ContentItem())
         ->setTable($tableToDeIdentify);
 
-    // Specify when the above fields should be de-identified.
+    // Specify when the content should be de-identified.
     $condition = (new Condition())
         ->setField((new FieldId())
             ->setName('AGE'))
@@ -106,9 +106,11 @@ function deidentify_table_row_suppress(
                 )
         );
 
+    // Use record suppression as the only transformation
     $recordtransformations = (new RecordTransformations())
         ->setRecordSuppressions([$recordSuppressions]);
 
+    // Create the deidentification configuration object
     $deidentifyConfig = (new DeidentifyConfig())
         ->setRecordTransformations($recordtransformations);
 

--- a/dlp/src/deidentify_table_row_suppress.php
+++ b/dlp/src/deidentify_table_row_suppress.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_table_row_suppress]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\Value;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\RecordTransformations;
+use Google\Cloud\Dlp\V2\RelationalOperator;
+use Google\Cloud\Dlp\V2\RecordCondition;
+use Google\Cloud\Dlp\V2\RecordCondition\Condition;
+use Google\Cloud\Dlp\V2\RecordCondition\Conditions;
+use Google\Cloud\Dlp\V2\RecordCondition\Expressions;
+use Google\Cloud\Dlp\V2\RecordSuppression;
+
+/**
+ * De-identify table data: Suppress a row based on the content of a column
+ * Suppress a row based on the content of a column. You can remove a row entirely based on the content that appears in any column. This example suppresses the record for "Charles Dickens," as this patient is over 89 years old.
+ *
+ * @param string $callingProjectId      The Google Cloud project id to use as a parent resource.
+ * @param string $inputCsvFile          The input file(csv) path  to deidentify
+ * @param string $outputCsvFile         The oupt file path to save deidentify content */
+
+function deidentify_table_row_suppress(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $inputCsvFile = './test/data/table2.csv',
+    string $outputCsvFile = './test/data/deidentify_table_row_suppress_output.csv'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$callingProjectId/locations/global";
+
+    // Read a CSV file
+    $csvLines = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+    $csvHeaders = explode(',', $csvLines[0]);
+    $csvRows = array_slice($csvLines, 1);
+
+    // Convert CSV file into protobuf objects
+    $tableHeaders = array_map(function ($csvHeader) {
+        return (new FieldId)
+            ->setName($csvHeader);
+    }, $csvHeaders);
+
+    $tableRows = array_map(function ($csvRow) {
+        $rowValues = array_map(function ($csvValue) {
+            return (new Value())
+                ->setStringValue($csvValue);
+        }, explode(',', $csvRow));
+        return (new Row())
+            ->setValues($rowValues);
+    }, $csvRows);
+
+    // Construct the table object
+    $tableToDeIdentify = (new Table())
+        ->setHeaders($tableHeaders)
+        ->setRows($tableRows);
+
+    // Specify the content to be inspected.
+    $content = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Specify when the above fields should be de-identified.
+    $condition = (new Condition())
+        ->setField((new FieldId())
+            ->setName('AGE'))
+        ->setOperator(RelationalOperator::GREATER_THAN)
+        ->setValue((new Value())
+            ->setIntegerValue(89));
+
+    // Apply the condition to record suppression.
+    $recordSuppressions = (new RecordSuppression())
+        ->setCondition((new RecordCondition())
+                ->setExpressions((new Expressions())
+                        ->setConditions((new Conditions())
+                                ->setConditions([$condition])
+                        )
+                )
+        );
+
+    $recordtransformations = (new RecordTransformations())
+        ->setRecordSuppressions([$recordSuppressions]);
+
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setRecordTransformations($recordtransformations);
+
+    // Run request
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'item' => $content
+    ]);
+
+    // Print the results
+    $csvRef = fopen($outputCsvFile, 'w');
+    fputcsv($csvRef, $csvHeaders);
+    foreach ($response->getItem()->getTable()->getRows() as $tableRow) {
+        $values = array_map(function ($tableValue) {
+            return $tableValue->getStringValue();
+        }, iterator_to_array($tableRow->getValues()));
+        fputcsv($csvRef, $values);
+    };
+    printf($outputCsvFile);
+}
+# [END dlp_deidentify_table_row_suppress]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/test/data/table1.csv
+++ b/dlp/test/data/table1.csv
@@ -1,0 +1,4 @@
+AGE,PATIENT,HAPPINESS_SCORE,FACTOID
+101,Charles Dickens,95,Charles Dickens name was a curse invented by Shakespeare.
+22,Jane Austen,21,There are 14 kisses in Jane Austen's novels.
+55,Mark Twain,75,Mark Twain loved cats.

--- a/dlp/test/data/table2.csv
+++ b/dlp/test/data/table2.csv
@@ -1,0 +1,4 @@
+AGE,PATIENT,HAPPINESS_SCORE
+101,Charles Dickens,95
+22,Jane Austen,21
+55,Mark Twain,75

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -448,4 +448,131 @@ class dlpTest extends TestCase
         $this->assertStringContainsString('[email-address]', $output);
         $this->assertNotEquals($output, $string);
     }
+
+    public function testDeidentifyTableInfotypes()
+    {
+        $inputCsvFile = __DIR__ . '/data/table1.csv';
+        $outputCsvFile = __DIR__ . '/data/deidentify_table_infotypes_output_unitest.csv';
+        $output = $this->runFunctionSnippet('deidentify_table_infotypes', [
+            self::$projectId,
+            $inputCsvFile,
+            $outputCsvFile,
+        ]);
+
+        $this->assertNotEquals(
+            sha1_file($outputCsvFile),
+            sha1_file($inputCsvFile)
+        );
+
+        $csvLines_input = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+        $csvLines_ouput = file($outputCsvFile, FILE_IGNORE_NEW_LINES);
+
+        $this->assertEquals($csvLines_input[0], $csvLines_ouput[0]);
+        $this->assertStringContainsString('[PERSON_NAME]', $csvLines_ouput[1]);
+        $this->assertStringNotContainsString('Charles Dickens', $csvLines_ouput[1]);
+
+        unlink($outputCsvFile);
+    }
+
+    public function testDeidentifyTableConditionMasking()
+    {
+        $inputCsvFile = __DIR__ . '/data/table2.csv';
+        $outputCsvFile = __DIR__ . '/data/deidentify_table_condition_masking_output_unittest.csv';
+
+        $output = $this->runFunctionSnippet('deidentify_table_condition_masking', [
+            self::$projectId,
+            $inputCsvFile,
+            $outputCsvFile
+        ]);
+        $this->assertNotEquals(
+            sha1_file($outputCsvFile),
+            sha1_file($inputCsvFile)
+        );
+
+        $csvLines_input = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+        $csvLines_ouput = file($outputCsvFile, FILE_IGNORE_NEW_LINES);
+
+        $this->assertEquals($csvLines_input[0], $csvLines_ouput[0]);
+        $this->assertStringContainsString('**', $csvLines_ouput[1]);
+
+        unlink($outputCsvFile);
+    }
+
+    public function testDeidentifyTableConditionInfotypes()
+    {
+        $inputCsvFile = __DIR__ . '/data/table1.csv';
+        $outputCsvFile = __DIR__ . '/data/deidentify_table_condition_infotypes_output_unittest.csv';
+
+        $output = $this->runFunctionSnippet('deidentify_table_condition_infotypes', [
+            self::$projectId,
+            $inputCsvFile,
+            $outputCsvFile
+        ]);
+
+        $this->assertNotEquals(
+            sha1_file($inputCsvFile),
+            sha1_file($outputCsvFile)
+        );
+
+        $csvLines_input = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+        $csvLines_ouput = file($outputCsvFile, FILE_IGNORE_NEW_LINES);
+
+        $this->assertEquals($csvLines_input[0], $csvLines_ouput[0]);
+        $this->assertStringContainsString('[PERSON_NAME]', $csvLines_ouput[1]);
+        $this->assertStringNotContainsString('Charles Dickens', $csvLines_ouput[1]);
+        $this->assertStringNotContainsString('[PERSON_NAME]', $csvLines_ouput[2]);
+        $this->assertStringContainsString('Jane Austen', $csvLines_ouput[2]);
+
+        unlink($outputCsvFile);
+    }
+
+    public function testDeidentifyTableBucketing()
+    {
+        $inputCsvFile = __DIR__ . '/data/table2.csv';
+        $outputCsvFile = __DIR__ . '/data/deidentify_table_bucketing_output_unittest.csv';
+
+        $output = $this->runFunctionSnippet('deidentify_table_bucketing', [
+            self::$projectId,
+            $inputCsvFile,
+            $outputCsvFile
+        ]);
+
+        $this->assertNotEquals(
+            sha1_file($outputCsvFile),
+            sha1_file($inputCsvFile)
+        );
+
+        $csvLines_input = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+        $csvLines_ouput = file($outputCsvFile, FILE_IGNORE_NEW_LINES);
+
+        $this->assertEquals($csvLines_input[0], $csvLines_ouput[0]);
+        $this->assertStringContainsString('90:100', $csvLines_ouput[1]);
+        $this->assertStringContainsString('20:30', $csvLines_ouput[2]);
+        $this->assertStringContainsString('70:80', $csvLines_ouput[3]);
+
+        unlink($outputCsvFile);
+    }
+
+    public function testDeidentifyTableRowSuppress()
+    {
+        $inputCsvFile = __DIR__ . '/data/table2.csv';
+        $outputCsvFile = __DIR__ . '/data/deidentify_table_row_suppress_output_unitest.csv';
+        $output = $this->runFunctionSnippet('deidentify_table_row_suppress', [
+            self::$projectId,
+            $inputCsvFile,
+            $outputCsvFile,
+        ]);
+
+        $this->assertNotEquals(
+            sha1_file($outputCsvFile),
+            sha1_file($inputCsvFile)
+        );
+
+        $csvLines_input = file($inputCsvFile, FILE_IGNORE_NEW_LINES);
+        $csvLines_ouput = file($outputCsvFile, FILE_IGNORE_NEW_LINES);
+
+        $this->assertEquals($csvLines_input[0], $csvLines_ouput[0]);
+        $this->assertEquals(3, count($csvLines_ouput));
+        unlink($outputCsvFile);
+    }
 }


### PR DESCRIPTION
Implemented below samples 

1) [dlp_deidentify_table_infotypes](https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_findings_found_in_columns)
2) [dlp_deidentify_table_condition_masking](https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_a_column_based_on_the_value_of_another_column)
3) [dlp_deidentify_table_condition_infotypes](https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_findings_only_when_specific_conditions_are_met_on_another_field)
4) [dlp_deidentify_table_bucketing](https://cloud.google.com/dlp/docs/examples-deid-tables.md#transform_a_column_without_inspection)
5) [dlp_deidentify_table_row_suppress](https://cloud.google.com/dlp/docs/examples-deid-tables.md#suppress_a_row_based_on_the_content_of_a_column)

Added test cases for the same

