### PR TITLE
chore(tests): check both "test" and "tests" dirs

### DIFF
--- a/testing/run_test_suite.sh
+++ b/testing/run_test_suite.sh
@@ -160,7 +160,7 @@ do
         continue
     fi
     if [ "$RUN_DEPLOYMENT_TESTS" != "true" ] &&
-       [[ -z $(find $DIR/test/ -type f -name *Test.php -not -name Deploy*Test.php) ]]; then
+       [[ -z $(find $DIR/test{,s}/ -type f -name *Test.php -not -name Deploy*Test.php 2>/dev/null) ]]; then
         echo "Skipping tests in $DIR (Deployment tests only)"
         continue
     fi


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1932 by checking to see if deployment tests exist in either `test` or `tests`