### PR TITLE
chore: show composer install logs

### DIFF
--- a/bigtable/src/create_app_profile.php
+++ b/bigtable/src/create_app_profile.php
@@ -43,6 +43,7 @@ function create_app_profile(
     string $clusterId,
     string $appProfileId
 ): void {
+    $instanceAdminClient = 'Hello';
     $instanceAdminClient = new BigtableInstanceAdminClient();
     $instanceName = $instanceAdminClient->instanceName($projectId, $instanceId);
 

--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -172,7 +172,7 @@ do
     set +e
     if [ -f "composer.json" ]; then
         # install composer dependencies
-        composer -q install
+        composer install
     fi
     if [ $? != 0 ]; then
         # Generate the lock file (required for check-platform-reqs)


### PR DESCRIPTION
This PR is to inspect what versions of product libraries are getting installed while running system tests.