### PR TITLE
feat(storage): Add samples for HNS

### DIFF
--- a/storage/src/create_bucket_hierarchical_namespace.php
+++ b/storage/src/create_bucket_hierarchical_namespace.php
@@ -40,7 +40,7 @@ function create_bucket_hierarchical_namespace(string $bucketName): void
         'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]
     ]);
 
-    printf("Created bucket %s with Hierarchical Namespace enabled.", $bucket->name());
+    printf('Created bucket %s with Hierarchical Namespace enabled.', $bucket->name());
 }
 # [END storage_create_bucket_hierarchical_namespace]
 

--- a/storage/src/create_bucket_hierarchical_namespace.php
+++ b/storage/src/create_bucket_hierarchical_namespace.php
@@ -36,7 +36,7 @@ function create_bucket_hierarchical_namespace(string $bucketName): void
 {
     $storage = new StorageClient();
     $bucket = $storage->createBucket($bucketName, [
-        'hierarchicalNamespace' => ['enabled' => true,],
+        'hierarchicalNamespace' => ['enabled' => true],
         'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]
     ]);
 

--- a/storage/src/create_bucket_hierarchical_namespace.php
+++ b/storage/src/create_bucket_hierarchical_namespace.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_create_bucket_hierarchical_namespace]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Create a new bucket with Hierarchical Namespace enabled.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function create_bucket_hierarchical_namespace(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->createBucket($bucketName, [
+        'hierarchicalNamespace' => ['enabled' => true,],
+        'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]
+    ]);
+
+    printf("Created bucket %s with Hierarchical Namespace enabled.", $bucket->name());
+}
+# [END storage_create_bucket_hierarchical_namespace]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -840,6 +840,28 @@ class storageTest extends TestCase
         $this->assertContains($region2, $info['customPlacementConfig']['dataLocations']);
     }
 
+    public function testCreateBucketHnsEnabled()
+    {
+        $bucketName = uniqid('samples-create-hierarchical-namespace-enabled-');
+        $output = self::runFunctionSnippet('create_bucket_hierarchical_namespace', [
+            $bucketName,
+        ]);
+
+        $bucket = self::$storage->bucket($bucketName);
+        $info = $bucket->reload();
+        $exists = $bucket->exists();
+
+        $this->assertTrue($exists);
+        $this->assertEquals(
+            sprintf(
+                'Created bucket %s with Hierarchical Namespace enabled.',
+                $bucketName,
+            ),
+            $output
+        );
+        $this->assertTrue($info['hierarchicalNamespace']['enabled']);
+    }
+
     public function testObjectCsekToCmek()
     {
         $objectName = uniqid('samples-object-csek-to-cmek-');


### PR DESCRIPTION
Added sample for HNS:

```
➜  storage git:(main) ✗ ../testing/vendor/bin/phpunit -c phpunit.xml.dist --filter="::testCreateBucketHnsEnabled"
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

.                                                                   1 / 1 (100%)

Time: 00:11.752, Memory: 12.00 MB

OK (1 test, 3 assertions)
➜  storage git:(main) ✗ 
```

partially addresses https://github.com/googleapis/google-cloud-php/issues/7357