### PR TITLE
chore: migrate storage transfer phpunit config

### DIFF
--- a/storagetransfer/phpunit.xml.dist
+++ b/storagetransfer/phpunit.xml.dist
@@ -1,21 +1,23 @@
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP storagetransfer test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP storagetransfer test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>


### PR DESCRIPTION
Removes the following warning:

```
➜  storagetransfer git:(main) ✗ ../testing/vendor/bin/phpunit -c phpunit.xml.dist --filter="does_not_exist" 
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set
Warning:       Your XML configuration validates against a deprecated schema. <------ FIXES THIS WARNING ########
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

No tests executed!
➜  storagetransfer git:(main) ✗ ../testing/vendor/bin/phpunit -c phpunit.xml.dist --migrate-configuration   
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

Created backup:         /usr/local/google/home/vishwarajanand/github/php-docs-samples/storagetransfer/phpunit.xml.dist.bak
Migrated configuration: /usr/local/google/home/vishwarajanand/github/php-docs-samples/storagetransfer/phpunit.xml.dist
➜  storagetransfer git:(main) ✗ ../testing/vendor/bin/phpunit -c phpunit.xml.dist --filter="does_not_exist"
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

No tests executed!
➜  storagetransfer git:(main) ✗
```