### PR TITLE
Added sample for DLP :  Inspect info types samples

### DIFF
--- a/dlp/src/inspect_augment_infotypes.php
+++ b/dlp/src/inspect_augment_infotypes.php
@@ -46,11 +46,13 @@ use Google\Cloud\Dlp\V2\Likelihood;
  *
  * @param string $projectId         The Google Cloud project id to use as a parent resource.
  * @param string $textToInspect     The string to inspect.
+ * @param array  $matchWordList     Specify the set of words to match.
  */
 function inspect_augment_infotypes(
     // TODO(developer): Replace sample parameters before running the code.
     string $projectId,
-    string $textToInspect = 'Smith and Quasimodo are good cricketer'
+    string $textToInspect = 'Smith and Quasimodo are good cricketer',
+    array  $matchWordList = ['quasimodo']
 ): void {
     // Instantiate a client.
     $dlp = new DlpServiceClient();
@@ -68,7 +70,7 @@ function inspect_augment_infotypes(
     // Construct the word list to be detected.
     $wordList = (new Dictionary())
         ->setWordList((new WordList())
-            ->setWords(['quasimodo']));
+            ->setWords($matchWordList));
 
     // Construct the custom infotype detector.
     $customInfoType = (new CustomInfoType())

--- a/dlp/src/inspect_augment_infotypes.php
+++ b/dlp/src/inspect_augment_infotypes.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+// [START dlp_inspect_augment_infotypes]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary;
+use Google\Cloud\Dlp\V2\CustomInfoType\Dictionary\WordList;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\Likelihood;
+
+/**
+ * Augment a built-in infotype detector.
+ * Consider a scenario in which a built-in infoType detector isn’t returning the correct values.
+ * For example, you want to return matches on person names, but Cloud DLP's built-in
+ * PERSON_NAME detector is failing to return matches on some person names that are common in your dataset.
+ * Cloud DLP allows you to augment built-in infoType detectors by including a built-in detector in the
+ * declaration for a custom infoType detector, as shown in the following example. This snippet
+ * illustrates how to configure Cloud DLP so that the PERSON_NAME built-in infoType detector will
+ * additionally match the name “Quasimodo:”.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ * @param string $textToInspect     The string to inspect.
+ */
+function inspect_augment_infotypes(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $projectId,
+    string $textToInspect = 'Smith and Quasimodo are good cricketer'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify what content you want the service to Inspect.
+    $item = (new ContentItem())
+        ->setValue($textToInspect);
+
+    // The infoTypes of information to match.
+    $personNameInfoType = (new InfoType())
+        ->setName('PERSON_NAME');
+
+    // Construct the word list to be detected.
+    $wordList = (new Dictionary())
+        ->setWordList((new WordList())
+            ->setWords(['quasimodo']));
+
+    // Construct the custom infotype detector.
+    $customInfoType = (new CustomInfoType())
+        ->setInfoType($personNameInfoType)
+        ->setLikelihood(Likelihood::POSSIBLE)
+        ->setDictionary($wordList);
+
+    // Construct the configuration for the Inspect request.
+    $inspectConfig = (new InspectConfig())
+        ->setCustomInfoTypes([$customInfoType])
+        ->setIncludeQuote(true);
+
+    // Run request.
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results.
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        printf('No findings.' . PHP_EOL);
+    } else {
+        printf('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            printf('  Quote: %s' . PHP_EOL, $finding->getQuote());
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
+        }
+    }
+}
+// [END dlp_inspect_augment_infotypes]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_column_values_w_custom_hotwords.php
+++ b/dlp/src/inspect_column_values_w_custom_hotwords.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+// [START dlp_inspect_column_values_w_custom_hotwords]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\CustomInfoType\DetectionRule\HotwordRule;
+use Google\Cloud\Dlp\V2\CustomInfoType\DetectionRule\LikelihoodAdjustment;
+use Google\Cloud\Dlp\V2\CustomInfoType\DetectionRule\Proximity;
+use Google\Cloud\Dlp\V2\CustomInfoType\Regex;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\InspectionRule;
+use Google\Cloud\Dlp\V2\InspectionRuleSet;
+use Google\Cloud\Dlp\V2\Likelihood;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\Value;
+
+/**
+ * Hotword example: Set the match likelihood of a table column.
+ * This example demonstrates how you can set the match likelihood of an entire column of data.
+ * This approach is helpful, for example, if you want to exclude a column of data from inspection
+ * results.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ */
+function inspect_column_values_w_custom_hotwords(string $projectId): void
+{
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify the table to be inspected.
+    $tableToDeIdentify = (new Table())
+        ->setHeaders([
+            (new FieldId())
+                ->setName('Fake Social Security Number'),
+            (new FieldId())
+                ->setName('Real Social Security Number'),
+        ])
+        ->setRows([
+            (new Row())->setValues([
+                (new Value())
+                    ->setStringValue('111-11-1111'),
+                (new Value())
+                    ->setStringValue('222-22-2222')
+            ])
+        ]);
+
+    $item = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Specify the regex pattern the inspection will look for.
+    $hotwordRegexPattern = 'Fake Social Security Number';
+
+    // Specify hotword likelihood adjustment.
+    $likelihoodAdjustment = (new LikelihoodAdjustment())
+        ->setFixedLikelihood(Likelihood::VERY_UNLIKELY);
+
+    // Specify a window around a finding to apply a detection rule.
+    $proximity = (new Proximity())
+        ->setWindowBefore(1);
+
+    // Construct the hotword rule.
+    $hotwordRule = (new HotwordRule())
+        ->setHotwordRegex((new Regex())
+            ->setPattern($hotwordRegexPattern))
+        ->setLikelihoodAdjustment($likelihoodAdjustment)
+        ->setProximity($proximity);
+
+    // Construct rule set for the inspect config.
+    $infotype = (new InfoType())
+        ->setName('US_SOCIAL_SECURITY_NUMBER');
+    $inspectionRuleSet = (new InspectionRuleSet())
+        ->setInfoTypes([$infotype])
+        ->setRules([
+            (new InspectionRule())
+                ->setHotwordRule($hotwordRule)
+        ]);
+
+    // Construct the configuration for the Inspect request.
+    $inspectConfig = (new InspectConfig())
+        ->setInfoTypes([$infotype])
+        ->setIncludeQuote(true)
+        ->setRuleSet([$inspectionRuleSet])
+        ->setMinLikelihood(Likelihood::POSSIBLE);
+
+    // Run request.
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results.
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        printf('No findings.' . PHP_EOL);
+    } else {
+        printf('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            printf('  Quote: %s' . PHP_EOL, $finding->getQuote());
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
+        }
+    }
+}
+// [END dlp_inspect_column_values_w_custom_hotwords]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_image_all_infotypes.php
+++ b/dlp/src/inspect_image_all_infotypes.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_inspect_image_all_infotypes]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\ByteContentItem;
+use Google\Cloud\Dlp\V2\ByteContentItem\BytesType;
+use Google\Cloud\Dlp\V2\Likelihood;
+
+/**
+ * Inspect image for sensitive data with infoTypes.
+ * To inspect an image for sensitive data, you submit a base64-encoded image to the Cloud DLP API's
+ * content.inspect method. Unless you specify information types (infoTypes) to search for, Cloud DLP
+ * searches for the most common infoTypes.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ * @param string $inputPath         The image path to inspect.
+ */
+function inspect_image_all_infotypes(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $projectId,
+    string $inputPath = './test/data/test.png'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    // Get the bytes of the file.
+    $fileBytes = (new ByteContentItem())
+        ->setType(BytesType::IMAGE_PNG)
+        ->setData(file_get_contents($inputPath));
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify what content you want the service to Inspect.
+    $item = (new ContentItem())
+        ->setByteItem($fileBytes);
+
+    // Run request.
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'item' => $item
+    ]);
+
+    // Print the results.
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        printf('No findings.' . PHP_EOL);
+    } else {
+        printf('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
+        }
+    }
+}
+
+# [END dlp_inspect_image_all_infotypes]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_image_listed_infotypes.php
+++ b/dlp/src/inspect_image_listed_infotypes.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+// [START dlp_inspect_image_listed_infotypes]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\ByteContentItem;
+use Google\Cloud\Dlp\V2\ByteContentItem\BytesType;
+use Google\Cloud\Dlp\V2\Likelihood;
+
+/**
+ * Inspect an image for sensitive data with listed infoTypes.
+ * If you want to inspect an image for only certain sensitive data types, specify their corresponding
+ * built-in infoTypes.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ * @param string $inputPath         The image path to inspect.
+ */
+function inspect_image_listed_infotypes(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $projectId,
+    string $inputPath = './test/data/test.png'
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    // Get the bytes of the file.
+    $fileBytes = (new ByteContentItem())
+        ->setType(BytesType::IMAGE_PNG)
+        ->setData(file_get_contents($inputPath));
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify what content you want the service to Inspect.
+    $item = (new ContentItem())
+        ->setByteItem($fileBytes);
+
+    // Create inspect config configuration.
+    $inspectConfig = (new InspectConfig())
+        // The infoTypes of information to match.
+        ->setInfoTypes([
+            (new InfoType())->setName('PHONE_NUMBER'),
+            (new InfoType())->setName('EMAIL_ADDRESS'),
+            (new InfoType())->setName('US_SOCIAL_SECURITY_NUMBER')
+        ]);
+
+    // Run request.
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results.
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        printf('No findings.' . PHP_EOL);
+    } else {
+        printf('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
+        }
+    }
+}
+
+// [END dlp_inspect_image_listed_infotypes]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_table.php
+++ b/dlp/src/inspect_table.php
@@ -71,9 +71,7 @@ function inspect_table(string $projectId): void
     $phoneNumber = (new InfoType())
         ->setName('PHONE_NUMBER');
     $inspectConfig = (new InspectConfig())
-        ->setInfoTypes([
-            $phoneNumber
-        ])
+        ->setInfoTypes([$phoneNumber])
         ->setIncludeQuote(true);
 
     // Run request.

--- a/dlp/src/inspect_table.php
+++ b/dlp/src/inspect_table.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/bigquery/api/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+// [START dlp_inspect_table]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\Likelihood;
+use Google\Cloud\Dlp\V2\Table;
+use Google\Cloud\Dlp\V2\Table\Row;
+use Google\Cloud\Dlp\V2\Value;
+
+/**
+ * Inspect a table for sensitive content.
+ *
+ * @param string $projectId         The Google Cloud project id to use as a parent resource.
+ */
+function inspect_table(string $projectId): void
+{
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$projectId/locations/global";
+
+    // Specify the table to be inspected.
+    $tableToDeIdentify = (new Table())
+        ->setHeaders([
+            (new FieldId())
+                ->setName('NAME'),
+            (new FieldId())
+                ->setName('PHONE'),
+        ])
+        ->setRows([
+            (new Row())->setValues([
+                (new Value())
+                    ->setStringValue('John Doe'),
+                (new Value())
+                    ->setStringValue('(206) 555-0123')
+            ])
+        ]);
+
+    $item = (new ContentItem())
+        ->setTable($tableToDeIdentify);
+
+    // Construct the configuration for the Inspect request.
+    $phoneNumber = (new InfoType())
+        ->setName('PHONE_NUMBER');
+    $inspectConfig = (new InspectConfig())
+        ->setInfoTypes([
+            $phoneNumber
+        ])
+        ->setIncludeQuote(true);
+
+    // Run request.
+    $response = $dlp->inspectContent([
+        'parent' => $parent,
+        'inspectConfig' => $inspectConfig,
+        'item' => $item
+    ]);
+
+    // Print the results.
+    $findings = $response->getResult()->getFindings();
+    if (count($findings) == 0) {
+        printf('No findings.' . PHP_EOL);
+    } else {
+        printf('Findings:' . PHP_EOL);
+        foreach ($findings as $finding) {
+            printf('  Quote: %s' . PHP_EOL, $finding->getQuote());
+            printf('  Info type: %s' . PHP_EOL, $finding->getInfoType()->getName());
+            printf('  Likelihood: %s' . PHP_EOL, Likelihood::name($finding->getLikelihood()));
+        }
+    }
+}
+// [END dlp_inspect_table]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -575,4 +575,66 @@ class dlpTest extends TestCase
         $this->assertEquals(3, count($csvLines_ouput));
         unlink($outputCsvFile);
     }
+
+    public function testInspectImageAllInfoTypes()
+    {
+        $output = $this->runFunctionSnippet('inspect_image_all_infotypes', [
+            self::$projectId,
+            __DIR__ . '/data/test.png'
+        ]);
+        $this->assertStringContainsString('Info type: PHONE_NUMBER', $output);
+        $this->assertStringContainsString('Info type: PERSON_NAME', $output);
+        $this->assertStringContainsString('Info type: EMAIL_ADDRESS', $output);
+    }
+
+    public function testInspectImageListedInfotypes()
+    {
+        $output = $this->runFunctionSnippet('inspect_image_listed_infotypes', [
+            self::$projectId,
+            __DIR__ . '/data/test.png'
+        ]);
+
+        $this->assertStringContainsString('Info type: EMAIL_ADDRESS', $output);
+        $this->assertStringContainsString('Info type: PHONE_NUMBER', $output);
+    }
+
+    public function testInspectAugmentInfotypes()
+    {
+        $output = $this->runFunctionSnippet('inspect_augment_infotypes', [
+            self::$projectId,
+            'Smith and Quasimodo'
+        ]);
+        $this->assertStringContainsString('Quote: Quasimodo', $output);
+        $this->assertStringContainsString('Info type: PERSON_NAME', $output);
+    }
+
+    public function testInspectAugmentInfotypesIgnore()
+    {
+        $output = $this->runFunctionSnippet('inspect_augment_infotypes', [
+            self::$projectId,
+            'My mobile number is 9545141023'
+        ]);
+        $this->assertStringContainsString('No findings.', $output);
+    }
+
+    public function testInspectColumnValuesWCustomHotwords()
+    {
+        $output = $this->runFunctionSnippet('inspect_column_values_w_custom_hotwords', [
+            self::$projectId,
+        ]);
+        $this->assertStringContainsString('Info type: US_SOCIAL_SECURITY_NUMBER', $output);
+        $this->assertStringContainsString('Likelihood: VERY_LIKELY', $output);
+        $this->assertStringContainsString('Quote: 222-22-2222', $output);
+    }
+
+    public function testInspectTable()
+    {
+        $output = $this->runFunctionSnippet('inspect_table', [
+            self::$projectId
+        ]);
+
+        $this->assertStringContainsString('Info type: PHONE_NUMBER', $output);
+        $this->assertStringContainsString('Quote: (206) 555-0123', $output);
+        $this->assertStringNotContainsString('Info type: PERSON_NAME', $output);
+    }
 }

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -600,9 +600,12 @@ class dlpTest extends TestCase
 
     public function testInspectAugmentInfotypes()
     {
+        $textToInspect = "The patient's name is Quasimodo";
+        $matchWordList = ['quasimodo'];
         $output = $this->runFunctionSnippet('inspect_augment_infotypes', [
             self::$projectId,
-            'Smith and Quasimodo'
+            $textToInspect,
+            $matchWordList
         ]);
         $this->assertStringContainsString('Quote: Quasimodo', $output);
         $this->assertStringContainsString('Info type: PERSON_NAME', $output);
@@ -610,9 +613,12 @@ class dlpTest extends TestCase
 
     public function testInspectAugmentInfotypesIgnore()
     {
+        $textToInspect = 'My mobile number is 9545141023';
+        $matchWordList = ['quasimodo'];
         $output = $this->runFunctionSnippet('inspect_augment_infotypes', [
             self::$projectId,
-            'My mobile number is 9545141023'
+            $textToInspect,
+            $matchWordList
         ]);
         $this->assertStringContainsString('No findings.', $output);
     }
@@ -625,6 +631,7 @@ class dlpTest extends TestCase
         $this->assertStringContainsString('Info type: US_SOCIAL_SECURITY_NUMBER', $output);
         $this->assertStringContainsString('Likelihood: VERY_LIKELY', $output);
         $this->assertStringContainsString('Quote: 222-22-2222', $output);
+        $this->assertStringNotContainsString('111-11-1111', $output);
     }
 
     public function testInspectTable()


### PR DESCRIPTION
Implemented below samples
1) [dlp_inspect_image_all_infotypes](https://cloud.google.com/dlp/docs/inspecting-images.md#dlp-inspect-image-all-infotypes-java)
2) [dlp_inspect_image_listed_infotypes](https://cloud.google.com/dlp/docs/samples/dlp-inspect-image-listed-infotypes)
3) [dlp_inspect_augment_infotypes](https://cloud.google.com/dlp/docs/creating-custom-infotypes-dictionary#augment_a_built-in_infotype_detector)
4) [dlp_inspect_column_values_w_custom_hotwords](https://cloud.google.com/dlp/docs/creating-custom-infotypes-likelihood.md#match-column-values)
5) [dlp_inspect_table](https://cloud.google.com/dlp/docs/inspecting-structured-text.md#dlp-inspect-table-java)

Added test cases for the same