### PR TITLE
chore: Update some PHP GAE Flex samples to use newer runtimes

### DIFF
--- a/appengine/flexible/datastore/app.yaml
+++ b/appengine/flexible/datastore/app.yaml
@@ -3,3 +3,5 @@ env: flex
 
 runtime_config:
   document_root: .
+  operating_system: ubuntu22
+  runtime_version: 8.3

--- a/appengine/flexible/helloworld/app.yaml
+++ b/appengine/flexible/helloworld/app.yaml
@@ -3,6 +3,8 @@ env: flex
 
 runtime_config:
   document_root: web
+  operating_system: ubuntu22
+  runtime_version: 8.3
 
 # This sample incurs costs to run on the App Engine flexible environment.
 # The settings below are to reduce costs during testing and are not appropriate

--- a/appengine/flexible/storage/app.yaml
+++ b/appengine/flexible/storage/app.yaml
@@ -3,6 +3,8 @@ env: flex
 
 runtime_config:
   document_root: .
+  operating_system: ubuntu22
+  runtime_version: 8.3
 
 # [START gae_flex_storage_yaml]
 env_variables:


### PR DESCRIPTION
Update the PHP versions to use 8.3 for some of the doc samples. 