### PR TITLE
fix: update write log sample to setup severity

### DIFF
--- a/logging/src/write_log.php
+++ b/logging/src/write_log.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Samples\Logging;
 
 // [START logging_write_log_entry]
 use Google\Cloud\Logging\LoggingClient;
+use Google\Cloud\Logging\Logger;
 
 /** Write a log message via the Stackdriver Logging API.
  *
@@ -37,7 +38,9 @@ function write_log($projectId, $loggerName, $message)
             ]
         ]
     ]);
-    $entry = $logger->entry($message);
+    $entry = $logger->entry($message, [
+        'severity' => Logger::INFO
+    ]);
     $logger->write($entry);
     printf("Wrote a log to a logger '%s'." . PHP_EOL, $loggerName);
 }


### PR DESCRIPTION
Update the code sample for [write a log][1] to show how to explicitly add severity.

[1]: https://cloud.google.com/logging/docs/samples/logging-write-log-entry#logging_write_log_entry-php
