### PR TITLE
fix: updates cloud run mc php nginx sample

### DIFF
--- a/run/multi-container/hello-php-nginx-sample/README.md
+++ b/run/multi-container/hello-php-nginx-sample/README.md
@@ -51,7 +51,7 @@ gcloud builds submit --tag=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/p
 
 4. Configure the service with the appropriate memory limit.
 
-You will see as you read through `service.yaml`, that the memory limit has been explicitly set to `320Mi`. This leaves ~128M for PHP processes after allocating 192M for opcache. 
+You will see as you read through `service.yaml`, that the memory limit has been explicitly set to `335M`. This leaves ~143M for PHP processes after allocating 192M for opcache. 
 See how we got [here](https://cloud.google.com/run/docs/configuring/services/memory-limits#optimizing) and read more about how to [optimize for concurrency](https://cloud.google.com/run/docs/tips/general#optimize_concurrency).
 
 **Note:** This sample does not contain extra configuration to tune php-fpm settings to specify the number of workers to correlate with the container concurrency.

--- a/run/multi-container/hello-php-nginx-sample/README.md
+++ b/run/multi-container/hello-php-nginx-sample/README.md
@@ -51,7 +51,7 @@ gcloud builds submit --tag=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/p
 
 4. Configure the service with the appropriate memory limit.
 
-You will see as you read through `service.yaml`, that the memory limit has been explicitly set to `320Mi` due to container concurrency of `1`. 
+You will see as you read through `service.yaml`, that the memory limit has been explicitly set to `320Mi`. This leaves ~128M for PHP processes after allocating 192M for opcache. 
 See how we got [here](https://cloud.google.com/run/docs/configuring/services/memory-limits#optimizing) and read more about how to [optimize for concurrency](https://cloud.google.com/run/docs/tips/general#optimize_concurrency).
 
 **Note:** This sample does not contain extra configuration to tune php-fpm settings to specify the number of workers to correlate with the container concurrency.

--- a/run/multi-container/hello-php-nginx-sample/README.md
+++ b/run/multi-container/hello-php-nginx-sample/README.md
@@ -51,9 +51,10 @@ gcloud builds submit --tag=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/p
 
 4. Configure the service with the appropriate memory limit.
 
-You will see as you read through `service.yaml`, that the memory limit has been explicitly
-set to `320Mi` due to container concurrency of `1` with a single `fpm` worker.
+You will see as you read through `service.yaml`, that the memory limit has been explicitly set to `320Mi` due to container concurrency of `1`. 
 See how we got [here](https://cloud.google.com/run/docs/configuring/services/memory-limits#optimizing) and read more about how to [optimize for concurrency](https://cloud.google.com/run/docs/tips/general#optimize_concurrency).
+
+**Note:** This sample does not contain extra configuration to tune php-fpm settings to specify the number of workers to correlate with the container concurrency.
 
 5. Deploy the multi-container service.
 

--- a/run/multi-container/hello-php-nginx-sample/php-app/Dockerfile
+++ b/run/multi-container/hello-php-nginx-sample/php-app/Dockerfile
@@ -22,14 +22,25 @@
 
 FROM php:8-fpm-alpine
 
-# Use the default production configuration
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-
-RUN docker-php-ext-install opcache
-
-# COPY php.ini /usr/local/etc/php
-COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+# Configure PHP for Cloud Run.
+# Precompile PHP code with opcache.
+RUN docker-php-ext-install -j "$(nproc)" opcache
+RUN set -ex; \
+  { \
+    echo "; Cloud Run enforces memory & timeouts"; \
+    echo "memory_limit = -1"; \
+    echo "; Configure Opcache for Containers"; \
+    echo "opcache.enable = 1"; \
+    echo "opcache.validate_timestamps = 0"; \
+    echo "opcache.memory_consumption = 192"; \
+    echo "opcache.max_accelerated_files = 10000"; \
+    echo "opcache.max_wasted_percentage = 10"; \
+    echo "opcache.interned_strings_buffer = 16";\
+  } > "$PHP_INI_DIR/conf.d/cloud-run.ini"
 
 COPY . /var/www/html/
+
+# Use the default production configuration
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # [END cloudrun_hello_mc_nginx_app_dockerfile]

--- a/run/multi-container/hello-php-nginx-sample/php-app/cloudrun.ini
+++ b/run/multi-container/hello-php-nginx-sample/php-app/cloudrun.ini
@@ -1,2 +1,0 @@
-; Configure Cloud Run memory
-memory_limit = -1

--- a/run/multi-container/hello-php-nginx-sample/php-app/cloudrun.ini
+++ b/run/multi-container/hello-php-nginx-sample/php-app/cloudrun.ini
@@ -1,0 +1,2 @@
+; Configure Cloud Run memory
+memory_limit = -1

--- a/run/multi-container/hello-php-nginx-sample/php-app/opcache.ini
+++ b/run/multi-container/hello-php-nginx-sample/php-app/opcache.ini
@@ -1,8 +1,0 @@
-; Configure Opcache for containers
-[opcache]
-opcache.enable=1
-opcache.validate_timestamps=0
-opcache.max_accelerated_files=10000
-opcache.memory_consumption=192
-opcache.max_wasted_percentage=10
-opcache.interned_strings_buffer=16

--- a/run/multi-container/hello-php-nginx-sample/php-app/opcache.ini
+++ b/run/multi-container/hello-php-nginx-sample/php-app/opcache.ini
@@ -1,6 +1,3 @@
-; Configure Cloud Run memory
-memory_limit = -1
-
 ; Configure Opcache for containers
 [opcache]
 opcache.enable=1

--- a/run/multi-container/hello-php-nginx-sample/service.yaml
+++ b/run/multi-container/hello-php-nginx-sample/service.yaml
@@ -43,7 +43,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 256M
         - name: hellophp
           image: "REGION-docker.pkg.dev/PROJECT_ID/REPO_NAME/php"
           env:
@@ -55,5 +55,5 @@ spec:
               # Explore more how to set memory limits in Cloud Run
               # https://cloud.google.com/run/docs/tips/general#optimize_concurrency
               # https://cloud.google.com/run/docs/configuring/services/memory-limits#optimizing
-              memory: 320Mi 
+              memory: 335M 
 # [END cloudrun_mc_hello_php_nginx_mc]


### PR DESCRIPTION
**Updates include:**
* Adding note in readme about lack of explicit settings defining php-fpm workers
* Add `opcache.ini` content into Dockerfile
* Swap from `Mi` memory unit to `M`