### PR TITLE
fix(Datastore): migrate insert sample to individual file

### DIFF
--- a/datastore/api/composer.json
+++ b/datastore/api/composer.json
@@ -1,11 +1,5 @@
 {
     "require": {
         "google/cloud-datastore": "^1.2"
-    },
-    "autoload": {
-        "psr-4": { "Google\\Cloud\\Samples\\Datastore\\": "src" },
-        "files": [
-            "src/functions/concepts.php"
-        ]
     }
 }

--- a/datastore/api/composer.json
+++ b/datastore/api/composer.json
@@ -1,5 +1,11 @@
 {
     "require": {
         "google/cloud-datastore": "^1.2"
+    },
+    "autoload": {
+        "psr-4": { "Google\\Cloud\\Samples\\Datastore\\": "src" },
+        "files": [
+            "src/functions/concepts.php"
+        ]
     }
 }

--- a/datastore/api/src/functions/concepts.php
+++ b/datastore/api/src/functions/concepts.php
@@ -78,27 +78,6 @@ function upsert(DatastoreClient $datastore)
 }
 
 /**
- * Create a Datastore entity and insert it. It will fail if there is already
- * an entity with the same key.
- *
- * @param DatastoreClient $datastore
- * @return Entity
- */
-function insert(DatastoreClient $datastore)
-{
-    // [START datastore_insert]
-    $task = $datastore->entity('Task', [
-        'category' => 'Personal',
-        'done' => false,
-        'priority' => 4,
-        'description' => 'Learn Cloud Datastore'
-    ]);
-    $datastore->insert($task);
-    // [END datastore_insert]
-    return $task;
-}
-
-/**
  * Look up a Datastore entity with the given key.
  *
  * @param DatastoreClient $datastore

--- a/datastore/api/src/insert.php
+++ b/datastore/api/src/insert.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Samples\Datastore;
+
+// [START datastore_insert]
+use Google\Cloud\Datastore\DatastoreClient;
+use Google\Cloud\Datastore\Entity;
+
+/**
+ * Create a Datastore entity and insert it. It will fail if there is already
+ * an entity with the same key.
+ *
+ * @param DatastoreClient $datastore
+ */
+function insert(DatastoreClient $datastore)
+{
+    $task = $datastore->entity('Task', [
+        'category' => 'Personal',
+        'done' => false,
+        'priority' => 4,
+        'description' => 'Learn Cloud Datastore'
+    ]);
+    $datastore->insert($task);
+    printf("Added Entity with description '%s'", $task['description']);
+}
+// [END datastore_insert]
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/datastore/api/test/ConceptsTest.php
+++ b/datastore/api/test/ConceptsTest.php
@@ -23,6 +23,7 @@ use Google\Cloud\Datastore\Entity;
 use Google\Cloud\Datastore\Query\GqlQuery;
 use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
+use Google\Cloud\TestUtils\TestTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -42,6 +43,7 @@ function generateRandomString($length = 10)
 class ConceptsTest extends TestCase
 {
     use EventuallyConsistentTestTrait;
+    use TestTrait;
 
     /* @var $hasCredentials boolean */
     protected static $hasCredentials;
@@ -98,14 +100,13 @@ class ConceptsTest extends TestCase
 
     public function testInsert()
     {
-        $task = insert(self::$datastore);
-        self::$keys[] = $task->key();
-        $task = self::$datastore->lookup($task->key());
-        $this->assertEquals('Personal', $task['category']);
-        $this->assertEquals(false, $task['done']);
-        $this->assertEquals(4, $task['priority']);
-        $this->assertEquals('Learn Cloud Datastore', $task['description']);
-        $this->assertArrayHasKey('id', $task->key()->pathEnd());
+        $output = $this->runFunctionSnippet('insert', [
+            self::$datastore
+        ]);
+        $this->assertStringContainsString(
+            sprintf("Added Entity with description '%s'", 'Learn Cloud Datastore'),
+            $output
+        );
     }
 
     public function testLookup()


### PR DESCRIPTION
This PR migrates a single Datstore sample to individual file format. 
ref: [b/138631070](http://b/138631070)

## Changes

1. __Removed autoload from `composer.json` to load new samples (existing tests will fail till then, so removed now to migrate samples one by one)__
2. Removed a particular sample from `/datastore/api/src/functions/concepts.php`
3. Added the sample (with license information & removing the return statements) to its own file `/datastore/api/src/<function_name>.php`
4. Added a print statement with an information specific to the sample, say some id, description string, etc
5. Modified the sample test function in `/datastore/api/test/ConceptsTest.php` to assert on the sample's print statement.


## Tests
1. Ensure we have a GCP with Datastore enabled.
2. Run tests:
```
➜  php-docs-samples git:(datastore_samples_migration) cd datastore/api                                                           
➜  api git:(datastore_samples_migration) ../../testing/vendor/bin/phpunit -c phpunit.xml.dist --filter="testInsert"                     
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

.                                                                   1 / 1 (100%)

Time: 00:00.309, Memory: 10.00 MB

OK (1 test, 1 assertion)
➜  api git:(datastore_samples_migration)
```
