### PR TITLE
docs(scc-samples): update comments to add new parent resource types

### DIFF
--- a/securitycenter/src/create_notification.php
+++ b/securitycenter/src/create_notification.php
@@ -35,7 +35,11 @@ function create_notification(
     string $topicName
 ): void {
     $securityCenterClient = new SecurityCenterClient();
-    $organizationName = $securityCenterClient::organizationName($organizationId);
+    // 'parent' must be in one of the following formats:
+    //		"organizations/{orgId}"
+    //		"projects/{projectId}"
+    //		"folders/{folderId}"
+    $parent = $securityCenterClient::organizationName($organizationId);
     $pubsubTopic = $securityCenterClient::topicName($projectId, $topicName);
 
     $streamingConfig = (new StreamingConfig())->setFilter('state = "ACTIVE"');
@@ -45,7 +49,7 @@ function create_notification(
         ->setStreamingConfig($streamingConfig);
 
     $response = $securityCenterClient->createNotificationConfig(
-        $organizationName,
+        $parent,
         $notificationConfigId,
         $notificationConfig
     );

--- a/securitycenter/src/delete_notification.php
+++ b/securitycenter/src/delete_notification.php
@@ -28,6 +28,7 @@ function delete_notification(string $organizationId, string $notificationConfigI
 {
     $securityCenterClient = new SecurityCenterClient();
     $notificationConfigName = $securityCenterClient::notificationConfigName(
+        // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
         $organizationId,
         $notificationConfigId
     );

--- a/securitycenter/src/get_notification.php
+++ b/securitycenter/src/get_notification.php
@@ -28,6 +28,7 @@ function get_notification(string $organizationId, string $notificationConfigId):
 {
     $securityCenterClient = new SecurityCenterClient();
     $notificationConfigName = $securityCenterClient::notificationConfigName(
+        // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
         $organizationId,
         $notificationConfigId
     );

--- a/securitycenter/src/list_notification.php
+++ b/securitycenter/src/list_notification.php
@@ -26,9 +26,13 @@ use Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
 function list_notification(string $organizationId): void
 {
     $securityCenterClient = new SecurityCenterClient();
-    $organizationName = $securityCenterClient::organizationName($organizationId);
+    // 'parent' must be in one of the following formats:
+    //		"organizations/{orgId}"
+    //		"projects/{projectId}"
+    //		"folders/{folderId}"
+    $parent = $securityCenterClient::organizationName($organizationId);
 
-    foreach ($securityCenterClient->listNotificationConfigs($organizationName) as $element) {
+    foreach ($securityCenterClient->listNotificationConfigs($parent) as $element) {
         printf('Found notification config %s' . PHP_EOL, $element->getName());
     }
 

--- a/securitycenter/src/update_notification.php
+++ b/securitycenter/src/update_notification.php
@@ -40,6 +40,7 @@ function update_notification(
     // Ensure this ServiceAccount has the 'pubsub.topics.setIamPolicy' permission on the topic.
     // https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/setIamPolicy
     $pubsubTopic = $securityCenterClient::topicName($projectId, $topicName);
+    // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
     $notificationConfigName = $securityCenterClient::notificationConfigName($organizationId, $notificationConfigId);
 
     $streamingConfig = (new StreamingConfig())->setFilter('state = "ACTIVE"');


### PR DESCRIPTION
## Security Command Center Samples
Contains only comment updates to allow new parent types (b/263299056)