### PR TITLE
fix(documentai): fix 'quickstart' for latest client-library

### DIFF
--- a/documentai/composer.json
+++ b/documentai/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/cloud-document-ai": "^1.0.1"
+        "google/cloud-document-ai": "^2.1.3"
     }
 }

--- a/documentai/composer.json
+++ b/documentai/composer.json
@@ -1,12 +1,6 @@
 {
     "require": {
         "php": "^8.1",
-
-        "ext-bcmath": "*",
-        "ext-mbstring": "*",
-        "ext-xml": "*",
-
-        "google/cloud-document-ai": "^2.1.3",
-        "grpc/grpc": "^1.38"
+        "google/cloud-document-ai": "^2.1.3"
     }
 }

--- a/documentai/composer.json
+++ b/documentai/composer.json
@@ -1,5 +1,12 @@
 {
     "require": {
-        "google/cloud-document-ai": "^2.1.3"
+        "php": "^8.1",
+
+        "ext-bcmath": "*",
+        "ext-mbstring": "*",
+        "ext-xml": "*",
+
+        "google/cloud-document-ai": "^2.1.3",
+        "grpc/grpc": "^1.38"
     }
 }

--- a/documentai/composer.json
+++ b/documentai/composer.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "php": "^8.1",
         "google/cloud-document-ai": "^2.1.3"
     }
 }

--- a/documentai/phpunit.xml.dist
+++ b/documentai/phpunit.xml.dist
@@ -14,25 +14,26 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<phpunit bootstrap="../testing/bootstrap.php">
-    <testsuites>
-        <testsuite name="PHP documentai test">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <file>quickstart.php</file>
-            <exclude>
-              <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="PHPUNIT_TESTS" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+      <file>quickstart.php</file>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP documentai test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
 </phpunit>

--- a/documentai/quickstart.php
+++ b/documentai/quickstart.php
@@ -32,11 +32,11 @@ $projectId = 'YOUR_PROJECT_ID';
 $location = 'us';
 
 # Your Processor ID as hexadecimal characters.
-# Not to be confused with the Processor Name.
+# Not to be confused with the Processor Display Name.
 $processorId = 'YOUR_PROCESSOR_ID';
 
 # Path for the file to read.
-$documentPath = 'resources/invoice.pdf';
+$documentPath = '../resources/invoice.pdf';
 
 # Create Client.
 $client = new DocumentProcessorServiceClient();

--- a/documentai/quickstart.php
+++ b/documentai/quickstart.php
@@ -16,43 +16,51 @@
  */
 
 # [START documentai_quickstart]
-# Includes the autoloader for libraries installed with composer
+# Include the autoloader for libraries installed with Composer.
 require __DIR__ . '/vendor/autoload.php';
 
-# Imports the Google Cloud client library
-use Google\Cloud\DocumentAI\V1\DocumentProcessorServiceClient;
+# Import the Google Cloud client library.
+use Google\Cloud\DocumentAI\V1\Client\DocumentProcessorServiceClient;
 use Google\Cloud\DocumentAI\V1\RawDocument;
+use Google\Cloud\DocumentAI\V1\ProcessRequest;
 
-$projectId = 'YOUR_PROJECT_ID'; # Your Google Cloud Platform project ID
-$location = 'us'; # Your Processor Location
-$processor = 'YOUR_PROCESSOR_ID'; # Your Processor ID
+# TODO(developer): Update the following lines before running the sample.
+# Your Google Cloud Platform project ID.
+$projectId = 'YOUR_PROJECT_ID';
 
-# Create Client
-$client = new DocumentProcessorServiceClient();
+# Your Processor Location.
+$location = 'us';
 
-# Local File Path
+# Your Processor ID as hexadecimal characters.
+# Not to be confused with the Processor Name.
+$processorId = 'YOUR_PROCESSOR_ID';
+
+# Path for the file to read.
 $documentPath = 'resources/invoice.pdf';
 
-# Read in File Contents
+# Create Client.
+$client = new DocumentProcessorServiceClient();
+
+# Read in file.
 $handle = fopen($documentPath, 'rb');
 $contents = fread($handle, filesize($documentPath));
 fclose($handle);
 
-# Load File Contents into RawDocument
-$rawDocument = new RawDocument([
-    'content' => $contents,
-    'mime_type' => 'application/pdf'
-]);
+# Load file contents into a RawDocument.
+$rawDocument = new RawDocument()
+    ->setContent($contents)
+    ->SetMimeType('application/pdf');
 
-# Fully-qualified Processor Name
-$name = $client->processorName($projectId, $location, $processor);
+# Get the Fully-qualified Processor Name.
+$fullProcessorName = $client->processorName($projectId, $location, $processorId);
 
-# Make Processing Request
-$response = $client->processDocument($name, [
-    'rawDocument' => $rawDocument
-]);
+# Send a ProcessRequest and get a ProcessResponse.
+$request = new ProcessRequest()
+    ->setName($fullProcessorName)
+    ->setRawDocument($rawDocument);
 
-# Print Document Text
+$response = $client->processDocument($request);
+
+# Show the text found in the document.
 printf('Document Text: %s', $response->getDocument()->getText());
-
 # [END documentai_quickstart]

--- a/documentai/quickstart.php
+++ b/documentai/quickstart.php
@@ -36,7 +36,7 @@ $location = 'us';
 $processorId = 'YOUR_PROCESSOR_ID';
 
 # Path for the file to read.
-$documentPath = '../resources/invoice.pdf';
+$documentPath = 'resources/invoice.pdf';
 
 # Create Client.
 $client = new DocumentProcessorServiceClient();

--- a/documentai/quickstart.php
+++ b/documentai/quickstart.php
@@ -47,7 +47,7 @@ $contents = fread($handle, filesize($documentPath));
 fclose($handle);
 
 # Load file contents into a RawDocument.
-$rawDocument = new RawDocument()
+$rawDocument = (new RawDocument())
     ->setContent($contents)
     ->SetMimeType('application/pdf');
 
@@ -55,7 +55,7 @@ $rawDocument = new RawDocument()
 $fullProcessorName = $client->processorName($projectId, $location, $processorId);
 
 # Send a ProcessRequest and get a ProcessResponse.
-$request = new ProcessRequest()
+$request = (new ProcessRequest())
     ->setName($fullProcessorName)
     ->setRawDocument($rawDocument);
 


### PR DESCRIPTION
## Description

Fixes Internal: b/393632125

- Update `google/cloud-document-ai` to the latest version `2.1.3`
- Refactor sample to comply with new syntax requested by the client library
- Migrate phpunit XML definition to v9.3, as requested when running the test

## Checklist

- [x] I have followed guidelines from the [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/CONTRIBUTING.md)
- [ ] Appropriate changes to README are included in PR
- [x] Test passed: ../testing/vendor/bin/phpunit test/ -v
- [ ] Lint passed: php-cs-fixer fix . --config .php-cs-fixer.dist.php
- [ ] Please merge this PR for me once it is approved