### PR TITLE
feat(storagecontrol): add HNS folders samples

### DIFF
--- a/storagecontrol/src/create_folder.php
+++ b/storagecontrol/src/create_folder.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_create_folder]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\CreateFolderRequest;
+
+/**
+ * Create a new folder in an existing bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $folderName The name of your folder inside the bucket.
+ *        (e.g. 'my-folder')
+ */
+function create_folder(string $bucketName, string $folderName): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->bucketName('_', $bucketName);
+
+    $request = new CreateFolderRequest([
+        'parent' => $formattedName,
+        'folder_id' => $folderName,
+    ]);
+
+    $folder = $storageControlClient->createFolder($request);
+
+    printf('Created folder: %s', $folder->getName());
+}
+# [END storage_control_create_folder]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/delete_folder.php
+++ b/storagecontrol/src/delete_folder.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_delete_folder]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\DeleteFolderRequest;
+
+/**
+ * Delete a folder in an existing bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $folderName The name of your folder inside the bucket.
+ *        (e.g. 'my-folder')
+ */
+function delete_folder(string $bucketName, string $folderName): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->folderName('_', $bucketName, $folderName);
+
+    $request = new DeleteFolderRequest([
+        'name' => $formattedName,
+    ]);
+
+    $storageControlClient->deleteFolder($request);
+
+    printf('Deleted folder: %s', $folderName);
+}
+# [END storage_control_delete_folder]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/get_folder.php
+++ b/storagecontrol/src/get_folder.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_get_folder]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\GetFolderRequest;
+
+/**
+ * Get a folder in an existing bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $folderName The name of your folder inside the bucket.
+ *        (e.g. 'my-folder')
+ */
+function get_folder(string $bucketName, string $folderName): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->folderName('_', $bucketName, $folderName);
+
+    $request = new GetFolderRequest([
+        'name' => $formattedName,
+    ]);
+
+    $folder = $storageControlClient->getFolder($request);
+
+    printf($folder->getName());
+}
+# [END storage_control_get_folder]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/list_folders.php
+++ b/storagecontrol/src/list_folders.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_list_folders]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\ListFoldersRequest;
+
+/**
+ * List folders in an existing bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function list_folders(string $bucketName): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->bucketName('_', $bucketName);
+
+    $request = new ListFoldersRequest([
+        'parent' => $formattedName,
+    ]);
+
+    $folders = $storageControlClient->listFolders($request);
+
+    foreach ($folders as $folder) {
+        printf('Folder name: %s' . PHP_EOL, $folder->getName());
+    }
+}
+# [END storage_control_list_folders]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/rename_folder.php
+++ b/storagecontrol/src/rename_folder.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_rename_folder]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\RenameFolderRequest;
+
+/**
+ * Rename a folder in an existing bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $sourceFolder The source folder ID.
+ *        (e.g. 'my-folder')
+ * @param string $destinationFolder The destination folder ID.
+ *        (e.g. 'my-folder')
+ */
+function rename_folder(string $bucketName, string $sourceFolder, string $destinationFolder): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->folderName('_', $bucketName, $sourceFolder);
+
+    $request = new RenameFolderRequest([
+        'name' => $formattedName,
+        'destination_folder_id' => $destinationFolder,
+    ]);
+
+    $storageControlClient->renameFolder($request);
+
+    printf('Renamed folder %s to %s', $sourceFolder, $destinationFolder);
+}
+# [END storage_control_rename_folder]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/test/StorageControlTest.php
+++ b/storagecontrol/test/StorageControlTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for storage control library samples.
+ */
+class StorageControlTest extends TestCase
+{
+    use TestTrait;
+
+    private static $sourceBucket;
+    private static $folderId;
+    private static $folderName;
+    private static $storage;
+    private static $storageControlClient;
+    private static $location;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::checkProjectEnvVars();
+        self::$storage = new StorageClient();
+        self::$storageControlClient = new StorageControlClient();
+        self::$location = 'us-west1';
+        $uniqueBucketId = time() . rand();
+        self::$folderId = time() . rand();
+        self::$sourceBucket = self::$storage->createBucket(
+            sprintf('php-gcscontrol-sample-%s', $uniqueBucketId),
+            [
+                'location' => self::$location,
+                'hierarchicalNamespace' => ['enabled' => true,],
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]
+            ]
+        );
+        self::$folderName = self::$storageControlClient->folderName(
+            '_',
+            self::$sourceBucket->name(),
+            self::$folderId
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        foreach (self::$sourceBucket->objects(['versions' => true]) as $object) {
+            $object->delete();
+        }
+        self::$sourceBucket->delete();
+    }
+
+    public function testCreateFolder()
+    {
+        $output = $this->runFunctionSnippet('create_folder', [
+            self::$sourceBucket->name(), self::$folderId
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Created folder: %s', self::$folderName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testCreateFolder
+     */
+    public function testGetFolder()
+    {
+        $output = $this->runFunctionSnippet('get_folder', [
+            self::$sourceBucket->name(), self::$folderId
+        ]);
+
+        $this->assertStringContainsString(
+            self::$folderName,
+            $output
+        );
+    }
+
+    /**
+     * @depends testGetFolder
+     */
+    public function testListFolders()
+    {
+        $output = $this->runFunctionSnippet('list_folders', [
+            self::$sourceBucket->name()
+        ]);
+
+        $this->assertStringContainsString(
+            self::$folderName,
+            $output
+        );
+    }
+
+    /**
+     * @depends testListFolders
+     */
+    public function testRenameFolder()
+    {
+        $newFolderId = time() . rand();
+        $output = $this->runFunctionSnippet('rename_folder', [
+            self::$sourceBucket->name(), self::$folderId, $newFolderId
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Renamed folder %s to %s', self::$folderId, $newFolderId),
+            $output
+        );
+
+        self::$folderId = $newFolderId;
+    }
+
+    /**
+     * @depends testRenameFolder
+     */
+    public function testDeleteFolder()
+    {
+        $output = $this->runFunctionSnippet('delete_folder', [
+            self::$sourceBucket->name(), self::$folderId
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Deleted folder: %s', self::$folderId),
+            $output
+        );
+    }
+}

--- a/storagecontrol/test/StorageControlTest.php
+++ b/storagecontrol/test/StorageControlTest.php
@@ -48,7 +48,7 @@ class StorageControlTest extends TestCase
             sprintf('php-gcscontrol-sample-%s', $uniqueBucketId),
             [
                 'location' => self::$location,
-                'hierarchicalNamespace' => ['enabled' => true,],
+                'hierarchicalNamespace' => ['enabled' => true],
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]
             ]
         );


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-php/issues/7357

```
➜  storagecontrol git:(main) ✗ ../testing/vendor/bin/phpunit -c phpunit.xml.dist --testdox
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

Storage Control (Google\Cloud\Samples\StorageControl\StorageControl)
 ✔ Create folder
 ✔ Get folder
 ✔ List folders
 ✔ Rename folder
 ✔ Delete folder

quickstart
 ✔ Quickstart

Time: 00:10.662, Memory: 12.00 MB

OK (6 tests, 7 assertions)
➜  storagecontrol git:(main) ✗
```