### PR TITLE
chore: upgrade to PHP 8.1 and PHP 8.2, drop support for PHP 7.4 and below

### DIFF
--- a/.kokoro/deploy_gae.cfg
+++ b/.kokoro/deploy_gae.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php74"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php80"
 }
 
 # Run the deployment tests

--- a/.kokoro/deploy_gcf.cfg
+++ b/.kokoro/deploy_gcf.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php74"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php80"
 }
 
 # Run the deployment tests

--- a/.kokoro/deploy_misc.cfg
+++ b/.kokoro/deploy_misc.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php74"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php80"
 }
 
 # Run the deployment tests

--- a/.kokoro/php81.cfg
+++ b/.kokoro/php81.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php74"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php81"
 }
 
 # Give the docker image a unique project ID and credentials per PHP version

--- a/.kokoro/php82.cfg
+++ b/.kokoro/php82.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php73"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php82"
 }
 
 # Give the docker image a unique project ID and credentials per PHP version

--- a/.kokoro/php_rest.cfg
+++ b/.kokoro/php_rest.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php74"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php80"
 }
 
 # Set this project to run REST tests only

--- a/.kokoro/php_rest.cfg
+++ b/.kokoro/php_rest.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/php73"
+    value: "gcr.io/cloud-devrel-kokoro-resources/php74"
 }
 
 # Set this project to run REST tests only

--- a/.kokoro/system_tests.sh
+++ b/.kokoro/system_tests.sh
@@ -59,5 +59,8 @@ fi
 # Install global test dependencies
 composer install -d testing/
 
+# Configure the current directory as a safe directory
+git config --global --add safe.directory $(pwd)
+
 # Run tests
 bash testing/run_test_suite.sh

--- a/appengine/standard/errorreporting/README.md
+++ b/appengine/standard/errorreporting/README.md
@@ -10,11 +10,15 @@ these two steps:
    ```sh
    composer require google/cloud-error-reporting
    ```
-1. Create a [`php.ini`](php.ini) file in the root of your project and set
-   `auto_prepend_file` to the following:
-    ```ini
-    ; in php.ini
-    auto_prepend_file=/srv/vendor/google/cloud-error-reporting/src/prepend.php
+1. Add the command to autoload the "prepend.php" file at the beginning of every
+   request in `composer.json:
+    ```js
+    {
+        "autoload": {
+            "files": ["vendor/google/cloud-error-reporting/src/prepend.php"]
+        }
+    }
+
     ```
 
 The [`prepend.php`][prepend] file will be executed prior to each request, which
@@ -22,8 +26,8 @@ registers the client library's error handler.
 
 [prepend]: https://github.com/GoogleCloudPlatform/google-cloud-php-errorreporting/blob/main/src/prepend.php
 
-If you cannot modify your `php.ini`, the `prepend.php` file can be manually
-included to register the error handler:
+Alternatively, the `prepend.php` file can be manually included to register the
+error handler:
 
 ```php
 # This works for files in the root of your project. Adjust __DIR__ accordingly.
@@ -56,8 +60,10 @@ in your browser. Browse to `/` to see a list of examples to execute.
 
 ### Run Locally
 
-Uncomment the `require_once` statement at the top of [`index.php`](index.php),
-or add the `auto_prepend_file` above to your local `php.ini`.
+The `prepend.php` file will be autoloaded on each request via composer. You
+can also uncomment the `require_once` statement at the top of
+[`index.php`](index.php), or load the file using `auto_prepend_file` in your
+local `php.ini`.
 
 Now run the sample locally using PHP's build-in web server:
 

--- a/appengine/standard/errorreporting/app.yaml
+++ b/appengine/standard/errorreporting/app.yaml
@@ -1,4 +1,4 @@
-runtime: php74
+runtime: php82
 
 # Defaults to "serve index.php" and "serve public/index.php". Can be used to
 # serve a custom PHP front controller (e.g. "serve backend/index.php") or to

--- a/appengine/standard/errorreporting/composer.json
+++ b/appengine/standard/errorreporting/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/cloud-error-reporting": "^0.19.0"
+        "google/cloud-error-reporting": "^0.20.0"
     }
 }

--- a/appengine/standard/errorreporting/composer.json
+++ b/appengine/standard/errorreporting/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
         "google/cloud-error-reporting": "^0.20.0"
+    },
+    "autoload": {
+        "files": [
+            "vendor/google/cloud-error-reporting/src/prepend.php"
+        ]
     }
 }

--- a/appengine/standard/errorreporting/index.php
+++ b/appengine/standard/errorreporting/index.php
@@ -14,7 +14,7 @@ require __DIR__ . '/vendor/autoload.php';
 # [END gae_erroreporting_register_handler]
 
 # Uncomment this line if you'd like to include `prepend.php` manually instead of
-# using composer autolaoding or `php.ini`:
+# using composer autoloading or `php.ini`:
 #
 #    require_once 'vendor/google/cloud-error-reporting/src/prepend.php';
 #

--- a/appengine/standard/errorreporting/index.php
+++ b/appengine/standard/errorreporting/index.php
@@ -1,5 +1,8 @@
 <?php
 
+# This will register the error handler via autoload.files in composer.json.
+require __DIR__ . '/vendor/autoload.php';
+
 # [START gae_erroreporting_register_handler]
 # After running "composer require google/cloud-error-reporting", register the
 # error handler by including `prepend.php` in your application. This is most
@@ -11,7 +14,7 @@
 # [END gae_erroreporting_register_handler]
 
 # Uncomment this line if you'd like to include `prepend.php` manually instead of
-# using `php.ini`:
+# using composer autolaoding or `php.ini`:
 #
 #    require_once 'vendor/google/cloud-error-reporting/src/prepend.php';
 #

--- a/appengine/standard/errorreporting/php.ini
+++ b/appengine/standard/errorreporting/php.ini
@@ -1,1 +1,1 @@
-auto_prepend_file=/workspace/vendor/google/cloud-error-reporting/src/prepend.php
+auto_prepend_file=vendor/google/cloud-error-reporting/src/prepend.php

--- a/appengine/standard/errorreporting/php.ini
+++ b/appengine/standard/errorreporting/php.ini
@@ -1,1 +1,0 @@
-auto_prepend_file=vendor/google/cloud-error-reporting/src/prepend.php

--- a/appengine/standard/errorreporting/php.ini
+++ b/appengine/standard/errorreporting/php.ini
@@ -1,1 +1,1 @@
-auto_prepend_file=/srv/vendor/google/cloud-error-reporting/src/prepend.php
+auto_prepend_file=/workspace/vendor/google/cloud-error-reporting/src/prepend.php

--- a/appengine/standard/grpc/README.md
+++ b/appengine/standard/grpc/README.md
@@ -1,4 +1,4 @@
-# gRPC for App Engine (php72)
+# gRPC for App Engine
 
 This app demonstrates how to run gRPC client libraries on App Engine.
 

--- a/appengine/standard/grpc/app.yaml
+++ b/appengine/standard/grpc/app.yaml
@@ -1,4 +1,4 @@
-runtime: php74
+runtime: php82
 
 handlers:
 - url: /(monitoring|spanner|speech)\.php$

--- a/appengine/standard/memorystore/test/DeployTest.php
+++ b/appengine/standard/memorystore/test/DeployTest.php
@@ -35,7 +35,7 @@ class DeployTest extends TestCase
         $resp = $this->client->request('GET', '/');
 
         $this->assertEquals('200', $resp->getStatusCode());
-        $this->assertRegExp('/Visitor number: \d+/', (string) $resp->getBody());
+        $this->assertMatchesRegularExpression('/Visitor number: \d+/', (string) $resp->getBody());
     }
 
     public static function beforeDeploy()

--- a/appengine/standard/symfony-framework/app.yaml
+++ b/appengine/standard/symfony-framework/app.yaml
@@ -1,4 +1,4 @@
-runtime: php74
+runtime: php82
 
 env_variables:
   APP_ENV: prod

--- a/asset/src/export_assets.php
+++ b/asset/src/export_assets.php
@@ -44,7 +44,7 @@ function export_assets(string $projectId, string $dumpFilePath)
         print('The result is dumped to $dumpFilePath successfully.' . PHP_EOL);
     } else {
         $error = $resp->getError();
-        printf('There was an error: "%s".' . PHP_EOL, $error->getMessage());
+        printf('There was an error: "%s".' . PHP_EOL, $error?->getMessage());
         // handleError($error)
     }
 }

--- a/asset/test/assetSearchTest.php
+++ b/asset/test/assetSearchTest.php
@@ -21,14 +21,18 @@ use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\TestUtils\TestTrait;
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use PHPUnit\Framework\TestCase;
+use PHPUnitRetry\RetryTrait;
 
 /**
  * Unit Tests for asset search commands.
+ *
+ * @retryAttempts 3
+ * @retryDelayMethod exponentialBackoff
  */
 class assetSearchTest extends TestCase
 {
+    use RetryTrait;
     use TestTrait;
-    use EventuallyConsistentTestTrait;
 
     private static $datasetId;
     private static $dataset;
@@ -52,13 +56,12 @@ class assetSearchTest extends TestCase
         $scope = 'projects/' . self::$projectId;
         $query = 'name:' . self::$datasetId;
 
-        $this->runEventuallyConsistentTest(function () use ($scope, $query) {
-            $output = $this->runFunctionSnippet('search_all_resources', [
-                $scope,
-                $query
-            ]);
-            $this->assertStringContainsString(self::$datasetId, $output);
-        }, 3, true);
+        $output = $this->runFunctionSnippet('search_all_resources', [
+            $scope,
+            $query
+        ]);
+
+        $this->assertStringContainsString(self::$datasetId, $output);
     }
 
     public function testSearchAllIamPolicies()

--- a/asset/test/assetSearchTest.php
+++ b/asset/test/assetSearchTest.php
@@ -19,7 +19,6 @@ namespace Google\Cloud\Samples\Asset;
 
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\TestUtils\TestTrait;
-use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use PHPUnit\Framework\TestCase;
 use PHPUnitRetry\RetryTrait;
 

--- a/asset/test/assetTest.php
+++ b/asset/test/assetTest.php
@@ -19,7 +19,6 @@ namespace Google\Cloud\Samples\Asset;
 
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\TestUtils\TestTrait;
-use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use PHPUnit\Framework\TestCase;
 use PHPUnitRetry\RetryTrait;
 

--- a/asset/test/assetTest.php
+++ b/asset/test/assetTest.php
@@ -21,14 +21,18 @@ use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\TestUtils\TestTrait;
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use PHPUnit\Framework\TestCase;
+use PHPUnitRetry\RetryTrait;
 
 /**
  * Unit Tests for asset commands.
+ *
+ * @retryAttempts 3
+ * @retryDelayMethod exponentialBackoff
  */
 class assetTest extends TestCase
 {
+    use RetryTrait;
     use TestTrait;
-    use EventuallyConsistentTestTrait;
 
     private static $storage;
     private static $bucketName;
@@ -62,28 +66,24 @@ class assetTest extends TestCase
     public function testListAssets()
     {
         $assetName = '//storage.googleapis.com/' . self::$bucketName;
-        $this->runEventuallyConsistentTest(function () use ($assetName) {
-            $output = $this->runFunctionSnippet('list_assets', [
-                'projectId' => self::$projectId,
-                'assetTypes' => ['storage.googleapis.com/Bucket'],
-                'pageSize' => 1000,
-            ]);
+        $output = $this->runFunctionSnippet('list_assets', [
+            'projectId' => self::$projectId,
+            'assetTypes' => ['storage.googleapis.com/Bucket'],
+            'pageSize' => 1000,
+        ]);
 
-            $this->assertStringContainsString($assetName, $output);
-        }, 10, true);
+        $this->assertStringContainsString($assetName, $output);
     }
 
     public function testBatchGetAssetsHistory()
     {
         $assetName = '//storage.googleapis.com/' . self::$bucketName;
 
-        $this->runEventuallyConsistentTest(function () use ($assetName) {
-            $output = $this->runFunctionSnippet('batch_get_assets_history', [
-                'projectId' => self::$projectId,
-                'assetNames' => [$assetName],
-            ]);
+        $output = $this->runFunctionSnippet('batch_get_assets_history', [
+            'projectId' => self::$projectId,
+            'assetNames' => [$assetName],
+        ]);
 
-            $this->assertStringContainsString($assetName, $output);
-        }, 10, true);
+        $this->assertStringContainsString($assetName, $output);
     }
 }

--- a/auth/app.yaml
+++ b/auth/app.yaml
@@ -1,1 +1,1 @@
-runtime: php74
+runtime: php82

--- a/auth/app.yaml
+++ b/auth/app.yaml
@@ -1,1 +1,1 @@
-runtime: php72
+runtime: php74

--- a/bigtable/src/create_cluster.php
+++ b/bigtable/src/create_cluster.php
@@ -92,7 +92,7 @@ function create_cluster(
                 printf('Cluster created: %s', $clusterId);
             } else {
                 $error = $operationResponse->getError();
-                printf('Cluster not created: %s', $error->getMessage());
+                printf('Cluster not created: %s', $error?->getMessage());
             }
         } else {
             throw $e;

--- a/bigtable/src/create_cluster_autoscale_config.php
+++ b/bigtable/src/create_cluster_autoscale_config.php
@@ -87,7 +87,7 @@ function create_cluster_autoscale_config(
         printf('Cluster created: %s' . PHP_EOL, $clusterId);
     } else {
         $error = $operationResponse->getError();
-        printf('Cluster not created: %s' . PHP_EOL, $error->getMessage());
+        printf('Cluster not created: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 // [END bigtable_api_cluster_create_autoscaling]

--- a/bigtable/src/disable_cluster_autoscale_config.php
+++ b/bigtable/src/disable_cluster_autoscale_config.php
@@ -66,7 +66,7 @@ function disable_cluster_autoscale_config(
             printf('Cluster updated with the new num of nodes: %s.' . PHP_EOL, $updatedCluster->getServeNodes());
         } else {
             $error = $operationResponse->getError();
-            printf('Cluster %s failed to update: %s.' . PHP_EOL, $clusterId, $error->getMessage());
+            printf('Cluster %s failed to update: %s.' . PHP_EOL, $clusterId, $error?->getMessage());
         }
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {

--- a/bigtable/src/update_cluster_autoscale_config.php
+++ b/bigtable/src/update_cluster_autoscale_config.php
@@ -83,7 +83,7 @@ function update_cluster_autoscale_config(
             printf('Cluster %s updated with autoscale config.' . PHP_EOL, $clusterId);
         } else {
             $error = $operationResponse->getError();
-            printf('Cluster %s failed to update: %s.' . PHP_EOL, $clusterId, $error->getMessage());
+            printf('Cluster %s failed to update: %s.' . PHP_EOL, $clusterId, $error?->getMessage());
         }
     } catch (ApiException $e) {
         if ($e->getStatus() === 'NOT_FOUND') {

--- a/cloud_sql/mysql/pdo/app.standard.yaml
+++ b/cloud_sql/mysql/pdo/app.standard.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: php74
+runtime: php82
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
 # something like https://cloud.google.com/secret-manager/ to help keep secrets secret.

--- a/cloud_sql/mysql/pdo/test/IntegrationTest.php
+++ b/cloud_sql/mysql/pdo/test/IntegrationTest.php
@@ -25,9 +25,6 @@ use Google\Cloud\TestUtils\TestTrait;
 use Google\Cloud\TestUtils\CloudSqlProxyTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @runTestsInSeparateProcesses
- */
 class IntegrationTest extends TestCase
 {
     use TestTrait;

--- a/cloud_sql/mysql/pdo/test/VotesTest.php
+++ b/cloud_sql/mysql/pdo/test/VotesTest.php
@@ -23,10 +23,13 @@ use PDOException;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use RuntimeException;
 
 class VotesTest extends TestCase
 {
+    use ProphecyTrait;
+
     private $conn;
 
     public function setUp(): void

--- a/cloud_sql/postgres/pdo/app.standard.yaml
+++ b/cloud_sql/postgres/pdo/app.standard.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: php74
+runtime: php82
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
 # something like https://cloud.google.com/secret-manager/ to help keep secrets secret.

--- a/cloud_sql/postgres/pdo/test/IntegrationTest.php
+++ b/cloud_sql/postgres/pdo/test/IntegrationTest.php
@@ -25,9 +25,6 @@ use Google\Cloud\TestUtils\TestTrait;
 use Google\Cloud\TestUtils\CloudSqlProxyTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @runTestsInSeparateProcesses
- */
 class IntegrationTest extends TestCase
 {
     use TestTrait;

--- a/cloud_sql/postgres/pdo/test/VotesTest.php
+++ b/cloud_sql/postgres/pdo/test/VotesTest.php
@@ -23,10 +23,13 @@ use PDOException;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use RuntimeException;
 
 class VotesTest extends TestCase
 {
+    use ProphecyTrait;
+
     private $conn;
 
     public function setUp(): void

--- a/cloud_sql/sqlserver/pdo/Dockerfile
+++ b/cloud_sql/sqlserver/pdo/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_appengine/php74
+FROM gcr.io/google_appengine/php72
 
 COPY --from=composer:latest-bin /composer /usr/local/bin/composer
 
@@ -16,6 +16,6 @@ RUN apt-get update && \
         unzip
 
 RUN pecl install pdo_sqlsrv
-RUN echo "extension=pdo_sqlsrv.so" > /opt/php74/lib/ext.enabled/ext-pdo_sqlsrv.ini
+RUN echo "extension=pdo_sqlsrv.so" > /opt/php72/lib/ext.enabled/ext-pdo_sqlsrv.ini
 # RUN phpenmod pdo_sqlsrv
 RUN composer update

--- a/cloud_sql/sqlserver/pdo/Dockerfile
+++ b/cloud_sql/sqlserver/pdo/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_appengine/php72
+FROM gcr.io/google_appengine/php74
 
 COPY --from=composer:latest-bin /composer /usr/local/bin/composer
 
@@ -16,6 +16,6 @@ RUN apt-get update && \
         unzip
 
 RUN pecl install pdo_sqlsrv
-RUN echo "extension=pdo_sqlsrv.so" > /opt/php72/lib/ext.enabled/ext-pdo_sqlsrv.ini
+RUN echo "extension=pdo_sqlsrv.so" > /opt/php74/lib/ext.enabled/ext-pdo_sqlsrv.ini
 # RUN phpenmod pdo_sqlsrv
 RUN composer update

--- a/cloud_sql/sqlserver/pdo/test/IntegrationTest.php
+++ b/cloud_sql/sqlserver/pdo/test/IntegrationTest.php
@@ -24,9 +24,6 @@ use Google\Cloud\TestUtils\TestTrait;
 use Google\Cloud\TestUtils\CloudSqlProxyTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @runTestsInSeparateProcesses
- */
 class IntegrationTest extends TestCase
 {
     use TestTrait;

--- a/cloud_sql/sqlserver/pdo/test/VotesTest.php
+++ b/cloud_sql/sqlserver/pdo/test/VotesTest.php
@@ -23,10 +23,13 @@ use PDOException;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use RuntimeException;
 
 class VotesTest extends TestCase
 {
+    use ProphecyTrait;
+
     private $conn;
 
     public function setUp(): void

--- a/compute/firewall/src/create_firewall_rule.php
+++ b/compute/firewall/src/create_firewall_rule.php
@@ -82,7 +82,7 @@ function create_firewall_rule(string $projectId, string $firewallRuleName, strin
         printf('Created rule %s.' . PHP_EOL, $firewallRuleName);
     } else {
         $error = $operation->getError();
-        printf('Firewall rule creation failed: %s' . PHP_EOL, $error->getMessage());
+        printf('Firewall rule creation failed: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_firewall_create]

--- a/compute/firewall/src/delete_firewall_rule.php
+++ b/compute/firewall/src/delete_firewall_rule.php
@@ -48,7 +48,7 @@ function delete_firewall_rule(string $projectId, string $firewallRuleName)
         printf('Rule %s deleted successfully!' . PHP_EOL, $firewallRuleName);
     } else {
         $error = $operation->getError();
-        printf('Failed to delete firewall rule: %s' . PHP_EOL, $error->getMessage());
+        printf('Failed to delete firewall rule: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_firewall_delete]

--- a/compute/firewall/src/patch_firewall_priority.php
+++ b/compute/firewall/src/patch_firewall_priority.php
@@ -52,7 +52,7 @@ function patch_firewall_priority(string $projectId, string $firewallRuleName, in
         printf('Patched %s priority to %d.' . PHP_EOL, $firewallRuleName, $priority);
     } else {
         $error = $operation->getError();
-        printf('Patching failed: %s' . PHP_EOL, $error->getMessage());
+        printf('Patching failed: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_firewall_patch]

--- a/compute/instances/src/create_instance.php
+++ b/compute/instances/src/create_instance.php
@@ -91,7 +91,7 @@ function create_instance(
         printf('Created instance %s' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Instance creation failed: %s' . PHP_EOL, $error->getMessage());
+        printf('Instance creation failed: %s' . PHP_EOL, $error?->getMessage());
     }
     # [END compute_instances_operation_check]
 }

--- a/compute/instances/src/create_instance_with_encryption_key.php
+++ b/compute/instances/src/create_instance_with_encryption_key.php
@@ -102,7 +102,7 @@ function create_instance_with_encryption_key(
         printf('Created instance %s' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Instance creation failed: %s' . PHP_EOL, $error->getMessage());
+        printf('Instance creation failed: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_instances_create_encrypted]

--- a/compute/instances/src/delete_instance.php
+++ b/compute/instances/src/delete_instance.php
@@ -51,7 +51,7 @@ function delete_instance(
         printf('Deleted instance %s' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Failed to delete instance: %s' . PHP_EOL, $error->getMessage());
+        printf('Failed to delete instance: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_instances_delete]

--- a/compute/instances/src/disable_usage_export_bucket.php
+++ b/compute/instances/src/disable_usage_export_bucket.php
@@ -46,7 +46,7 @@ function disable_usage_export_bucket(string $projectId)
         printf('Compute Engine usage export bucket for project `%s` was disabled.', $projectId);
     } else {
         $error = $operation->getError();
-        printf('Failed to disable usage report bucket for project `%s`: %s' . PHP_EOL, $projectId, $error->getMessage());
+        printf('Failed to disable usage report bucket for project `%s`: %s' . PHP_EOL, $projectId, $error?->getMessage());
     }
 }
 # [END compute_usage_report_disable]

--- a/compute/instances/src/reset_instance.php
+++ b/compute/instances/src/reset_instance.php
@@ -51,7 +51,7 @@ function reset_instance(
         printf('Instance %s reset successfully' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Failed to reset instance: %s' . PHP_EOL, $error->getMessage());
+        printf('Failed to reset instance: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 

--- a/compute/instances/src/resume_instance.php
+++ b/compute/instances/src/resume_instance.php
@@ -51,7 +51,7 @@ function resume_instance(
         printf('Instance %s resumed successfully' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Failed to resume instance: %s' . PHP_EOL, $error->getMessage());
+        printf('Failed to resume instance: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_resume_instance]

--- a/compute/instances/src/set_usage_export_bucket.php
+++ b/compute/instances/src/set_usage_export_bucket.php
@@ -76,7 +76,7 @@ function set_usage_export_bucket(
         );
     } else {
         $error = $operation->getError();
-        printf('Setting usage export bucket failed: %s' . PHP_EOL, $error->getMessage());
+        printf('Setting usage export bucket failed: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_usage_report_set]

--- a/compute/instances/src/start_instance.php
+++ b/compute/instances/src/start_instance.php
@@ -51,7 +51,7 @@ function start_instance(
         printf('Instance %s started successfully' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Failed to start instance: %s' . PHP_EOL, $error->getMessage());
+        printf('Failed to start instance: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_start_instance]

--- a/compute/instances/src/start_instance_with_encryption_key.php
+++ b/compute/instances/src/start_instance_with_encryption_key.php
@@ -77,7 +77,7 @@ function start_instance_with_encryption_key(
         printf('Instance %s started successfully' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Starting instance failed: %s' . PHP_EOL, $error->getMessage());
+        printf('Starting instance failed: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 # [END compute_start_enc_instance]

--- a/compute/instances/src/stop_instance.php
+++ b/compute/instances/src/stop_instance.php
@@ -51,7 +51,7 @@ function stop_instance(
         printf('Instance %s stopped successfully' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Failed to stop instance: %s' . PHP_EOL, $error->getMessage());
+        printf('Failed to stop instance: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 

--- a/compute/instances/src/suspend_instance.php
+++ b/compute/instances/src/suspend_instance.php
@@ -51,7 +51,7 @@ function suspend_instance(
         printf('Instance %s suspended successfully' . PHP_EOL, $instanceName);
     } else {
         $error = $operation->getError();
-        printf('Failed to suspend instance: %s' . PHP_EOL, $error->getMessage());
+        printf('Failed to suspend instance: %s' . PHP_EOL, $error?->getMessage());
     }
 }
 

--- a/compute/instances/test/instancesTest.php
+++ b/compute/instances/test/instancesTest.php
@@ -20,9 +20,15 @@ namespace Google\Cloud\Samples\Compute;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
+use PHPUnitRetry\RetryTrait;
 
+/**
+ * @retryAttempts 3
+ * @retryDelayMethod exponentialBackoff
+ */
 class instancesTest extends TestCase
 {
+    use RetryTrait;
     use TestTrait;
 
     private static $instanceName;

--- a/dlp/README.md
+++ b/dlp/README.md
@@ -58,7 +58,7 @@ PHP Fatal error:  Uncaught Error: Call to undefined function Google\Protobuf\Int
 You may need to install the bcmath PHP extension.
 e.g. (may depend on your php version)
 ```
-$ sudo apt-get install php7.3-bcmath
+$ sudo apt-get install php7.4-bcmath
 ```
 
 

--- a/dlp/README.md
+++ b/dlp/README.md
@@ -58,7 +58,7 @@ PHP Fatal error:  Uncaught Error: Call to undefined function Google\Protobuf\Int
 You may need to install the bcmath PHP extension.
 e.g. (may depend on your php version)
 ```
-$ sudo apt-get install php7.4-bcmath
+$ sudo apt-get install php8.0-bcmath
 ```
 
 

--- a/dlp/test/dlpLongRunningTest.php
+++ b/dlp/test/dlpLongRunningTest.php
@@ -107,8 +107,8 @@ class dlpLongRunningTest extends TestCase
             $columnName,
         ]);
 
-        $this->assertRegExp('/Value range: \[\d+, \d+\]/', $output);
-        $this->assertRegExp('/Value at \d+ quantile: \d+/', $output);
+        $this->assertMatchesRegularExpression('/Value range: \[\d+, \d+\]/', $output);
+        $this->assertMatchesRegularExpression('/Value at \d+ quantile: \d+/', $output);
     }
 
     public function testCategoricalStats()
@@ -125,9 +125,9 @@ class dlpLongRunningTest extends TestCase
             $columnName,
         ]);
 
-        $this->assertRegExp('/Most common value occurs \d+ time\(s\)/', $output);
-        $this->assertRegExp('/Least common value occurs \d+ time\(s\)/', $output);
-        $this->assertRegExp('/\d+ unique value\(s\) total/', $output);
+        $this->assertMatchesRegularExpression('/Most common value occurs \d+ time\(s\)/', $output);
+        $this->assertMatchesRegularExpression('/Least common value occurs \d+ time\(s\)/', $output);
+        $this->assertMatchesRegularExpression('/\d+ unique value\(s\) total/', $output);
     }
 
     public function testKAnonymity()
@@ -144,7 +144,7 @@ class dlpLongRunningTest extends TestCase
             $quasiIds,
         ]);
         $this->assertStringContainsString('{"stringValue":"Female"}', $output);
-        $this->assertRegExp('/Class size: \d/', $output);
+        $this->assertMatchesRegularExpression('/Class size: \d/', $output);
     }
 
     public function testLDiversity()
@@ -163,7 +163,7 @@ class dlpLongRunningTest extends TestCase
             $quasiIds,
         ]);
         $this->assertStringContainsString('{"stringValue":"Female"}', $output);
-        $this->assertRegExp('/Class size: \d/', $output);
+        $this->assertMatchesRegularExpression('/Class size: \d/', $output);
         $this->assertStringContainsString('{"stringValue":"James"}', $output);
     }
 
@@ -184,8 +184,8 @@ class dlpLongRunningTest extends TestCase
             $quasiIds,
             $infoTypes,
         ]);
-        $this->assertRegExp('/Anonymity range: \[\d, \d\]/', $output);
-        $this->assertRegExp('/Size: \d/', $output);
+        $this->assertMatchesRegularExpression('/Anonymity range: \[\d, \d\]/', $output);
+        $this->assertMatchesRegularExpression('/Size: \d/', $output);
         $this->assertStringContainsString('{"stringValue":"Female"}', $output);
     }
 }

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -153,7 +153,7 @@ class dlpTest extends TestCase
             $wrappedKey,
             $surrogateType,
         ]);
-        $this->assertRegExp('/My SSN is SSN_TOKEN\(9\):\d+/', $deidOutput);
+        $this->assertMatchesRegularExpression('/My SSN is SSN_TOKEN\(9\):\d+/', $deidOutput);
 
         $reidOutput = $this->runFunctionSnippet('reidentify_fpe', [
             self::$projectId,
@@ -248,7 +248,7 @@ class dlpTest extends TestCase
             $filter,
         ]);
 
-        $this->assertRegExp($jobIdRegex, $output);
+        $this->assertMatchesRegularExpression($jobIdRegex, $output);
         preg_match($jobIdRegex, $output, $jobIds);
         $jobId = $jobIds[0];
 

--- a/language/test/quickstartTest.php
+++ b/language/test/quickstartTest.php
@@ -36,8 +36,8 @@ class quickstartTest extends TestCase
         // Invoke quickstart.php
         $output = $this->runSnippet($file);
 
-        $this->assertRegExp('/Text: Hello, world!/', $output);
-        $this->assertRegExp($p = '/Sentiment: (\\d.\\d+), (\\d.\\d+)/', $output);
+        $this->assertMatchesRegularExpression('/Text: Hello, world!/', $output);
+        $this->assertMatchesRegularExpression($p = '/Sentiment: (\\d.\\d+), (\\d.\\d+)/', $output);
 
         // Make sure it looks correct
         preg_match($p, $output, $matches);

--- a/logging/test/loggingTest.php
+++ b/logging/test/loggingTest.php
@@ -91,7 +91,7 @@ class loggingTest extends TestCase
         $logging = new LoggingClient(['projectId' => self::$projectId]);
         $sink = $logging->sink(self::$sinkName);
         $sink->reload();
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             sprintf(
                 '|projects/%s/logs/%s|',
                 self::$projectId,
@@ -119,7 +119,7 @@ class loggingTest extends TestCase
         $logging = new LoggingClient(['projectId' => self::$projectId]);
         $sink = $logging->sink(self::$sinkName);
         $sink->reload();
-        $this->assertRegExp('/severity >= INFO/', $sink->info()['filter']);
+        $this->assertMatchesRegularExpression('/severity >= INFO/', $sink->info()['filter']);
     }
 
     /**

--- a/media/transcoder/test/transcoderTest.php
+++ b/media/transcoder/test/transcoderTest.php
@@ -167,7 +167,7 @@ class transcoderTest extends TestCase
             self::$inputVideoUri,
             self::$outputUriForAdHoc
         ]);
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $createOutput);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $createOutput);
 
         $jobId = explode('/', $createOutput);
         $jobId = trim($jobId[(count($jobId) - 1)]);
@@ -209,7 +209,7 @@ class transcoderTest extends TestCase
             self::$preset
         ]);
 
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $output);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $output);
 
         $jobId = explode('/', $output);
         $jobId = trim($jobId[(count($jobId) - 1)]);
@@ -241,7 +241,7 @@ class transcoderTest extends TestCase
             $jobTemplateId
         ]);
 
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $output);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $output);
 
         $jobId = explode('/', $output);
         $jobId = trim($jobId[(count($jobId) - 1)]);
@@ -272,7 +272,7 @@ class transcoderTest extends TestCase
             self::$outputUriForAnimatedOverlay
         ]);
 
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $output);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $output);
 
         $jobId = explode('/', $output);
         $jobId = trim($jobId[(count($jobId) - 1)]);
@@ -297,7 +297,7 @@ class transcoderTest extends TestCase
             self::$outputUriForStaticOverlay
         ]);
 
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $output);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $output);
 
         $jobId = explode('/', $output);
         $jobId = trim($jobId[(count($jobId) - 1)]);
@@ -321,7 +321,7 @@ class transcoderTest extends TestCase
             self::$outputUriForPeriodicImagesSpritesheet
         ]);
 
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $output);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $output);
 
         $jobId = explode('/', $output);
         $jobId = trim($jobId[(count($jobId) - 1)]);
@@ -345,7 +345,7 @@ class transcoderTest extends TestCase
             self::$outputUriForSetNumberImagesSpritesheet
         ]);
 
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $output);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $output);
 
         $jobId = explode('/', $output);
         $jobId = trim($jobId[(count($jobId) - 1)]);
@@ -374,7 +374,7 @@ class transcoderTest extends TestCase
             self::$outputUriForConcat
         ]);
 
-        $this->assertRegExp(sprintf('%s', self::$jobIdRegex), $output);
+        $this->assertMatchesRegularExpression(sprintf('%s', self::$jobIdRegex), $output);
 
         $jobId = explode('/', $output);
         $jobId = trim($jobId[(count($jobId) - 1)]);

--- a/pubsub/api/test/pubsubTest.php
+++ b/pubsub/api/test/pubsubTest.php
@@ -133,7 +133,7 @@ class PubSubTest extends TestCase
         $output = $this->runFunctionSnippet('list_topics', [
             self::$projectId,
         ]);
-        $this->assertRegExp(sprintf('/%s/', $topic), $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
     }
 
     public function testCreateAndDeleteTopic()
@@ -144,16 +144,16 @@ class PubSubTest extends TestCase
             $topic,
         ]);
 
-        $this->assertRegExp('/Topic created:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $topic), $output);
+        $this->assertMatchesRegularExpression('/Topic created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
 
         $output = $this->runFunctionSnippet('delete_topic', [
             self::$projectId,
             $topic,
         ]);
 
-        $this->assertRegExp('/Topic deleted:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $topic), $output);
+        $this->assertMatchesRegularExpression('/Topic deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
     }
 
     public function testTopicMessage()
@@ -166,7 +166,7 @@ class PubSubTest extends TestCase
             'This is a test message',
         ]);
 
-        $this->assertRegExp('/Message published/', $output);
+        $this->assertMatchesRegularExpression('/Message published/', $output);
     }
 
     public function testTopicMessageWithRetrySettings()
@@ -179,7 +179,7 @@ class PubSubTest extends TestCase
             'This is a test message',
         ]);
 
-        $this->assertRegExp('/Message published with retry settings/', $output);
+        $this->assertMatchesRegularExpression('/Message published with retry settings/', $output);
     }
 
     public function testListSubscriptions()
@@ -190,7 +190,7 @@ class PubSubTest extends TestCase
             self::$projectId,
         ]);
 
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
     }
 
     public function testCreateAndDeleteSubscription()
@@ -203,16 +203,16 @@ class PubSubTest extends TestCase
             $subscription,
         ]);
 
-        $this->assertRegExp('/Subscription created:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
 
         $output = $this->runFunctionSnippet('delete_subscription', [
             self::$projectId,
             $subscription,
         ]);
 
-        $this->assertRegExp('/Subscription deleted:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
     }
 
     public function testCreateAndDeleteSubscriptionWithFilter()
@@ -271,16 +271,16 @@ class PubSubTest extends TestCase
             $fakeUrl,
         ]);
 
-        $this->assertRegExp('/Subscription created:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
 
         $output = $this->runFunctionSnippet('delete_subscription', [
             self::$projectId,
             $subscription,
         ]);
 
-        $this->assertRegExp('/Subscription deleted:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
     }
 
     public function testCreateAndDeleteBigQuerySubscription()
@@ -297,16 +297,16 @@ class PubSubTest extends TestCase
             $table,
         ]);
 
-        $this->assertRegExp('/Subscription created:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
 
         $output = $this->runFunctionSnippet('delete_subscription', [
             self::$projectId,
             $subscription,
         ]);
 
-        $this->assertRegExp('/Subscription deleted:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
     }
 
     public function testCreateAndDetachSubscription()
@@ -319,16 +319,16 @@ class PubSubTest extends TestCase
             $subscription,
         ]);
 
-        $this->assertRegExp('/Subscription created:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
 
         $output = $this->runFunctionSnippet('detach_subscription', [
             self::$projectId,
             $subscription,
         ]);
 
-        $this->assertRegExp('/Subscription detached:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription detached:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
 
         // delete test resource
         $output = $this->runFunctionSnippet('delete_subscription', [
@@ -336,8 +336,8 @@ class PubSubTest extends TestCase
             $subscription,
         ]);
 
-        $this->assertRegExp('/Subscription deleted:/', $output);
-        $this->assertRegExp(sprintf('/%s/', $subscription), $output);
+        $this->assertMatchesRegularExpression('/Subscription deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
     }
 
     public function testPullMessages()
@@ -351,14 +351,14 @@ class PubSubTest extends TestCase
             'This is a test message',
         ]);
 
-        $this->assertRegExp('/Message published/', $output);
+        $this->assertMatchesRegularExpression('/Message published/', $output);
 
         $this->runEventuallyConsistentTest(function () use ($subscription) {
             $output = $this->runFunctionSnippet('pull_messages', [
                 self::$projectId,
                 $subscription,
             ]);
-            $this->assertRegExp('/This is a test message/', $output);
+            $this->assertMatchesRegularExpression('/This is a test message/', $output);
         });
     }
 
@@ -379,7 +379,7 @@ class PubSubTest extends TestCase
             $messageData,
         ]);
 
-        $this->assertRegExp('/Messages enqueued for publication/', $output);
+        $this->assertMatchesRegularExpression('/Messages enqueued for publication/', $output);
 
         $this->runEventuallyConsistentTest(function () use ($subscription, $messageData) {
             $output = $this->runFunctionSnippet('pull_messages', [
@@ -421,7 +421,7 @@ class PubSubTest extends TestCase
 
             // There should be at least one acked message
             // pulled from the subscription.
-            $this->assertRegExp('/Acknowledged message:/', $output);
+            $this->assertMatchesRegularExpression('/Acknowledged message:/', $output);
         });
     }
 }

--- a/servicedirectory/README.md
+++ b/servicedirectory/README.md
@@ -55,7 +55,7 @@ PHP Fatal error:  Uncaught Error: Call to undefined function Google\Protobuf\Int
 You may need to install the bcmath PHP extension.
 e.g. (may depend on your php version)
 ```
-$ sudo apt-get install php7.4-bcmath
+$ sudo apt-get install php8.0-bcmath
 ```
 
 

--- a/servicedirectory/README.md
+++ b/servicedirectory/README.md
@@ -55,7 +55,7 @@ PHP Fatal error:  Uncaught Error: Call to undefined function Google\Protobuf\Int
 You may need to install the bcmath PHP extension.
 e.g. (may depend on your php version)
 ```
-$ sudo apt-get install php7.3-bcmath
+$ sudo apt-get install php7.4-bcmath
 ```
 
 

--- a/spanner/test/spannerBackupTest.php
+++ b/spanner/test/spannerBackupTest.php
@@ -180,7 +180,7 @@ class spannerBackupTest extends TestCase
         ]);
 
         $regex = '/Backup %s of size \d+ bytes was copied at (.+) from the source backup %s/';
-        $this->assertRegExp(sprintf($regex, $newBackupId, self::$backupId), $output);
+        $this->assertMatchesRegularExpression(sprintf($regex, $newBackupId, self::$backupId), $output);
     }
 
     /**

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -59,7 +59,7 @@ class storageTest extends TestCase
             self::$tempBucket->name(),
         ]);
 
-        $this->assertRegExp('/: OWNER/', $output);
+        $this->assertMatchesRegularExpression('/: OWNER/', $output);
     }
 
     public function testPrintDefaultBucketAcl()

--- a/storagetransfer/test/StorageTransferTest.php
+++ b/storagetransfer/test/StorageTransferTest.php
@@ -62,7 +62,7 @@ class StorageTransferTest extends TestCase
             self::$projectId, self::$sinkBucket->name(), self::$sourceBucket->name()
         ]);
 
-        $this->assertRegExp('/transferJobs\/.*/', $output);
+        $this->assertMatchesRegularExpression('/transferJobs\/.*/', $output);
 
         preg_match('/transferJobs\/\d+/', $output, $match);
         $jobName = $match[0];

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^7.4|^8.0"
+        "php": "^8.0"
     },
     "require-dev": {
         "bshaffer/phpunit-retry-annotations": "^0.3.0",

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -7,7 +7,7 @@
         "google/auth": "^1.12",
         "google/cloud-tools": "dev-main",
         "guzzlehttp/guzzle": "^7.0",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9.0",
         "friendsofphp/php-cs-fixer": "^3,<3.9",
         "composer/semver": "^3.2",
         "phpspec/prophecy-phpunit": "^2.0"

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -7,7 +7,7 @@
         "google/auth": "^1.12",
         "google/cloud-tools": "dev-main",
         "guzzlehttp/guzzle": "^7.0",
-        "phpunit/phpunit": "^7|^8,<8.5.27",
+        "phpunit/phpunit": "^8.5",
         "friendsofphp/php-cs-fixer": "^3,<3.9",
         "composer/semver": "^3.2"
     }

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -7,8 +7,9 @@
         "google/auth": "^1.12",
         "google/cloud-tools": "dev-main",
         "guzzlehttp/guzzle": "^7.0",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9",
         "friendsofphp/php-cs-fixer": "^3,<3.9",
-        "composer/semver": "^3.2"
+        "composer/semver": "^3.2",
+        "phpspec/prophecy-phpunit": "^2.0"
     }
 }

--- a/testing/composer.json
+++ b/testing/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^7.2|^7.3|^7.4|^8.0"
+        "php": "^7.4|^8.0"
     },
     "require-dev": {
         "bshaffer/phpunit-retry-annotations": "^0.3.0",


### PR DESCRIPTION
Dropping support for PHP 7.3 to be consistent with all Google PHP repositories.
As this is the samples repo and we are a bit more aggressive, we are dropping PHP 7.4 as well (since it's EOL)

 - upgrade to PHPUnit 9, add support for `prophecy-phpunit`
 - upgrade GAE runtimes to `php82`
 - upgrade appengine dir from `/srv` to `/workspace` for `php82`
 - fix failing tests (add retries to flakey tests, other misc fixes)

depends on cl/531237878

 