### PR TITLE
feat(dlp): sample for  Hybrid Job Trigger , kAnonymity with entity id , and DeIdentify Replace InfoType

### DIFF
--- a/dlp/src/deidentify_replace_infotype.php
+++ b/dlp/src/deidentify_replace_infotype.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_deidentify_replace_infotype]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\InfoType;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations\InfoTypeTransformation;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\ReplaceWithInfoTypeConfig;
+
+/**
+ * De-identify sensitive data by replacing with infoType.
+ * Uses the Data Loss Prevention API to deidentify sensitive data in a string by replacing it with
+ * the info type.
+ *
+ * @param string $callingProjectId  The Google Cloud project id to use as a parent resource.
+ * @param string $string            The string to deidentify (will be treated as text).
+ */
+
+function deidentify_replace_infotype(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $string
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $parent = "projects/$callingProjectId/locations/global";
+
+    // Specify what content you want the service to de-identify.
+    $content = (new ContentItem())
+        ->setValue($string);
+
+    // The infoTypes of information to mask.
+    $phoneNumberinfoType = (new InfoType())
+        ->setName('PHONE_NUMBER');
+    $personNameinfoType = (new InfoType())
+        ->setName('PERSON_NAME');
+    $infoTypes = [$phoneNumberinfoType, $personNameinfoType];
+
+    // Create the configuration object.
+    $inspectConfig = (new InspectConfig())
+        ->setInfoTypes($infoTypes);
+
+    // Create the information transform configuration objects.
+    $primitiveTransformation = (new PrimitiveTransformation())
+        ->setReplaceWithInfoTypeConfig(new ReplaceWithInfoTypeConfig());
+
+    $infoTypeTransformation = (new InfoTypeTransformation())
+        ->setPrimitiveTransformation($primitiveTransformation);
+
+    $infoTypeTransformations = (new InfoTypeTransformations())
+        ->setTransformations([$infoTypeTransformation]);
+
+    // Create the deidentification configuration object.
+    $deidentifyConfig = (new DeidentifyConfig())
+        ->setInfoTypeTransformations($infoTypeTransformations);
+
+    // Run request.
+    $response = $dlp->deidentifyContent([
+        'parent' => $parent,
+        'deidentifyConfig' => $deidentifyConfig,
+        'item' => $content,
+        'inspectConfig' => $inspectConfig
+    ]);
+
+    // Print the results.
+    printf('Text after replace with infotype config: %s', $response->getItem()->getValue());
+}
+# [END dlp_deidentify_replace_infotype]
+
+// The following 2 lines are only needed to run the samples.
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/inspect_send_data_to_hybrid_job_trigger.php
+++ b/dlp/src/inspect_send_data_to_hybrid_job_trigger.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_inspect_send_data_to_hybrid_job_trigger]
+
+use Google\Cloud\Dlp\V2\Container;
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\ContentItem;
+use Google\Cloud\Dlp\V2\DlpJob\JobState;
+use Google\Cloud\Dlp\V2\HybridContentItem;
+use Google\Cloud\Dlp\V2\HybridFindingDetails;
+
+/**
+ * Inspect data hybrid job trigger.
+ * Send data to the hybrid job or hybrid job trigger.
+ *
+ * @param string $callingProjectId  The Google Cloud project id to use as a parent resource.
+ * @param string $string            The string to inspect (will be treated as text).
+ */
+
+function inspect_send_data_to_hybrid_job_trigger(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $jobTriggerId,
+    string $string
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+
+    $content = (new ContentItem())
+        ->setValue($string);
+
+    $container = (new Container())
+        ->setFullPath('10.0.0.2:logs1:app1')
+        ->setRelativePath('app1')
+        ->setRootPath('10.0.0.2:logs1')
+        ->setType('logging_sys')
+        ->setVersion('1.2');
+
+    $findingDetails = (new HybridFindingDetails())
+        ->setContainerDetails($container)
+        ->setLabels([
+            'env' => 'prod',
+            'appointment-bookings-comments' => ''
+        ]);
+
+    $hybridItem = (new HybridContentItem())
+        ->setItem($content)
+        ->setFindingDetails($findingDetails);
+
+    $parent = "projects/$callingProjectId/locations/global";
+    $name = "projects/$callingProjectId/locations/global/jobTriggers/" . $jobTriggerId;
+
+    $triggerJob = null;
+    try {
+        $triggerJob = $dlp->activateJobTrigger($name);
+    } catch (\Exception $e) {
+        $result = $dlp->listDlpJobs($parent, ['filter' => 'trigger_name=' . $name]);
+        foreach ($result as $job) {
+            $triggerJob = $job;
+        }
+    }
+
+    $dlp->hybridInspectJobTrigger($name, [
+        'hybridItem' => $hybridItem,
+    ]);
+
+    $numOfAttempts = 10;
+    do {
+        printf('Waiting for job to complete' . PHP_EOL);
+        sleep(10);
+        $job = $dlp->getDlpJob($triggerJob->getName());
+        if ($job->getState() != JobState::RUNNING) {
+            break;
+        }
+        $numOfAttempts--;
+    } while ($numOfAttempts > 0);
+
+    // Print finding counts.
+    printf('Job %s status: %s' . PHP_EOL, $job->getName(), JobState::name($job->getState()));
+    switch ($job->getState()) {
+        case JobState::DONE:
+            $infoTypeStats = $job->getInspectDetails()->getResult()->getInfoTypeStats();
+            if (count($infoTypeStats) === 0) {
+                printf('No findings.' . PHP_EOL);
+            } else {
+                foreach ($infoTypeStats as $infoTypeStat) {
+                    printf(
+                        '  Found %s instance(s) of infoType %s' . PHP_EOL,
+                        $infoTypeStat->getCount(),
+                        $infoTypeStat->getInfoType()->getName()
+                    );
+                }
+            }
+            break;
+        case JobState::FAILED:
+            printf('Job %s had errors:' . PHP_EOL, $job->getName());
+            $errors = $job->getErrors();
+            foreach ($errors as $error) {
+                var_dump($error->getDetails());
+            }
+            break;
+        case JobState::PENDING:
+            printf('Job has not completed. Consider a longer timeout or an asynchronous execution model' . PHP_EOL);
+            break;
+        default:
+            printf('Unexpected job state. Most likely, the job is either running or has not yet started.');
+    }
+}
+# [END dlp_inspect_send_data_to_hybrid_job_trigger]
+
+// The following 2 lines are only needed to run the samples.
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/src/k_anonymity_with_entity_id.php
+++ b/dlp/src/k_anonymity_with_entity_id.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the samples:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/dlp/README.md
+ */
+
+namespace Google\Cloud\Samples\Dlp;
+
+# [START dlp_k_anonymity_with_entity_id]
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+use Google\Cloud\Dlp\V2\RiskAnalysisJobConfig;
+use Google\Cloud\Dlp\V2\BigQueryTable;
+use Google\Cloud\Dlp\V2\DlpJob\JobState;
+use Google\Cloud\Dlp\V2\Action;
+use Google\Cloud\Dlp\V2\Action\PublishToPubSub;
+use Google\Cloud\Dlp\V2\EntityId;
+use Google\Cloud\Dlp\V2\PrivacyMetric\KAnonymityConfig;
+use Google\Cloud\Dlp\V2\PrivacyMetric;
+use Google\Cloud\Dlp\V2\FieldId;
+use Google\Cloud\PubSub\PubSubClient;
+
+/**
+ * Computes the k-anonymity of a column set in a Google BigQuery table with entity id.
+ *
+ * @param string    $callingProjectId  The project ID to run the API call under.
+ * @param string    $topicId           The name of the Pub/Sub topic to notify once the job completes.
+ * @param string    $subscriptionId    The name of the Pub/Sub subscription to use when listening for job.
+ * @param string    $datasetId         The ID of the dataset to inspect.
+ * @param string    $tableId           The ID of the table to inspect.
+ * @param string[]  $quasiIdNames      Array columns that form a composite key (quasi-identifiers).
+ */
+
+function k_anonymity_with_entity_id(
+    // TODO(developer): Replace sample parameters before running the code.
+    string $callingProjectId,
+    string $topicId,
+    string $subscriptionId,
+    string $datasetId,
+    string $tableId,
+    array  $quasiIdNames
+): void {
+    // Instantiate a client.
+    $dlp = new DlpServiceClient();
+    $pubsub = new PubSubClient();
+    $topic = $pubsub->topic($topicId);
+
+    // Create a list of FieldId objects based on the provided list of column names.
+    $quasiIds = array_map(
+        function ($id) {
+            return (new FieldId())
+                ->setName($id);
+        },
+        $quasiIdNames
+    );
+
+    // Specify the unique identifier in the source table for the k-anonymity analysis.
+    $statsConfig = (new KAnonymityConfig())
+        ->setEntityId((new EntityId())
+            ->setField((new FieldId())
+                ->setName('Name')))
+        ->setQuasiIds($quasiIds);
+
+    // Configure the privacy metric to compute for re-identification risk analysis.
+    $privacyMetric = (new PrivacyMetric())
+        ->setKAnonymityConfig($statsConfig);
+
+    // Specify the BigQuery table to analyze.
+    $bigqueryTable = (new BigQueryTable())
+        ->setProjectId($callingProjectId)
+        ->setDatasetId($datasetId)
+        ->setTableId($tableId);
+
+    // Create action to publish job status notifications over Google Cloud Pub/Sub.
+    $pubSubAction = (new PublishToPubSub())
+        ->setTopic($topic->name());
+
+    $action = (new Action())
+        ->setPubSub($pubSubAction);
+
+    // Construct risk analysis job config to run.
+    $riskJob = (new RiskAnalysisJobConfig())
+        ->setPrivacyMetric($privacyMetric)
+        ->setSourceTable($bigqueryTable)
+        ->setActions([$action]);
+
+    // Listen for job notifications via an existing topic/subscription.
+    $subscription = $topic->subscription($subscriptionId);
+
+    // Submit request.
+    $parent = "projects/$callingProjectId/locations/global";
+    $job = $dlp->createDlpJob($parent, [
+        'riskJob' => $riskJob
+    ]);
+
+    // Poll Pub/Sub using exponential backoff until job finishes.
+    // Consider using an asynchronous execution model such as Cloud Functions.
+    $attempt = 1;
+    $startTime = time();
+    do {
+        foreach ($subscription->pull() as $message) {
+            if (
+                isset($message->attributes()['DlpJobName']) &&
+                $message->attributes()['DlpJobName'] === $job->getName()
+            ) {
+                $subscription->acknowledge($message);
+                // Get the updated job. Loop to avoid race condition with DLP API.
+                do {
+                    $job = $dlp->getDlpJob($job->getName());
+                } while ($job->getState() == JobState::RUNNING);
+                break 2; // break from parent do while.
+            }
+        }
+        printf('Waiting for job to complete' . PHP_EOL);
+        // Exponential backoff with max delay of 60 seconds.
+        sleep(min(60, pow(2, ++$attempt)));
+    } while (time() - $startTime < 600); // 10 minute timeout.
+
+    // Print finding counts
+    printf('Job %s status: %s' . PHP_EOL, $job->getName(), JobState::name($job->getState()));
+    switch ($job->getState()) {
+        case JobState::DONE:
+            $histBuckets = $job->getRiskDetails()->getKAnonymityResult()->getEquivalenceClassHistogramBuckets();
+
+            foreach ($histBuckets as $bucketIndex => $histBucket) {
+                // Print bucket stats.
+                printf('Bucket %s:' . PHP_EOL, $bucketIndex);
+                printf(
+                    '  Bucket size range: [%s, %s]' . PHP_EOL,
+                    $histBucket->getEquivalenceClassSizeLowerBound(),
+                    $histBucket->getEquivalenceClassSizeUpperBound()
+                );
+
+                // Print bucket values.
+                foreach ($histBucket->getBucketValues() as $percent => $valueBucket) {
+                    // Pretty-print quasi-ID values.
+                    printf('  Quasi-ID values:' . PHP_EOL);
+                    foreach ($valueBucket->getQuasiIdsValues() as $index => $value) {
+                        print('    ' . $value->serializeToJsonString() . PHP_EOL);
+                    }
+                    printf(
+                        '  Class size: %s' . PHP_EOL,
+                        $valueBucket->getEquivalenceClassSize()
+                    );
+                }
+            }
+
+            break;
+        case JobState::FAILED:
+            printf('Job %s had errors:' . PHP_EOL, $job->getName());
+            $errors = $job->getErrors();
+            foreach ($errors as $error) {
+                var_dump($error->getDetails());
+            }
+            break;
+        case JobState::PENDING:
+            printf('Job has not completed. Consider a longer timeout or an asynchronous execution model' . PHP_EOL);
+            break;
+        default:
+            printf('Unexpected job state. Most likely, the job is either running or has not yet started.');
+    }
+}
+# [END dlp_k_anonymity_with_entity_id]
+
+// The following 2 lines are only needed to run the samples.
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/dlp/test/dlpTest.php
+++ b/dlp/test/dlpTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright 2016 Google Inc.
  *
@@ -30,6 +29,24 @@ use Google\Cloud\Dlp\V2\InfoType;
 use Google\Cloud\Dlp\V2\InfoTypeStats;
 use Google\Cloud\Dlp\V2\InspectDataSourceDetails;
 use Google\Cloud\Dlp\V2\InspectDataSourceDetails\Result;
+use Google\Cloud\Dlp\V2\AnalyzeDataSourceRiskDetails;
+use Google\Cloud\Dlp\V2\AnalyzeDataSourceRiskDetails\KAnonymityResult;
+use Google\Cloud\Dlp\V2\AnalyzeDataSourceRiskDetails\KAnonymityResult\KAnonymityEquivalenceClass;
+use Google\Cloud\Dlp\V2\AnalyzeDataSourceRiskDetails\KAnonymityResult\KAnonymityHistogramBucket;
+use Google\Cloud\Dlp\V2\Value;
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Topic;
+use Google\Cloud\PubSub\Subscription;
+use Google\Cloud\PubSub\Message;
+use Google\Cloud\Dlp\V2\HybridInspectResponse;
+use Google\Cloud\Dlp\V2\HybridOptions;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\InspectJobConfig;
+use Google\Cloud\Dlp\V2\JobTrigger;
+use Google\Cloud\Dlp\V2\JobTrigger\Status;
+use Google\Cloud\Dlp\V2\JobTrigger\Trigger;
+use Google\Cloud\Dlp\V2\Manual;
+use Google\Cloud\Dlp\V2\StorageConfig;
 
 /**
  * Unit Tests for dlp commands.
@@ -1081,5 +1098,269 @@ class dlpTest extends TestCase
         $this->assertStringContainsString('projects/' . self::$projectId . '/dlpJobs', $output);
         $this->assertStringContainsString('infoType PERSON_NAME', $output);
         $this->assertStringContainsString('infoType EMAIL_ADDRESS', $output);
+    }
+
+    public function testDeidentifyReplaceInfotype()
+    {
+
+        $inputString = 'Please call Steve Smith. His number is (555) 253-0000.';
+        $output = $this->runFunctionSnippet('deidentify_replace_infotype', [
+            self::$projectId,
+            $inputString
+        ]);
+        $this->assertStringContainsString('[PHONE_NUMBER]', $output);
+        $this->assertStringContainsString('[PERSON_NAME]', $output);
+    }
+
+    public function testKAnonymityWithEntityId()
+    {
+
+        $datasetId = $this->requireEnv('DLP_DATASET_ID');
+        $tableId = $this->requireEnv('DLP_TABLE_ID');
+
+        // Mock the necessary objects and methods
+        $dlpServiceClientMock = $this->prophesize(DlpServiceClient::class);
+
+        $createDlpJobResponse = (new DlpJob())
+            ->setName('projects/' . self::$projectId . '/dlpJobs/job-name-123')
+            ->setState(JobState::PENDING);
+
+        $getDlpJobResponse = (new DlpJob())
+            ->setName('projects/' . self::$projectId . '/dlpJobs/job-name-123')
+            ->setState(JobState::DONE)
+            ->setRiskDetails((new AnalyzeDataSourceRiskDetails())
+                    ->setKAnonymityResult((new KAnonymityResult())
+                            ->setEquivalenceClassHistogramBuckets([(new KAnonymityHistogramBucket())
+                                ->setEquivalenceClassSizeLowerBound(1)
+                                ->setEquivalenceClassSizeUpperBound(1)
+                                ->setBucketValues([
+                                    (new KAnonymityEquivalenceClass())
+                                        ->setQuasiIdsValues([(new Value())
+                                            ->setStringValue('{"stringValue":"[\"19\",\"8291 3627 8250 1234\"]"}')])
+                                        ->setEquivalenceClassSize(1),
+                                    (new KAnonymityEquivalenceClass())
+                                        ->setQuasiIdsValues([(new Value())
+                                            ->setStringValue('{"stringValue":"[\"27\",\"4231 5555 6781 9876\"]"}')])
+                                        ->setEquivalenceClassSize(1)
+
+                                ])])
+                    )
+            );
+
+        $dlpServiceClientMock->createDlpJob(Argument::any(), Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($createDlpJobResponse);
+
+        $dlpServiceClientMock->getDlpJob(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($getDlpJobResponse);
+
+        $pubsubObj = new PubSubClient();
+        $topic = $pubsubObj->createTopic('dlp-pubsub-topic-test');
+        $topicId = $topic->name();
+        $subscriptionId = 'dlp-subcription-test';
+        $subscription = $topic->subscription($subscriptionId);
+        $subscription->create();
+
+        $pubSubClientMock = $this->prophesize(PubSubClient::class);
+        $topicMock = $this->prophesize(Topic::class);
+        $subscriptionMock = $this->prophesize(Subscription::class);
+        $messageMock = $this->prophesize(Message::class);
+
+        // Set up the mock expectations for the Pub/Sub functions
+        $pubSubClientMock->topic($topicId)
+            ->shouldBeCalled()
+            ->willReturn($topicMock->reveal());
+
+        $topicMock->name()
+            ->shouldBeCalled()
+            ->willReturn('projects/' . self::$projectId . '/topics/' . $topicId);
+
+        $topicMock->subscription($subscriptionId)
+            ->shouldBeCalled()
+            ->willReturn($subscriptionMock->reveal());
+
+        $subscriptionMock->pull()
+            ->shouldBeCalled()
+            ->willReturn([$messageMock->reveal()]);
+
+        $messageMock->attributes()
+            ->shouldBeCalledTimes(2)
+            ->willReturn(['DlpJobName' => 'projects/' . self::$projectId . '/dlpJobs/job-name-123']);
+
+        $subscriptionMock->acknowledge(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($messageMock->reveal());
+
+        // Creating a temp file for testing.
+        $sampleFile = __DIR__ . '/../src/k_anonymity_with_entity_id.php';
+        $tmpFileName = basename($sampleFile, '.php') . '_temp';
+        $tmpFilePath = __DIR__ . '/../src/' . $tmpFileName . '.php';
+
+        $fileContent = file_get_contents($sampleFile);
+        $replacements = [
+            '$dlp = new DlpServiceClient();' => 'global $dlp;',
+            '$pubsub = new PubSubClient();' => 'global $pubsub;',
+            'k_anonymity_with_entity_id' => $tmpFileName
+        ];
+        $fileContent = strtr($fileContent, $replacements);
+        $tmpFile = file_put_contents(
+            $tmpFilePath,
+            $fileContent,
+        );
+        global $dlp;
+        global $pubsub;
+
+        $dlp = $dlpServiceClientMock->reveal();
+        $pubsub = $pubSubClientMock->reveal();
+
+        // Call the method under test
+        $output = $this->runFunctionSnippet($tmpFileName, [
+            self::$projectId,
+            $topicId,
+            $subscriptionId,
+            $datasetId,
+            $tableId,
+            ['Age', 'Mystery']
+        ]);
+        // delete topic , subscription , and temp file
+        $topic->delete();
+        $subscription->delete();
+        unlink($tmpFilePath);
+
+        // Assert the expected behavior or outcome
+        $this->assertStringContainsString('Job projects/' . self::$projectId . '/dlpJobs/', $output);
+        $this->assertStringContainsString('Bucket size range: [1, 1]', $output);
+    }
+
+    public function create_hybrid_job_trigger(string $triggerId, string $displayName, string $description): string
+    {
+        // Instantiate a client.
+        $dlp = new DlpServiceClient();
+
+        // Create the inspectConfig object.
+        $inspectConfig = (new InspectConfig())
+            ->setInfoTypes([
+                (new InfoType())
+                    ->setName('PERSON_NAME'),
+                (new InfoType())
+                    ->setName('PHONE_NUMBER')
+            ])
+            ->setIncludeQuote(true);
+
+        $storageConfig = (new StorageConfig())
+            ->setHybridOptions((new HybridOptions())
+                ->setRequiredFindingLabelKeys(
+                    ['appointment-bookings-comments']
+                )
+                ->setLabels([
+                    'env' => 'prod'
+                ]));
+
+        // Construct the insJobConfig object.
+        $inspectJobConfig = (new InspectJobConfig())
+            ->setInspectConfig($inspectConfig)
+            ->setStorageConfig($storageConfig);
+
+        // Create triggers
+        $triggerObject = (new Trigger())
+            ->setManual(new Manual());
+
+        // ----- Construct trigger object -----
+        $jobTriggerObject = (new JobTrigger())
+            ->setTriggers([$triggerObject])
+            ->setInspectJob($inspectJobConfig)
+            ->setStatus(Status::HEALTHY)
+            ->setDisplayName($displayName)
+            ->setDescription($description);
+
+        // Run trigger creation request
+        $parent = 'projects/' . self::$projectId . '/locations/global';
+        $trigger = $dlp->createJobTrigger($parent, $jobTriggerObject, [
+            'triggerId' => $triggerId
+        ]);
+
+        return $trigger->getName();
+    }
+
+    public function testInspectSendDataToHybridJobTrigger()
+    {
+        $displayName = uniqid('My trigger display name ');
+        $description = uniqid('My trigger description ');
+        $triggerId = uniqid('my-php-test-trigger-');
+        $string = 'My email is test@example.org';
+
+        $fullTriggerId = $this->create_hybrid_job_trigger(
+            $triggerId,
+            $displayName,
+            $description
+        );
+
+        // Mock the necessary objects and methods
+        $dlpServiceClientMock = $this->prophesize(DlpServiceClient::class);
+
+        $getDlpJobResponse = (new DlpJob())
+            ->setName('projects/' . self::$projectId . '/dlpJobs/i-3208317104051988812')
+            ->setState(JobState::DONE)
+            ->setInspectDetails((new InspectDataSourceDetails())
+                ->setResult((new Result())
+                    ->setInfoTypeStats([
+                        (new InfoTypeStats())
+                            ->setInfoType((new InfoType())->setName('PERSON_NAME'))
+                            ->setCount(13),
+                        (new InfoTypeStats())
+                            ->setInfoType((new InfoType())->setName('PHONE_NUMBER'))
+                            ->setCount(5)
+                    ])));
+
+        $dlpServiceClientMock
+            ->activateJobTrigger($fullTriggerId)
+            ->shouldBeCalled()
+            ->willReturn($getDlpJobResponse);
+
+        $dlpServiceClientMock
+            ->listDlpJobs(Argument::any(), Argument::type('array'))
+            ->willReturn([$getDlpJobResponse]);
+
+        $dlpServiceClientMock
+            ->hybridInspectJobTrigger(Argument::any(), Argument::type('array'))
+            ->shouldBeCalledTimes(1)
+            ->willReturn(new HybridInspectResponse());
+
+        $dlpServiceClientMock->getDlpJob(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($getDlpJobResponse);
+
+        // Creating a temp file for testing.
+        $sampleFile = __DIR__ . '/../src/inspect_send_data_to_hybrid_job_trigger.php';
+        $tmpFileName = basename($sampleFile, '.php') . '_temp';
+        $tmpFilePath = __DIR__ . '/../src/' . $tmpFileName . '.php';
+
+        $fileContent = file_get_contents($sampleFile);
+        $replacements = [
+            '$dlp = new DlpServiceClient();' => 'global $dlp;',
+            'inspect_send_data_to_hybrid_job_trigger' => $tmpFileName
+        ];
+        $fileContent = strtr($fileContent, $replacements);
+        $tmpFile = file_put_contents(
+            $tmpFilePath,
+            $fileContent
+        );
+        global $dlp;
+
+        $dlp = $dlpServiceClientMock->reveal();
+
+        $output = $this->runFunctionSnippet($tmpFileName, [
+            self::$projectId,
+            $triggerId,
+            $string
+        ]);
+
+        // delete a temp file.
+        unlink($tmpFilePath);
+
+        $this->assertStringContainsString('projects/' . self::$projectId . '/dlpJobs', $output);
+        $this->assertStringContainsString('infoType PERSON_NAME', $output);
+        $this->assertStringContainsString('infoType PHONE_NUMBER', $output);
     }
 }


### PR DESCRIPTION
Implemented below samples :
[1) dlp_k_anonymity_with_entity_id   ](https://cloud.google.com/dlp/docs/visualizing_re-id_risk.md?g=0&l=119#step_1_calculate_k-anonymity_on_the_dataset)
[2) dlp_inspect_send_data_to_hybrid_job_trigger](https://cloud.google.com/dlp/docs/how-to-hybrid-jobs#formatting)
[3) dlp_deidentify_replace_infotype](https://cloud.google.com/dlp/docs/samples/dlp-deidentify-replace-infotype)

Added test cases for the same