### PR TITLE
feat(Storagecontrol): Adding new library sample

### DIFF
--- a/storagecontrol/README.md
+++ b/storagecontrol/README.md
@@ -1,0 +1,60 @@
+# Google Cloud Storage Control Samples
+
+## Description
+
+All code in the snippets directory demonstrate how to invoke
+[Cloud Storage Control][cloud-storagecontrol] from PHP.
+
+[cloud-storage-control]: https://cloud.google.com/storage/docs/access-control
+
+## Setup:
+
+1.  **Enable APIs** - [Enable the Storage Control Service API](https://console.cloud.google.com/flows/enableapi?apiid=storage.googleapis.com)
+    and create a new project or select an existing project.
+2.  **Download The Credentials** - Click "Go to credentials" after enabling the APIs. Click "New Credentials"
+    and select "Service Account Key". Create a new service account, use the JSON key type, and
+    select "Create". Once downloaded, set the environment variable `GOOGLE_APPLICATION_CREDENTIALS`
+    to the path of the JSON key that was downloaded.
+3.  **Clone the repo** and cd into this directory
+
+    ```sh
+    $ git clone https://github.com/GoogleCloudPlatform/php-docs-samples
+    $ cd php-docs-samples/storagecontrol
+    ```
+4.  **Install dependencies** via [Composer](http://getcomposer.org/doc/00-intro.md).
+    Run `php composer.phar install` (if composer is installed locally) or `composer install`
+    (if composer is installed globally).
+
+
+## Samples
+
+To run the Storage Control Quickstart Samples, run any of the files in `src/` on the CLI:
+
+```
+$ php src/quickstart.php
+
+Usage: quickstart.php $bucketName
+
+  @param string $bucketName The Storage bucket name
+```
+
+Above command returns the storage layout configuration for a given bucket.
+
+## The client library
+
+This sample uses the [Cloud Storage Control Client Library for PHP][google-cloud-php-storage-control].
+You can read the documentation for more details on API usage and use GitHub
+to [browse the source][google-cloud-php-source] and  [report issues][google-cloud-php-issues].
+
+[google-cloud-php-storage-control]: https://cloud.google.com/storage/docs/reference/rpc
+[google-cloud-php-source]: https://github.com/GoogleCloudPlatform/google-cloud-php
+[google-cloud-php-issues]: https://github.com/GoogleCloudPlatform/google-cloud-php/issues
+[google-cloud-sdk]: https://cloud.google.com/sdk/
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](../../LICENSE)

--- a/storagecontrol/composer.json
+++ b/storagecontrol/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "google/cloud-storage-control": "0.1.0"
+    },
+    "require-dev": {
+        "google/cloud-storage": "^1.41.3"
+    }
+}

--- a/storagecontrol/phpunit.xml.dist
+++ b/storagecontrol/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP storagecontrol test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
+</phpunit>

--- a/storagecontrol/src/quickstart.php
+++ b/storagecontrol/src/quickstart.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START storage_control_quickstart_sample]
+// Includes the autoloader for libraries installed with composer
+require __DIR__ . '/../vendor/autoload.php';
+
+// Imports the Google Cloud client library
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\GetStorageLayoutRequest;
+
+// Instantiates a client
+$storageControlClient = new StorageControlClient();
+
+// The name for the new bucket
+$bucketName = 'my-new-bucket';
+
+// Set project to "_" to signify global bucket
+$formattedName = $storageControlClient->storageLayoutName('_', $bucketName);
+$request = (new GetStorageLayoutRequest())->setName($formattedName);
+
+$response = $storageControlClient->getStorageLayout($request);
+
+echo 'Performed get_storage_layout request for ' . $response->getName() . PHP_EOL;
+// [END storage_control_quickstart_sample]
+return $response;

--- a/storagecontrol/test/quickstartTest.php
+++ b/storagecontrol/test/quickstartTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Google\Cloud\Storage\Control\V2\StorageLayout;
+use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+class quickstartTest extends TestCase
+{
+    use TestTrait;
+    private $bucket;
+    private $bucketName;
+    private $storageClient;
+
+    public function setUp(): void
+    {
+        $this->bucketName = sprintf(
+            '%s-%s',
+            $this->requireEnv('GOOGLE_STORAGE_BUCKET'),
+            time()
+        );
+        $this->storageClient = new StorageClient();
+        $this->bucket = $this->storageClient->createBucket($this->bucketName);
+    }
+
+    public function tearDown(): void
+    {
+        $this->bucket->delete();
+    }
+
+    public function testQuickstart()
+    {
+        $file = $this->prepareFile();
+        // Invoke quickstart.php
+        ob_start();
+        $response = include $file;
+        $output = ob_get_clean();
+
+        // Make sure it looks correct
+        $this->assertInstanceOf(StorageLayout::class, $response);
+        $this->assertEquals(
+            sprintf(
+                'Performed get_storage_layout request for projects/_/buckets/%s/storageLayout' . PHP_EOL,
+                $this->bucketName
+            ),
+            $output
+        );
+    }
+
+    private function prepareFile()
+    {
+        $file = sys_get_temp_dir() . '/storage_control_quickstart.php';
+        $contents = file_get_contents(__DIR__ . '/../src/quickstart.php');
+        $contents = str_replace(
+            ['my-new-bucket', '__DIR__'],
+            [$this->bucketName, sprintf('"%s"', __DIR__)],
+            $contents
+        );
+        file_put_contents($file, $contents);
+        return $file;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-php/issues/7243

Storagecontrol Library already created https://github.com/googleapis/google-cloud-php/pull/7245


Tests pass on prod:
```
➜  storagecontrol git:(feat_storage_control) ✗ ../testing/vendor/bin/phpunit -c phpunit.xml.dist
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

.                                                                   1 / 1 (100%)

Time: 00:03.340, Memory: 10.00 MB

OK (1 test, 2 assertions)
➜  storagecontrol git:(feat_storage_control) ✗
```
