### PR TITLE
fix: refactor error reporting code sample

### DIFF
--- a/error_reporting/quickstart.php
+++ b/error_reporting/quickstart.php
@@ -11,7 +11,7 @@ use Google\Cloud\Core\Report\SimpleMetadataProvider;
 
 // These variables are set by the App Engine environment. To test locally,
 // ensure these are set or manually change their values.
-$projectId = getenv('GCLOUD_PROJECT') ?: 'YOUR_PROJECT_ID';
+$projectId = getenv('GOOGLE_CLOUD_PROJECT') ?: 'YOUR_PROJECT_ID';
 $service = getenv('GAE_SERVICE') ?: 'error_reporting_quickstart';
 $version = getenv('GAE_VERSION') ?: 'test';
 
@@ -30,5 +30,5 @@ $psrLogger = $logging->psrLogger('error-log', [
 Bootstrap::init($psrLogger);
 
 print('Throwing a test exception. You can view the message at https://console.cloud.google.com/errors.' . PHP_EOL);
-throw new Exception('quickstart.php test exception');
+throw new Exception('Something went wrong');
 # [END error_reporting_quickstart]

--- a/error_reporting/test/quickstartTest.php
+++ b/error_reporting/test/quickstartTest.php
@@ -49,6 +49,6 @@ class quickstartTest extends TestCase
 
         // Make sure it worked
         $this->assertStringContainsString('Throwing a test exception', $output);
-        $this->verifyReportedError(self::$projectId, 'quickstart.php test exception');
+        $this->verifyReportedError(self::$projectId, 'Something went wrong');
     }
 }


### PR DESCRIPTION
align code sample for error reporting with code in other languages (b/275730159):

- use the same error message across samples in all languages
- use correct env var for capturing project Id in the managed environment