### PR TITLE
fix: deprecate assertRegexp usage over assertMatchesRegularExpression

### DIFF
--- a/appengine/flexible/metadata/test/DeployTest.php
+++ b/appengine/flexible/metadata/test/DeployTest.php
@@ -31,7 +31,7 @@ class DeployTest extends TestCase
             '200',
             $resp->getStatusCode(),
             'Top page status code should be 200');
-        $this->assertRegExp('/External IP: .*/', (string) $resp->getBody());
+        $this->assertMatchesRegularExpression('/External IP: .*/', (string) $resp->getBody());
     }
 
     public function testCurl()
@@ -42,6 +42,6 @@ class DeployTest extends TestCase
             '200',
             $resp->getStatusCode(),
             '/curl status code should be 200');
-        $this->assertRegExp('/External IP: .*/', (string) $resp->getBody());
+        $this->assertMatchesRegularExpression('/External IP: .*/', (string) $resp->getBody());
     }
 }

--- a/monitoring/test/alertsTest.php
+++ b/monitoring/test/alertsTest.php
@@ -37,7 +37,7 @@ class alertsTest extends TestCase
         $output = $this->runFunctionSnippet('alert_create_policy', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertRegexp($regexp, $output);
+        $this->assertMatchesRegularExpression($regexp, $output);
 
         // Save the policy ID for later
         preg_match($regexp, $output, $matches);
@@ -93,7 +93,7 @@ class alertsTest extends TestCase
         $output = $this->runFunctionSnippet('alert_create_channel', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertRegexp($regexp, $output);
+        $this->assertMatchesRegularExpression($regexp, $output);
 
         // Save the channel ID for later
         preg_match($regexp, $output, $matches);
@@ -111,14 +111,14 @@ class alertsTest extends TestCase
         $output = $this->runFunctionSnippet('alert_create_channel', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertRegexp($regexp, $output);
+        $this->assertMatchesRegularExpression($regexp, $output);
         preg_match($regexp, $output, $matches);
         $channelId1 = $matches[1];
 
         $output = $this->runFunctionSnippet('alert_create_channel', [
             'projectId' => self::$projectId,
         ]);
-        $this->assertRegexp($regexp, $output);
+        $this->assertMatchesRegularExpression($regexp, $output);
         preg_match($regexp, $output, $matches);
         $channelId2 = $matches[1];
 

--- a/pubsub/api/test/pubsubTest.php
+++ b/pubsub/api/test/pubsubTest.php
@@ -433,14 +433,14 @@ class PubSubTest extends TestCase
             self::$projectId,
             $topic,
         ]);
-        $this->assertRegExp('/Message published/', $output);
+        $this->assertMatchesRegularExpression('/Message published/', $output);
 
         $output = $this->runFunctionSnippet('enable_subscription_ordering', [
             self::$projectId,
             $topic,
             'subscriberWithOrdering' . rand(),
         ]);
-        $this->assertRegExp('/Created subscription with ordering/', $output);
-        $this->assertRegExp('/\"enableMessageOrdering\":true/', $output);
+        $this->assertMatchesRegularExpression('/Created subscription with ordering/', $output);
+        $this->assertMatchesRegularExpression('/\"enableMessageOrdering\":true/', $output);
     }
 }

--- a/speech/test/speechTest.php
+++ b/speech/test/speechTest.php
@@ -85,7 +85,7 @@ class speechTest extends TestCase
 
         // Check for the word time offsets
         if (in_array($command, ['transcribe_async_words'])) {
-            $this->assertRegexp('/start: "*.*s", end: "*.*s/', $output);
+            $this->assertMatchesRegularExpression('/start: "*.*s", end: "*.*s/', $output);
         }
     }
 

--- a/storage/test/IamTest.php
+++ b/storage/test/IamTest.php
@@ -165,7 +165,7 @@ Members:(.*)
   %s
 
 /', self::$user);
-        $this->assertRegexp($binding, $output);
+        $this->assertMatchesRegularExpression($binding, $output);
 
         $bindingWithCondition = sprintf(
             'Role: roles/storage.objectViewer

--- a/vision/test/visionTest.php
+++ b/vision/test/visionTest.php
@@ -119,7 +119,7 @@ class visionTest extends TestCase
     {
         $path = __DIR__ . '/data/tower.jpg';
         $output = $this->runFunctionSnippet('detect_landmark', ['path' => $path]);
-        $this->assertRegexp(
+        $this->assertMatchesRegularExpression(
             '/Eiffel Tower|Champ de Mars|Trocadéro Gardens/',
             $output
         );
@@ -131,7 +131,7 @@ class visionTest extends TestCase
 
         $path = 'gs://' . $bucketName . '/vision/tower.jpg';
         $output = $this->runFunctionSnippet('detect_landmark_gcs', ['path' => $path]);
-        $this->assertRegexp(
+        $this->assertMatchesRegularExpression(
             '/Eiffel Tower|Champ de Mars|Trocadéro Gardens/',
             $output
         );


### PR DESCRIPTION
We are seeing warnings like below which will be fixed by this PR:
```
There was 1 warning:

1) Google\Cloud\Samples\PubSub\PubSubTest::testPublishAndSubscribeWithOrderingKeys
assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
```

ref: https://github.com/sebastianbergmann/phpunit/issues/4086