### PR TITLE
chore: upgrade errorreporting samples to new GAPIC

### DIFF
--- a/error_reporting/composer.json
+++ b/error_reporting/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/cloud-error-reporting": "^0.19.0"
+        "google/cloud-error-reporting": "^0.20.2"
     }
 }

--- a/error_reporting/src/report_error.php
+++ b/error_reporting/src/report_error.php
@@ -24,9 +24,10 @@
 namespace Google\Cloud\Samples\ErrorReporting;
 
 # [START report_error]
-use Google\Cloud\ErrorReporting\V1beta1\ReportErrorsServiceClient;
+use Google\Cloud\ErrorReporting\V1beta1\Client\ReportErrorsServiceClient;
 use Google\Cloud\ErrorReporting\V1beta1\ErrorContext;
 use Google\Cloud\ErrorReporting\V1beta1\ReportedErrorEvent;
+use Google\Cloud\ErrorReporting\V1beta1\ReportErrorEventRequest;
 use Google\Cloud\ErrorReporting\V1beta1\SourceLocation;
 
 /**
@@ -53,8 +54,11 @@ function report_error(string $projectId, string $message, string $user = '')
     $event = (new ReportedErrorEvent())
         ->setMessage($message)
         ->setContext($context);
+    $request = (new ReportErrorEventRequest())
+        ->setProjectName($projectName)
+        ->setEvent($event);
 
-    $errors->reportErrorEvent($projectName, $event);
+    $errors->reportErrorEvent($request);
     print('Reported an exception to Stackdriver' . PHP_EOL);
 }
 # [END report_error]


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1865

Done using [bshaffer/google-cloud-new-surface-fixer](https://github.com/bshaffer/google-cloud-new-surface-fixer)