### PR TITLE
chore: set gcs-sdk-team as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@
 /cloud_sql/**/*.php       @GoogleCloudPlatform/infra-db-sdk @GoogleCloudPlatform/php-samples-reviewers
 /datastore/**/*.php       @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/php-samples-reviewers
 /firestore/**/*.php       @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/php-samples-reviewers
-/storage/                 @GoogleCloudPlatform/cloud-storage-dpe @GoogleCloudPlatform/php-samples-reviewers
+/storage/                 @GoogleCloudPlatform/gcs-sdk-team @GoogleCloudPlatform/php-samples-reviewers
 /spanner/                 @GoogleCloudPlatform/api-spanner @GoogleCloudPlatform/php-samples-reviewers
 /secretmanager/           @GoogleCloudPlatform/php-samples-reviewers @GoogleCloudPlatform/cloud-secrets-team
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,10 +33,6 @@
 /run/                     @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/php-samples-reviewers
 /eventarc/                @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/php-samples-reviewers
 
-# Functions samples owned by the Firebase team
-
-/functions/firebase_analytics   @schandel
-
 # DLP samples owned by DLP team
 
 /dlp/                     @GoogleCloudPlatform/googleapis-dlp


### PR DESCRIPTION
Replace outdated cloud-storage-dpe group