### PR TITLE
chore: phpunit migrate configuration

### DIFF
--- a/analyticsdata/phpunit.xml.dist
+++ b/analyticsdata/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google Analytics Data API Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google Analytics Data API Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/appengine/flexible/drupal8/phpunit.xml.dist
+++ b/appengine/flexible/drupal8/phpunit.xml.dist
@@ -14,19 +14,19 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Drupal deployment test">
-            <directory>test</directory>
-            <exclude>test/DeployTest.php</exclude>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./web</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./web</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Drupal deployment test">
+      <directory>test</directory>
+      <exclude>test/DeployTest.php</exclude>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/appengine/flexible/helloworld/phpunit.xml.dist
+++ b/appengine/flexible/helloworld/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="PHP Getting Started Test Suite">
-            <directory>test</directory>
-            <exclude>test/DeployTest.php</exclude>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./web</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./web</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Getting Started Test Suite">
+      <directory>test</directory>
+      <exclude>test/DeployTest.php</exclude>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/appengine/flexible/laravel/phpunit.xml.dist
+++ b/appengine/flexible/laravel/phpunit.xml.dist
@@ -14,19 +14,19 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Laravel deployment test">
-            <directory>test</directory>
-            <exclude>test/DeployTest.php</exclude>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Laravel deployment test">
+      <directory>test</directory>
+      <exclude>test/DeployTest.php</exclude>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/appengine/flexible/wordpress/phpunit.xml.dist
+++ b/appengine/flexible/wordpress/phpunit.xml.dist
@@ -14,22 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php" colors="true">
-    <testsuites>
-        <testsuite name="App Engine Flexible WordPress test">
-            <directory>test</directory>
-            <exclude>test/DeployTest.php</exclude>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
-     <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="App Engine Flexible WordPress test">
+      <directory>test</directory>
+      <exclude>test/DeployTest.php</exclude>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/appengine/standard/auth/phpunit.xml.dist
+++ b/appengine/standard/auth/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="AppEngine for PHP 7.2 auth test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="AppEngine for PHP 7.2 auth test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/appengine/standard/errorreporting/phpunit.xml.dist
+++ b/appengine/standard/errorreporting/phpunit.xml.dist
@@ -14,18 +14,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="App Engine for PHP 7.2 Error Reporting tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="App Engine for PHP 7.2 Error Reporting tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/appengine/standard/front-controller/phpunit.xml.dist
+++ b/appengine/standard/front-controller/phpunit.xml.dist
@@ -14,18 +14,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="App Engine for PHP 7.2 Front Controller tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="App Engine for PHP 7.2 Front Controller tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/appengine/standard/getting-started/phpunit.xml.dist
+++ b/appengine/standard/getting-started/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="App Engine PHP 7.2 Getting Started Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="App Engine PHP 7.2 Getting Started Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/appengine/standard/laravel-framework/phpunit.xml.dist
+++ b/appengine/standard/laravel-framework/phpunit.xml.dist
@@ -14,20 +14,20 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="AppEngine for PHP 7.2 Laravel Framework test">
-            <!-- This sample is BROKEN! See issue link below. -->
-            <!-- https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1349 -->
-            <!-- <directory>test</directory> -->
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="AppEngine for PHP 7.2 Laravel Framework test">
+      <!-- This sample is BROKEN! See issue link below. -->
+      <!-- https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1349 -->
+      <!-- <directory>test</directory> -->
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/appengine/standard/symfony-framework/phpunit.xml.dist
+++ b/appengine/standard/symfony-framework/phpunit.xml.dist
@@ -14,11 +14,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="AppEngine for PHP 7.2 Symfony Framework tests">
-            <directory>test</directory>
-            <exclude>./vendor</exclude>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage/>
+  <testsuites>
+    <testsuite name="AppEngine for PHP 7.2 Symfony Framework tests">
+      <directory>test</directory>
+      <exclude>./vendor</exclude>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/appengine/standard/tasks/snippets/phpunit.xml.dist
+++ b/appengine/standard/tasks/snippets/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Cloud Tasks test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Tasks test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/asset/phpunit.xml.dist
+++ b/asset/phpunit.xml.dist
@@ -11,24 +11,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP Cloud Asset test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Cloud Asset test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/auth/phpunit.xml.dist
+++ b/auth/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP auth test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP auth test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/bigquery/api/phpunit.xml.dist
+++ b/bigquery/api/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP bigquery test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP bigquery test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/bigtable/phpunit.xml.dist
+++ b/bigtable/phpunit.xml.dist
@@ -14,29 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="../testing/bootstrap.php"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         timeoutForSmallTests="10"
-         timeoutForMediumTests="30"
-         timeoutForLargeTests="120">
-    <testsuites>
-        <testsuite name="PHP Bigtable tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="./build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory>./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="../testing/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" timeoutForSmallTests="10" timeoutForMediumTests="30" timeoutForLargeTests="120" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory>./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="./build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Bigtable tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/cloud_sql/mysql/pdo/phpunit.xml.dist
+++ b/cloud_sql/mysql/pdo/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="../../../testing/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="CloudSQLMySQLSample">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/cloud_sql/postgres/pdo/phpunit.xml.dist
+++ b/cloud_sql/postgres/pdo/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="../../../testing/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="CloudSQLPostgresSample">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/cloud_sql/sqlserver/pdo/phpunit.xml.dist
+++ b/cloud_sql/sqlserver/pdo/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="../../../testing/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="../../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="CloudSQLSQLServerSample">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/compute/firewall/phpunit.xml.dist
+++ b/compute/firewall/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google Compute Cloud Client Instances Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google Compute Cloud Client Instances Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/compute/instances/phpunit.xml.dist
+++ b/compute/instances/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google Compute Cloud Client Instances Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google Compute Cloud Client Instances Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/datastore/api/phpunit.xml.dist
+++ b/datastore/api/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Datastore Cloud library Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Datastore Cloud library Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/datastore/tutorial/phpunit.xml.dist
+++ b/datastore/tutorial/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Cloud Datastore tutorial application tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Datastore tutorial application tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/dialogflow/phpunit.xml.dist
+++ b/dialogflow/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP dialogflow test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP dialogflow test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/dlp/phpunit.xml.dist
+++ b/dlp/phpunit.xml.dist
@@ -14,25 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php"
-  convertNoticesToExceptions="false">
-    <testsuites>
-        <testsuite name="PHP DLP test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" convertNoticesToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP DLP test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/eventarc/generic/phpunit.xml.dist
+++ b/eventarc/generic/phpunit.xml.dist
@@ -11,13 +11,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/vendor/autoload.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Eventarc generic tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/vendor/autoload.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Eventarc generic tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/firestore/phpunit.xml.dist
+++ b/firestore/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP firestore test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP firestore test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/functions/concepts_build_extension/phpunit.xml.dist
+++ b/functions/concepts_build_extension/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Build Step Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Build Step Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/concepts_filesystem/phpunit.xml.dist
+++ b/functions/concepts_filesystem/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions List Files Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions List Files Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/concepts_requests/phpunit.xml.dist
+++ b/functions/concepts_requests/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions HTTP Requests Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions HTTP Requests Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/env_vars/phpunit.xml.dist
+++ b/functions/env_vars/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Environment Variables Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Environment Variables Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/firebase_analytics/phpunit.xml.dist
+++ b/functions/firebase_analytics/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Firebase Remote Config Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Firebase Remote Config Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/firebase_auth/phpunit.xml.dist
+++ b/functions/firebase_auth/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Firebase Auth Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Firebase Auth Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/firebase_firestore/phpunit.xml.dist
+++ b/functions/firebase_firestore/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Firebase Firestore Test Suite">
-            <directory>test</directory>
-            <exclude>vendor</exclude>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Firebase Firestore Test Suite">
+      <directory>test</directory>
+      <exclude>vendor</exclude>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/firebase_firestore_reactive/phpunit.xml.dist
+++ b/functions/firebase_firestore_reactive/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Firebase Firestore Reactive Test Suite">
-            <directory>test</directory>
-            <exclude>vendor</exclude>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Firebase Firestore Reactive Test Suite">
+      <directory>test</directory>
+      <exclude>vendor</exclude>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/firebase_remote_config/phpunit.xml.dist
+++ b/functions/firebase_remote_config/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Firebase Remote Config Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Firebase Remote Config Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/firebase_rtdb/phpunit.xml.dist
+++ b/functions/firebase_rtdb/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Firebase RTDB Test Suite">
-            <directory>.</directory>
-            <exclude>vendor</exclude>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Firebase RTDB Test Suite">
+      <directory>.</directory>
+      <exclude>vendor</exclude>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/helloworld_get/phpunit.xml.dist
+++ b/functions/helloworld_get/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Hello World (Get) Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Hello World (Get) Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/helloworld_http/phpunit.xml.dist
+++ b/functions/helloworld_http/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Hello World HTTP Test Suite">
-            <directory>.</directory>
-            <exclude>vendor</exclude>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Hello World HTTP Test Suite">
+      <directory>.</directory>
+      <exclude>vendor</exclude>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/helloworld_log/phpunit.xml.dist
+++ b/functions/helloworld_log/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Logging Hello World Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Logging Hello World Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/helloworld_pubsub/phpunit.xml.dist
+++ b/functions/helloworld_pubsub/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Helloworld Pub/Sub Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Helloworld Pub/Sub Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/helloworld_storage/phpunit.xml.dist
+++ b/functions/helloworld_storage/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Hello Cloud Storage Test Suite">
-            <directory>.</directory>
-            <exclude>vendor</exclude>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Hello Cloud Storage Test Suite">
+      <directory>.</directory>
+      <exclude>vendor</exclude>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/http_content_type/phpunit.xml.dist
+++ b/functions/http_content_type/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Hello World HTTP Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Hello World HTTP Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/http_cors/phpunit.xml.dist
+++ b/functions/http_cors/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions HTTP CORS Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions HTTP CORS Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/http_form_data/phpunit.xml.dist
+++ b/functions/http_form_data/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions HTTP Form Data Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions HTTP Form Data Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/http_method/phpunit.xml.dist
+++ b/functions/http_method/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions HTTP Methods Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions HTTP Methods Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/imagemagick/phpunit.xml.dist
+++ b/functions/imagemagick/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions ImageMagick Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions ImageMagick Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/response_streaming/phpunit.xml.dist
+++ b/functions/response_streaming/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions HTTP Methods Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions HTTP Methods Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/slack_slash_command/phpunit.xml.dist
+++ b/functions/slack_slash_command/phpunit.xml.dist
@@ -14,18 +14,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Slack Slash Command Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Slack Slash Command Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/functions/tips_infinite_retries/phpunit.xml.dist
+++ b/functions/tips_infinite_retries/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Tips Avoid Infinite Retries Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Tips Avoid Infinite Retries Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/tips_phpinfo/phpunit.xml.dist
+++ b/functions/tips_phpinfo/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions phpinfo() Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions phpinfo() Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/tips_retry/phpunit.xml.dist
+++ b/functions/tips_retry/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Tips Retry Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Tips Retry Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/functions/tips_scopes/phpunit.xml.dist
+++ b/functions/tips_scopes/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Functions Scope Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Functions Scope Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/iap/phpunit.xml.dist
+++ b/iap/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP IAP Test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP IAP Test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/iot/phpunit.xml.dist
+++ b/iot/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP IOT test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP IOT test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/kms/phpunit.xml.dist
+++ b/kms/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google Cloud KMS API Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google Cloud KMS API Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/language/phpunit.xml.dist
+++ b/language/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP natural language test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP natural language test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/logging/phpunit.xml.dist
+++ b/logging/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Stackdriver Logging Cloud library Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Stackdriver Logging Cloud library Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/media/livestream/phpunit.xml.dist
+++ b/media/livestream/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP Live Stream API tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Live Stream API tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/media/transcoder/phpunit.xml.dist
+++ b/media/transcoder/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google Transcoder API Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google Transcoder API Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/media/videostitcher/phpunit.xml.dist
+++ b/media/videostitcher/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP Video Stitcher API tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Video Stitcher API tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/pubsub/api/phpunit.xml.dist
+++ b/pubsub/api/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP pubsub test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP pubsub test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/recaptcha/phpunit.xml.dist
+++ b/recaptcha/phpunit.xml.dist
@@ -14,23 +14,24 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="PHP reCAPTCHA test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <logging>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
-  </logging>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./src</directory>
-      <exclude>
-        <directory>./vendor</directory>
-      </exclude>
-    </whitelist>
-  </filter>
+  <logging/>
   <php>
     <env name="PHPUNIT_TESTS" value="1"/>
   </php>

--- a/run/helloworld/phpunit.xml.dist
+++ b/run/helloworld/phpunit.xml.dist
@@ -11,13 +11,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/vendor/autoload.php" convertWarningsToExceptions="false">
-    <testsuites>
-        <testsuite name="Cloud Run Hello World tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/vendor/autoload.php" convertWarningsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Run Hello World tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/secretmanager/phpunit.xml.dist
+++ b/secretmanager/phpunit.xml.dist
@@ -14,23 +14,24 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="PHP Secret Manager test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <logging>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
-  </logging>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./src</directory>
-      <exclude>
-        <directory>./vendor</directory>
-      </exclude>
-    </whitelist>
-  </filter>
+  <logging/>
   <php>
     <env name="PHPUNIT_TESTS" value="1"/>
   </php>

--- a/securitycenter/phpunit.xml.dist
+++ b/securitycenter/phpunit.xml.dist
@@ -14,29 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="../testing/bootstrap.php"
-    colors="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    timeoutForSmallTests="10"
-    timeoutForMediumTests="30"
-    timeoutForLargeTests="120">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="../testing/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" timeoutForSmallTests="10" timeoutForMediumTests="30" timeoutForLargeTests="120" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory>./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="./build/logs/clover.xml"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="PHP SecurityCenter tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <logging>
-    <log type="coverage-clover" target="./build/logs/clover.xml"/>
-  </logging>
-  <filter>
-    <whitelist addUncoveredFilesFromWhitelist="true">
-      <directory>./src</directory>
-      <exclude>
-        <directory>./vendor</directory>
-      </exclude>
-    </whitelist>
-  </filter>
+  <logging/>
 </phpunit>

--- a/servicedirectory/phpunit.xml.dist
+++ b/servicedirectory/phpunit.xml.dist
@@ -14,22 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php"
-  convertNoticesToExceptions="false">
-    <testsuites>
-        <testsuite name="PHP Service Directory test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" convertNoticesToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Service Directory test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/storage/phpunit.xml.dist
+++ b/storage/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP storage test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP storage test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/storagetransfer/phpunit.xml.dist
+++ b/storagetransfer/phpunit.xml.dist
@@ -1,21 +1,23 @@
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP storagetransfer test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP storagetransfer test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/tasks/phpunit.xml.dist
+++ b/tasks/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Cloud Tasks test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Tasks test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/translate/phpunit.xml.dist
+++ b/translate/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP translate test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP translate test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/video/phpunit.xml.dist
+++ b/video/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP Video Intelligence test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Video Intelligence test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/vision/phpunit.xml.dist
+++ b/vision/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP vision test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP vision test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>


### PR DESCRIPTION
PhpUnit throws the following error / suggestion, hence upgrading all it's configs by using `--migrate-configuration`:
```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

Here's the script to do this migration:

Command to migrate PhpUnit configs:
```
php-docs-samples > find * -name 'phpunit.xml*' -not -path '*vendor/*' | \
xargs -I {} bash -c "echo \"## Running for '{}'\" && testing/vendor/bin/phpunit  -c {} --migrate-configuration && git add {}"
```

Log from script run: https://paste.googleplex.com/5904304555687936