### PR TITLE
feat(Spanner): Add directed read samples

### DIFF
--- a/spanner/src/directed_read.php
+++ b/spanner/src/directed_read.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spanner/src/directed_read.php
+++ b/spanner/src/directed_read.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2023 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/spanner/README.md
+ */
+
+namespace Google\Cloud\Samples\Spanner;
+
+// [START spanner_directed_read]
+use Google\Cloud\Spanner\SpannerClient;
+use Google\Cloud\Spanner\V1\DirectedReadOptions\ReplicaSelection\Type as ReplicaType;
+
+/**
+ * Queries sample data from the database with directed read options.
+ * Example:
+ * ```
+ * directed_read($instanceId, $databaseId);
+ * ```
+ *
+ * @param string $instanceId The Spanner instance ID.
+ * @param string $databaseId The Spanner database ID.
+ */
+function directed_read(string $instanceId, string $databaseId): void
+{
+    $directedReadOptionsForClient = [
+        'directedReadOptions' => [
+            'excludeReplicas' => [
+                'replicaSelections' => [
+                    [
+                        'location' => 'us-east4'
+                    ]
+                ]
+            ]
+        ]
+    ];
+
+    $directedReadOptionsForRequest = [
+        'directedReadOptions' => [
+            'includeReplicas' => [
+                'replicaSelections' => [
+                    [
+                        'type' => ReplicaType::READ_WRITE
+                    ]
+                ],
+                'autoFailoverDisabled' => true
+            ]
+        ]
+    ];
+
+    $spanner = new SpannerClient($directedReadOptionsForClient);
+    $instance = $spanner->instance($instanceId);
+    $database = $instance->database($databaseId);
+    $snapshot = $database->snapshot();
+
+    // directedReadOptions at Request level will override the options set at
+    // Client level
+    $results = $snapshot->execute(
+        'SELECT SingerId, AlbumId, AlbumTitle FROM Albums',
+        $directedReadOptionsForRequest
+    );
+
+    foreach ($results as $row) {
+        printf('SingerId: %s, AlbumId: %s, AlbumTitle: %s' . PHP_EOL,
+            $row['SingerId'], $row['AlbumId'], $row['AlbumTitle']);
+    }
+}
+// [END spanner_directed_read]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/spanner/test/spannerTest.php
+++ b/spanner/test/spannerTest.php
@@ -1268,4 +1268,17 @@ class spannerTest extends TestCase
             $output
         );
     }
+
+    /**
+     * @depends testInsertData
+     */
+    public function testDirectedRead()
+    {
+        $output = $this->runFunctionSnippet('directed_read');
+        $this->assertStringContainsString('SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk', $output);
+        $this->assertStringContainsString('SingerId: 1, AlbumId: 2, AlbumTitle: Go, Go, Go', $output);
+        $this->assertStringContainsString('SingerId: 2, AlbumId: 1, AlbumTitle: Green', $output);
+        $this->assertStringContainsString('SingerId: 2, AlbumId: 2, AlbumTitle: Forever Hold Your Peace', $output);
+        $this->assertStringContainsString('SingerId: 2, AlbumId: 3, AlbumTitle: Terrified', $output);
+    }
 }


### PR DESCRIPTION
This is dependent on https://github.com/googleapis/google-cloud-php/pull/6078
Once the dependent PR merged, need to update the `composer.json` file to match the `google-cloud-php` latest version.