### PR TITLE
chore: upgrade videostitcher samples to new GAPIC

### DIFF
--- a/media/videostitcher/src/create_cdn_key.php
+++ b/media/videostitcher/src/create_cdn_key.php
@@ -25,8 +25,9 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_create_cdn_key]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
 use Google\Cloud\Video\Stitcher\V1\CdnKey;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\CreateCdnKeyRequest;
 use Google\Cloud\Video\Stitcher\V1\GoogleCdnKey;
 use Google\Cloud\Video\Stitcher\V1\MediaCdnKey;
 
@@ -75,7 +76,11 @@ function create_cdn_key(
     $cloudCdn->setPrivateKey($privateKey);
 
     // Run CDN key creation request
-    $operationResponse = $stitcherClient->createCdnKey($parent, $cdnKey, $cdnKeyId);
+    $request = (new CreateCdnKeyRequest())
+        ->setParent($parent)
+        ->setCdnKey($cdnKey)
+        ->setCdnKeyId($cdnKeyId);
+    $operationResponse = $stitcherClient->createCdnKey($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $result = $operationResponse->getResult();

--- a/media/videostitcher/src/create_cdn_key_akamai.php
+++ b/media/videostitcher/src/create_cdn_key_akamai.php
@@ -25,9 +25,10 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_create_cdn_key_akamai]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
-use Google\Cloud\Video\Stitcher\V1\CdnKey;
 use Google\Cloud\Video\Stitcher\V1\AkamaiCdnKey;
+use Google\Cloud\Video\Stitcher\V1\CdnKey;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\CreateCdnKeyRequest;
 
 /**
  * Creates an Akamai CDN key.
@@ -57,7 +58,11 @@ function create_cdn_key_akamai(
     $cdnKey->setAkamaiCdnKey($cloudCdn);
 
     // Run CDN key creation request
-    $operationResponse = $stitcherClient->createCdnKey($parent, $cdnKey, $cdnKeyId);
+    $request = (new CreateCdnKeyRequest())
+        ->setParent($parent)
+        ->setCdnKey($cdnKey)
+        ->setCdnKeyId($cdnKeyId);
+    $operationResponse = $stitcherClient->createCdnKey($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $result = $operationResponse->getResult();

--- a/media/videostitcher/src/create_live_config.php
+++ b/media/videostitcher/src/create_live_config.php
@@ -25,8 +25,9 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_create_live_config]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
 use Google\Cloud\Video\Stitcher\V1\AdTracking;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\CreateLiveConfigRequest;
 use Google\Cloud\Video\Stitcher\V1\LiveConfig;
 
 /**
@@ -66,7 +67,11 @@ function create_live_config(
         ->setDefaultSlate($defaultSlate);
 
     // Run live config creation request
-    $operationResponse = $stitcherClient->createLiveConfig($parent, $liveConfigId, $liveConfig);
+    $request = (new CreateLiveConfigRequest())
+        ->setParent($parent)
+        ->setLiveConfigId($liveConfigId)
+        ->setLiveConfig($liveConfig);
+    $operationResponse = $stitcherClient->createLiveConfig($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $result = $operationResponse->getResult();

--- a/media/videostitcher/src/create_live_session.php
+++ b/media/videostitcher/src/create_live_session.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_create_live_session]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\CreateLiveSessionRequest;
 use Google\Cloud\Video\Stitcher\V1\LiveSession;
 
 /**
@@ -51,7 +52,10 @@ function create_live_session(
     $liveSession->setLiveConfig($liveConfig);
 
     // Run live session creation request
-    $response = $stitcherClient->createLiveSession($parent, $liveSession);
+    $request = (new CreateLiveSessionRequest())
+        ->setParent($parent)
+        ->setLiveSession($liveSession);
+    $response = $stitcherClient->createLiveSession($request);
 
     // Print results
     printf('Live session: %s' . PHP_EOL, $response->getName());

--- a/media/videostitcher/src/create_slate.php
+++ b/media/videostitcher/src/create_slate.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_create_slate]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\CreateSlateRequest;
 use Google\Cloud\Video\Stitcher\V1\Slate;
 
 /**
@@ -50,7 +51,11 @@ function create_slate(
     $slate->setUri($slateUri);
 
     // Run slate creation request
-    $operationResponse = $stitcherClient->createSlate($parent, $slateId, $slate);
+    $request = (new CreateSlateRequest())
+        ->setParent($parent)
+        ->setSlateId($slateId)
+        ->setSlate($slate);
+    $operationResponse = $stitcherClient->createSlate($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $result = $operationResponse->getResult();

--- a/media/videostitcher/src/create_vod_session.php
+++ b/media/videostitcher/src/create_vod_session.php
@@ -25,8 +25,9 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_create_vod_session]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
 use Google\Cloud\Video\Stitcher\V1\AdTracking;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\CreateVodSessionRequest;
 use Google\Cloud\Video\Stitcher\V1\VodSession;
 
 /**
@@ -57,7 +58,10 @@ function create_vod_session(
     $vodSession->setAdTracking(AdTracking::SERVER);
 
     // Run VOD session creation request
-    $response = $stitcherClient->createVodSession($parent, $vodSession);
+    $request = (new CreateVodSessionRequest())
+        ->setParent($parent)
+        ->setVodSession($vodSession);
+    $response = $stitcherClient->createVodSession($request);
 
     // Print results
     printf('VOD session: %s' . PHP_EOL, $response->getName());

--- a/media/videostitcher/src/delete_cdn_key.php
+++ b/media/videostitcher/src/delete_cdn_key.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_delete_cdn_key]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\DeleteCdnKeyRequest;
 
 /**
  * Deletes a CDN key.
@@ -43,7 +44,9 @@ function delete_cdn_key(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->cdnKeyName($callingProjectId, $location, $cdnKeyId);
-    $operationResponse = $stitcherClient->deleteCdnKey($formattedName);
+    $request = (new DeleteCdnKeyRequest())
+        ->setName($formattedName);
+    $operationResponse = $stitcherClient->deleteCdnKey($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         // Print status

--- a/media/videostitcher/src/delete_live_config.php
+++ b/media/videostitcher/src/delete_live_config.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_delete_live_config]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\DeleteLiveConfigRequest;
 
 /**
  * Deletes a live config.
@@ -43,7 +44,9 @@ function delete_live_config(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->liveConfigName($callingProjectId, $location, $liveConfigId);
-    $operationResponse = $stitcherClient->deleteLiveConfig($formattedName);
+    $request = (new DeleteLiveConfigRequest())
+        ->setName($formattedName);
+    $operationResponse = $stitcherClient->deleteLiveConfig($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         // Print status

--- a/media/videostitcher/src/delete_slate.php
+++ b/media/videostitcher/src/delete_slate.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_delete_slate]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\DeleteSlateRequest;
 
 /**
  * Deletes a slate.
@@ -43,7 +44,9 @@ function delete_slate(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->slateName($callingProjectId, $location, $slateId);
-    $operationResponse = $stitcherClient->deleteSlate($formattedName);
+    $request = (new DeleteSlateRequest())
+        ->setName($formattedName);
+    $operationResponse = $stitcherClient->deleteSlate($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         // Print status

--- a/media/videostitcher/src/get_cdn_key.php
+++ b/media/videostitcher/src/get_cdn_key.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_cdn_key]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetCdnKeyRequest;
 
 /**
  * Gets a CDN key.
@@ -43,7 +44,9 @@ function get_cdn_key(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->cdnKeyName($callingProjectId, $location, $cdnKeyId);
-    $key = $stitcherClient->getCdnKey($formattedName);
+    $request = (new GetCdnKeyRequest())
+        ->setName($formattedName);
+    $key = $stitcherClient->getCdnKey($request);
 
     // Print results
     printf('CDN key: %s' . PHP_EOL, $key->getName());

--- a/media/videostitcher/src/get_live_ad_tag_detail.php
+++ b/media/videostitcher/src/get_live_ad_tag_detail.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_live_ad_tag_detail]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetLiveAdTagDetailRequest;
 
 /**
  * Gets the specified ad tag detail for the live session.
@@ -45,7 +46,9 @@ function get_live_ad_tag_detail(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->liveAdTagDetailName($callingProjectId, $location, $sessionId, $adTagDetailId);
-    $adTagDetail = $stitcherClient->getLiveAdTagDetail($formattedName);
+    $request = (new GetLiveAdTagDetailRequest())
+        ->setName($formattedName);
+    $adTagDetail = $stitcherClient->getLiveAdTagDetail($request);
 
     // Print results
     printf('Live ad tag detail: %s' . PHP_EOL, $adTagDetail->getName());

--- a/media/videostitcher/src/get_live_config.php
+++ b/media/videostitcher/src/get_live_config.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_live_config]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetLiveConfigRequest;
 
 /**
  * Gets a live config.
@@ -43,7 +44,9 @@ function get_live_config(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->liveConfigName($callingProjectId, $location, $liveConfigId);
-    $liveConfig = $stitcherClient->getLiveConfig($formattedName);
+    $request = (new GetLiveConfigRequest())
+        ->setName($formattedName);
+    $liveConfig = $stitcherClient->getLiveConfig($request);
 
     // Print results
     printf('Live config: %s' . PHP_EOL, $liveConfig->getName());

--- a/media/videostitcher/src/get_live_session.php
+++ b/media/videostitcher/src/get_live_session.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_live_session]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetLiveSessionRequest;
 
 /**
  * Gets a live session.
@@ -43,7 +44,9 @@ function get_live_session(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->liveSessionName($callingProjectId, $location, $sessionId);
-    $session = $stitcherClient->getLiveSession($formattedName);
+    $request = (new GetLiveSessionRequest())
+        ->setName($formattedName);
+    $session = $stitcherClient->getLiveSession($request);
 
     // Print results
     printf('Live session: %s' . PHP_EOL, $session->getName());

--- a/media/videostitcher/src/get_slate.php
+++ b/media/videostitcher/src/get_slate.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_slate]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetSlateRequest;
 
 /**
  * Gets a slate.
@@ -43,7 +44,9 @@ function get_slate(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->slateName($callingProjectId, $location, $slateId);
-    $slate = $stitcherClient->getSlate($formattedName);
+    $request = (new GetSlateRequest())
+        ->setName($formattedName);
+    $slate = $stitcherClient->getSlate($request);
 
     // Print results
     printf('Slate: %s' . PHP_EOL, $slate->getName());

--- a/media/videostitcher/src/get_vod_ad_tag_detail.php
+++ b/media/videostitcher/src/get_vod_ad_tag_detail.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_vod_ad_tag_detail]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetVodAdTagDetailRequest;
 
 /**
  * Gets the specified ad tag detail for the VOD session.
@@ -45,7 +46,9 @@ function get_vod_ad_tag_detail(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->vodAdTagDetailName($callingProjectId, $location, $sessionId, $adTagDetailId);
-    $adTagDetail = $stitcherClient->getVodAdTagDetail($formattedName);
+    $request = (new GetVodAdTagDetailRequest())
+        ->setName($formattedName);
+    $adTagDetail = $stitcherClient->getVodAdTagDetail($request);
 
     // Print results
     printf('VOD ad tag detail: %s' . PHP_EOL, $adTagDetail->getName());

--- a/media/videostitcher/src/get_vod_session.php
+++ b/media/videostitcher/src/get_vod_session.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_vod_session]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetVodSessionRequest;
 
 /**
  * Gets a VOD session.
@@ -43,7 +44,9 @@ function get_vod_session(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->vodSessionName($callingProjectId, $location, $sessionId);
-    $session = $stitcherClient->getVodSession($formattedName);
+    $request = (new GetVodSessionRequest())
+        ->setName($formattedName);
+    $session = $stitcherClient->getVodSession($request);
 
     // Print results
     printf('VOD session: %s' . PHP_EOL, $session->getName());

--- a/media/videostitcher/src/get_vod_stitch_detail.php
+++ b/media/videostitcher/src/get_vod_stitch_detail.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_get_vod_stitch_detail]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\GetVodStitchDetailRequest;
 
 /**
  * Gets the specified stitch detail for the VOD session.
@@ -45,7 +46,9 @@ function get_vod_stitch_detail(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->vodStitchDetailName($callingProjectId, $location, $sessionId, $stitchDetailId);
-    $stitchDetail = $stitcherClient->getVodStitchDetail($formattedName);
+    $request = (new GetVodStitchDetailRequest())
+        ->setName($formattedName);
+    $stitchDetail = $stitcherClient->getVodStitchDetail($request);
 
     // Print results
     printf('VOD stitch detail: %s' . PHP_EOL, $stitchDetail->getName());

--- a/media/videostitcher/src/list_cdn_keys.php
+++ b/media/videostitcher/src/list_cdn_keys.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_list_cdn_keys]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\ListCdnKeysRequest;
 
 /**
  * Lists all CDN keys for a location.
@@ -41,7 +42,9 @@ function list_cdn_keys(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $parent = $stitcherClient->locationName($callingProjectId, $location);
-    $response = $stitcherClient->listCdnKeys($parent);
+    $request = (new ListCdnKeysRequest())
+        ->setParent($parent);
+    $response = $stitcherClient->listCdnKeys($request);
 
     // Print the CDN key list.
     $cdn_keys = $response->iterateAllElements();

--- a/media/videostitcher/src/list_live_ad_tag_details.php
+++ b/media/videostitcher/src/list_live_ad_tag_details.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_list_live_ad_tag_details]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\ListLiveAdTagDetailsRequest;
 
 /**
  * Lists the ad tag details for the specified live session.
@@ -43,7 +44,9 @@ function list_live_ad_tag_details(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->liveSessionName($callingProjectId, $location, $sessionId);
-    $response = $stitcherClient->listLiveAdTagDetails($formattedName);
+    $request = (new ListLiveAdTagDetailsRequest())
+        ->setParent($formattedName);
+    $response = $stitcherClient->listLiveAdTagDetails($request);
 
     // Print the ad tag details list.
     $adTagDetails = $response->iterateAllElements();

--- a/media/videostitcher/src/list_live_configs.php
+++ b/media/videostitcher/src/list_live_configs.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_list_live_configs]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\ListLiveConfigsRequest;
 
 /**
  * Lists all live configs for a location.
@@ -41,7 +42,9 @@ function list_live_configs(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $parent = $stitcherClient->locationName($callingProjectId, $location);
-    $response = $stitcherClient->listLiveConfigs($parent);
+    $request = (new ListLiveConfigsRequest())
+        ->setParent($parent);
+    $response = $stitcherClient->listLiveConfigs($request);
 
     // Print the live config list.
     $liveConfigs = $response->iterateAllElements();

--- a/media/videostitcher/src/list_slates.php
+++ b/media/videostitcher/src/list_slates.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_list_slates]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\ListSlatesRequest;
 
 /**
  * Lists all slates for a location.
@@ -41,7 +42,9 @@ function list_slates(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $parent = $stitcherClient->locationName($callingProjectId, $location);
-    $response = $stitcherClient->listSlates($parent);
+    $request = (new ListSlatesRequest())
+        ->setParent($parent);
+    $response = $stitcherClient->listSlates($request);
 
     // Print the slate list.
     $slates = $response->iterateAllElements();

--- a/media/videostitcher/src/list_vod_ad_tag_details.php
+++ b/media/videostitcher/src/list_vod_ad_tag_details.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_list_vod_ad_tag_details]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\ListVodAdTagDetailsRequest;
 
 /**
  * Lists the ad tag details for the specified VOD session.
@@ -43,7 +44,9 @@ function list_vod_ad_tag_details(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->vodSessionName($callingProjectId, $location, $sessionId);
-    $response = $stitcherClient->listVodAdTagDetails($formattedName);
+    $request = (new ListVodAdTagDetailsRequest())
+        ->setParent($formattedName);
+    $response = $stitcherClient->listVodAdTagDetails($request);
 
     // Print the ad tag details list.
     $adTagDetails = $response->iterateAllElements();

--- a/media/videostitcher/src/list_vod_stitch_details.php
+++ b/media/videostitcher/src/list_vod_stitch_details.php
@@ -25,7 +25,8 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_list_vod_stitch_details]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\ListVodStitchDetailsRequest;
 
 /**
  * Lists the stitch details for the specified VOD session.
@@ -43,7 +44,9 @@ function list_vod_stitch_details(
     $stitcherClient = new VideoStitcherServiceClient();
 
     $formattedName = $stitcherClient->vodSessionName($callingProjectId, $location, $sessionId);
-    $response = $stitcherClient->listVodStitchDetails($formattedName);
+    $request = (new ListVodStitchDetailsRequest())
+        ->setParent($formattedName);
+    $response = $stitcherClient->listVodStitchDetails($request);
 
     // Print the stitch details list.
     $stitchDetails = $response->iterateAllElements();

--- a/media/videostitcher/src/update_cdn_key.php
+++ b/media/videostitcher/src/update_cdn_key.php
@@ -25,10 +25,11 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_update_cdn_key]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
 use Google\Cloud\Video\Stitcher\V1\CdnKey;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
 use Google\Cloud\Video\Stitcher\V1\GoogleCdnKey;
 use Google\Cloud\Video\Stitcher\V1\MediaCdnKey;
+use Google\Cloud\Video\Stitcher\V1\UpdateCdnKeyRequest;
 use Google\Protobuf\FieldMask;
 
 /**
@@ -84,7 +85,10 @@ function update_cdn_key(
     $cloudCdn->setPrivateKey($privateKey);
 
     // Run CDN key creation request
-    $operationResponse = $stitcherClient->updateCdnKey($cdnKey, $updateMask);
+    $request = (new UpdateCdnKeyRequest())
+        ->setCdnKey($cdnKey)
+        ->setUpdateMask($updateMask);
+    $operationResponse = $stitcherClient->updateCdnKey($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $result = $operationResponse->getResult();

--- a/media/videostitcher/src/update_cdn_key_akamai.php
+++ b/media/videostitcher/src/update_cdn_key_akamai.php
@@ -25,9 +25,10 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_update_cdn_key_akamai]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
-use Google\Cloud\Video\Stitcher\V1\CdnKey;
 use Google\Cloud\Video\Stitcher\V1\AkamaiCdnKey;
+use Google\Cloud\Video\Stitcher\V1\CdnKey;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\UpdateCdnKeyRequest;
 use Google\Protobuf\FieldMask;
 
 /**
@@ -63,7 +64,10 @@ function update_cdn_key_akamai(
     ]);
 
     // Run CDN key creation request
-    $operationResponse = $stitcherClient->updateCdnKey($cdnKey, $updateMask);
+    $request = (new UpdateCdnKeyRequest())
+        ->setCdnKey($cdnKey)
+        ->setUpdateMask($updateMask);
+    $operationResponse = $stitcherClient->updateCdnKey($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $result = $operationResponse->getResult();

--- a/media/videostitcher/src/update_slate.php
+++ b/media/videostitcher/src/update_slate.php
@@ -25,8 +25,9 @@
 namespace Google\Cloud\Samples\Media\Stitcher;
 
 // [START videostitcher_update_slate]
-use Google\Cloud\Video\Stitcher\V1\VideoStitcherServiceClient;
+use Google\Cloud\Video\Stitcher\V1\Client\VideoStitcherServiceClient;
 use Google\Cloud\Video\Stitcher\V1\Slate;
+use Google\Cloud\Video\Stitcher\V1\UpdateSlateRequest;
 use Google\Protobuf\FieldMask;
 
 /**
@@ -55,7 +56,10 @@ function update_slate(
     ]);
 
     // Run slate update request
-    $operationResponse = $stitcherClient->updateSlate($slate, $updateMask);
+    $request = (new UpdateSlateRequest())
+        ->setSlate($slate)
+        ->setUpdateMask($updateMask);
+    $operationResponse = $stitcherClient->updateSlate($request);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $result = $operationResponse->getResult();


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1865

Done using [bshaffer/google-cloud-new-surface-fixer](https://github.com/bshaffer/google-cloud-new-surface-fixer)

~~**NOTE**: The API broke backwards compatibility, so these tests are failing because the code needed to change significantly to get the samples to pass.~~ this has been fixed in https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1876