### PR TITLE
chore: phpunit migrate configuration

### DIFF
--- a/bigquery/api/phpunit.xml.dist
+++ b/bigquery/api/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP bigquery test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP bigquery test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/bigquery/stackoverflow/phpunit.xml.dist
+++ b/bigquery/stackoverflow/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP BigQuery Shakespeare test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <file>shakespeare.php</file>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <file>shakespeare.php</file>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP BigQuery Shakespeare test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/bigtable/phpunit.xml.dist
+++ b/bigtable/phpunit.xml.dist
@@ -14,29 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="../testing/bootstrap.php"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         timeoutForSmallTests="10"
-         timeoutForMediumTests="30"
-         timeoutForLargeTests="120">
-    <testsuites>
-        <testsuite name="PHP Bigtable tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="./build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory>./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="../testing/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" timeoutForSmallTests="10" timeoutForMediumTests="30" timeoutForLargeTests="120" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory>./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="./build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Bigtable tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/datastore/api/phpunit.xml.dist
+++ b/datastore/api/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Datastore Cloud library Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Datastore Cloud library Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/datastore/quickstart/phpunit.xml.dist
+++ b/datastore/quickstart/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google Datastore Quickstart Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <file>quickstart.php</file>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <file>quickstart.php</file>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google Datastore Quickstart Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/datastore/tutorial/phpunit.xml.dist
+++ b/datastore/tutorial/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Cloud Datastore tutorial application tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cloud Datastore tutorial application tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/firestore/phpunit.xml.dist
+++ b/firestore/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP firestore test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP firestore test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/pubsub/api/phpunit.xml.dist
+++ b/pubsub/api/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP pubsub test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP pubsub test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/pubsub/app/phpunit.xml.dist
+++ b/pubsub/app/phpunit.xml.dist
@@ -14,22 +14,23 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP pubsub test">
-            <directory>test</directory>
-            <exclude>test/DeployAppEngineFlexTest.php</exclude>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <file>app.php</file>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <file>app.php</file>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP pubsub test">
+      <directory>test</directory>
+      <exclude>test/DeployAppEngineFlexTest.php</exclude>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/pubsub/quickstart/phpunit.xml.dist
+++ b/pubsub/quickstart/phpunit.xml.dist
@@ -14,21 +14,22 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google PubSub Quickstart Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <file>quickstart.php</file>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <file>quickstart.php</file>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google PubSub Quickstart Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/spanner/phpunit.xml.dist
+++ b/spanner/phpunit.xml.dist
@@ -14,25 +14,26 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="Google Spanner Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-            <file>quickstart.php</file>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+      <file>quickstart.php</file>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Google Spanner Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/storage/phpunit.xml.dist
+++ b/storage/phpunit.xml.dist
@@ -14,24 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP storage test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP storage test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>


### PR DESCRIPTION

<details>
<summary>Script ran to migrate configurations is below</summary>

```
#!/bin/bash

php_samples_path="$HOME/github/php-docs-samples/"
products=(
        "testing"
        "bigquery"
        "bigtable"
        "spanner"
        "firestore"
        "datastore"
        "storage"
        "pubsub"
    )
for phpunit_config in $(find * -name 'phpunit.xml*' -not -path '*vendor/*' );
do
    dir=$(dirname $phpunit_config)
    # echo -e "\n Checking => $dir\n " "${products[@]}"
    # echo "${dir%/%%/*}"
    if [[ "${products[@]}" != *"${dir%%/*}"* ]]; then
        # echo -e "\n Skiping => $dir\n"
        continue
    fi
    echo -e "\n RUNNING for => $phpunit_config\n"
    $php_samples_path/testing/vendor/bin/phpunit  -c $phpunit_config --migrate-configuration && git add "${phpunit_config}"
done
```
</details>

[Log file](https://paste.googleplex.com/5243033002967040) showing no failure

Context: https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1863 was giving failures when the phpunit configs were run. Hence, limiting the scope so that this work can be brought to concluson.
