### PR TITLE
feat(parametermanager): Added samples for handling CMEK in Parameter for Global and Regional

### DIFF
--- a/parametermanager/composer.json
+++ b/parametermanager/composer.json
@@ -1,0 +1,7 @@
+{
+  "require": {
+    "google/cloud-kms": "^1.20",
+    "google/cloud-secret-manager": "^1.15.2",
+    "google/cloud-parametermanager": "^0.2.0"
+  }
+}

--- a/parametermanager/phpunit.xml.dist
+++ b/parametermanager/phpunit.xml.dist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2025 Google LLC.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<phpunit bootstrap="../testing/bootstrap.php">
+    <testsuites>
+        <testsuite name="PHP Parameter Manager test">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+            <exclude>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <php>
+        <env name="PHPUNIT_TESTS" value="1"/>
+    </php>
+</phpunit>

--- a/parametermanager/src/create_param_with_kms_key.php
+++ b/parametermanager/src/create_param_with_kms_key.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_param_with_kms_key]
+// Import necessary classes for creating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+
+/**
+ * Creates a parameter of type "unformatted" with provided KMS key using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $kmsKey The KMS key used to encrypt the parameter (e.g. 'projects/my-project/locations/global/keyRings/test/cryptoKeys/test-key')
+ */
+function create_param_with_kms_key(string $projectId, string $parameterId, string $kmsKey): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parent object.
+    $parent = $client->locationName($projectId, 'global');
+
+    // Create a new Parameter object.
+    $parameter = (new Parameter())
+    ->setKmsKey($kmsKey);
+
+    // Prepare the request with the parent, parameter ID, and the parameter object.
+    $request = (new CreateParameterRequest())
+        ->setParent($parent)
+        ->setParameterId($parameterId)
+        ->setParameter($parameter);
+
+    // Crete the parameter.
+    $newParameter = $client->createParameter($request);
+
+    // Print the new parameter name
+    printf('Created parameter %s with kms key %s' . PHP_EOL, $newParameter->getName(), $newParameter->getKmsKey());
+
+}
+// [END parametermanager_create_param_with_kms_key]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_regional_param_with_kms_key.php
+++ b/parametermanager/src/create_regional_param_with_kms_key.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_regional_param_with_kms_key]
+// Import necessary classes for creating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+
+/**
+ * Creates a regional parameter of type "unformatted" with provided KMS key using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $kmsKey The KMS key used to encrypt the parameter (e.g. 'projects/my-project/locations/us-central1/keyRings/test/cryptoKeys/test-key')
+ */
+function create_regional_param_with_kms_key(string $projectId, string $locationId, string $parameterId, string $kmsKey): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parent object.
+    $parent = $client->locationName($projectId, $locationId);
+
+    // Create a new Parameter object.
+    $parameter = (new Parameter())
+    ->setKmsKey($kmsKey);
+
+    // Prepare the request with the parent, parameter ID, and the parameter object.
+    $request = (new CreateParameterRequest())
+        ->setParent($parent)
+        ->setParameterId($parameterId)
+        ->setParameter($parameter);
+
+    // Crete the parameter.
+    $newParameter = $client->createParameter($request);
+
+    // Print the new parameter name
+    printf('Created regional parameter %s with kms key %s' . PHP_EOL, $newParameter->getName(), $newParameter->getKmsKey());
+
+}
+// [END parametermanager_create_regional_param_with_kms_key]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/remove_param_kms_key.php
+++ b/parametermanager/src/remove_param_kms_key.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_remove_param_kms_key]
+// Import necessary classes for updating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterRequest;
+use Google\Cloud\ParameterManager\V1\UpdateParameterRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Update a parameter by removing kms key using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function remove_param_kms_key(string $projectId, string $parameterId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter.
+    $parameterName = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Prepare the request to get the parameter.
+    $request = (new GetParameterRequest())
+        ->setName($parameterName);
+
+    // Retrieve the parameter using the client.
+    $parameter = $client->getParameter($request);
+
+    $parameter->clearKmsKey();
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['kms_key']);
+
+    // Prepare the request to update the parameter.
+    $request = (new UpdateParameterRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameter($parameter);
+
+    // Update the parameter using the client.
+    $updatedParameter = $client->updateParameter($request);
+
+    // Print the parameter details.
+    printf('Removed kms key for parameter %s' . PHP_EOL, $updatedParameter->getName());
+}
+// [END parametermanager_remove_param_kms_key]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/remove_regional_param_kms_key.php
+++ b/parametermanager/src/remove_regional_param_kms_key.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_remove_regional_param_kms_key]
+// Import necessary classes for updating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterRequest;
+use Google\Cloud\ParameterManager\V1\UpdateParameterRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Update a regional parameter by removing kms key using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function remove_regional_param_kms_key(string $projectId, string $locationId, string $parameterId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter.
+    $parameterName = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Prepare the request to get the parameter.
+    $request = (new GetParameterRequest())
+        ->setName($parameterName);
+
+    // Retrieve the parameter using the client.
+    $parameter = $client->getParameter($request);
+
+    $parameter->clearKmsKey();
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['kms_key']);
+
+    // Prepare the request to update the parameter.
+    $request = (new UpdateParameterRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameter($parameter);
+
+    // Update the parameter using the client.
+    $updatedParameter = $client->updateParameter($request);
+
+    // Print the parameter details.
+    printf('Removed kms key for regional parameter %s' . PHP_EOL, $updatedParameter->getName());
+}
+// [END parametermanager_remove_regional_param_kms_key]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/update_param_kms_key.php
+++ b/parametermanager/src/update_param_kms_key.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_update_param_kms_key]
+// Import necessary classes for updating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterRequest;
+use Google\Cloud\ParameterManager\V1\UpdateParameterRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Update a parameter with kms key using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $kmsKey The KMS key used to encrypt the parameter (e.g. 'projects/my-project/locations/global/keyRings/test/cryptoKeys/test-key')
+ */
+function update_param_kms_key(string $projectId, string $parameterId, string $kmsKey): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter.
+    $parameterName = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Prepare the request to get the parameter.
+    $request = (new GetParameterRequest())
+        ->setName($parameterName);
+
+    // Retrieve the parameter using the client.
+    $parameter = $client->getParameter($request);
+
+    $parameter->setKmsKey($kmsKey);
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['kms_key']);
+
+    // Prepare the request to update the parameter.
+    $request = (new UpdateParameterRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameter($parameter);
+
+    // Update the parameter using the client.
+    $updatedParameter = $client->updateParameter($request);
+
+    // Print the parameter details.
+    printf('Updated parameter %s with kms key %s' . PHP_EOL, $updatedParameter->getName(), $updatedParameter->getKmsKey());
+}
+// [END parametermanager_update_param_kms_key]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/update_regional_param_kms_key.php
+++ b/parametermanager/src/update_regional_param_kms_key.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_update_regional_param_kms_key]
+// Import necessary classes for updating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterRequest;
+use Google\Cloud\ParameterManager\V1\UpdateParameterRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Update a parameter with kms key using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $kmsKey The KMS key used to encrypt the parameter (e.g. 'projects/my-project/locations/global/keyRings/test/cryptoKeys/test-key')
+ */
+function update_regional_param_kms_key(string $projectId, string $locationId, string $parameterId, string $kmsKey): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter.
+    $parameterName = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Prepare the request to get the parameter.
+    $request = (new GetParameterRequest())
+        ->setName($parameterName);
+
+    // Retrieve the parameter using the client.
+    $parameter = $client->getParameter($request);
+
+    $parameter->setKmsKey($kmsKey);
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['kms_key']);
+
+    // Prepare the request to update the parameter.
+    $request = (new UpdateParameterRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameter($parameter);
+
+    // Update the parameter using the client.
+    $updatedParameter = $client->updateParameter($request);
+
+    // Print the parameter details.
+    printf('Updated regional parameter %s with kms key %s' . PHP_EOL, $updatedParameter->getName(), $updatedParameter->getKmsKey());
+}
+// [END parametermanager_update_regional_param_kms_key]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/test/parametermanagerTest.php
+++ b/parametermanager/test/parametermanagerTest.php
@@ -1,0 +1,230 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+use Exception;
+use Google\ApiCore\ApiException;
+use Google\Cloud\Kms\V1\CreateCryptoKeyRequest;
+use Google\Cloud\Kms\V1\CreateKeyRingRequest;
+use Google\Cloud\Kms\V1\CryptoKey;
+use Google\Cloud\Kms\V1\CryptoKey\CryptoKeyPurpose;
+use Google\Cloud\Kms\V1\CryptoKeyVersion\CryptoKeyVersionAlgorithm;
+use Google\Cloud\Kms\V1\CryptoKeyVersion\CryptoKeyVersionState;
+use Google\Cloud\Kms\V1\CryptoKeyVersionTemplate;
+use Google\Cloud\Kms\V1\DestroyCryptoKeyVersionRequest;
+use Google\Cloud\Kms\V1\GetCryptoKeyVersionRequest;
+use Google\Cloud\Kms\V1\KeyRing;
+use Google\Cloud\Kms\V1\ListCryptoKeysRequest;
+use Google\Cloud\Kms\V1\ListCryptoKeyVersionsRequest;
+use Google\Cloud\Kms\V1\ProtectionLevel;
+use Google\Cloud\TestUtils\TestTrait;
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\Kms\V1\Client\KeyManagementServiceClient;
+use PHPUnit\Framework\TestCase;
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+
+class parametermanagerTest extends TestCase
+{
+    use TestTrait;
+
+    public const JSON_PAYLOAD = '{"username": "test-user", "host": "localhost"}';
+    private static $kmsClient;
+    private static $client;
+    private static $locationId = 'global';
+    private static $keyRingId;
+    private static $cryptoKey;
+    private static $cryptoUpdatedKey;
+    private static $testParameterNameWithKms;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$client = new ParameterManagerClient();
+        self::$kmsClient = new KeyManagementServiceClient();
+
+        self::$testParameterNameWithKms = self::$client->parameterName(self::$projectId, self::$locationId, self::randomId());
+
+        self::$keyRingId = self::createKeyRing();
+        $hsmKey = self::randomId();
+        self::createHsmKey($hsmKey);
+
+        $hsmUdpatedKey = self::randomId();
+        self::createUpdatedHsmKey($hsmUdpatedKey);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $keyRingName = self::$kmsClient->keyRingName(self::$projectId, self::$locationId, self::$keyRingId);
+        $listCryptoKeysRequest = (new ListCryptoKeysRequest())
+            ->setParent($keyRingName);
+        $keys = self::$kmsClient->listCryptoKeys($listCryptoKeysRequest);
+        foreach ($keys as $key) {
+            $listCryptoKeyVersionsRequest = (new ListCryptoKeyVersionsRequest())
+                ->setParent($key->getName())
+                ->setFilter('state != DESTROYED AND state != DESTROY_SCHEDULED');
+
+            $versions = self::$kmsClient->listCryptoKeyVersions($listCryptoKeyVersionsRequest);
+            foreach ($versions as $version) {
+                $destroyCryptoKeyVersionRequest = (new DestroyCryptoKeyVersionRequest())
+                    ->setName($version->getName());
+                self::$kmsClient->destroyCryptoKeyVersion($destroyCryptoKeyVersionRequest);
+            }
+        }
+
+        self::deleteParameter(self::$testParameterNameWithKms);
+    }
+
+    private static function deleteParameter(string $name)
+    {
+        try {
+            $deleteParameterRequest = (new DeleteParameterRequest())
+                ->setName($name);
+            self::$client->deleteParameter($deleteParameterRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function randomId(): string
+    {
+        return uniqid('php-snippets-');
+    }
+
+    private static function createKeyRing()
+    {
+        $id = 'test-pm-snippets';
+        $locationName = self::$kmsClient->locationName(self::$projectId, self::$locationId);
+        $keyRing = new KeyRing();
+        try {
+            $createKeyRingRequest = (new CreateKeyRingRequest())
+                ->setParent($locationName)
+                ->setKeyRingId($id)
+                ->setKeyRing($keyRing);
+            $keyRing = self::$kmsClient->createKeyRing($createKeyRingRequest);
+            return $keyRing->getName();
+        } catch (ApiException $e) {
+            if ($e->getStatus() == 'ALREADY_EXISTS') {
+                return $id;
+            }
+        } catch (Exception $e) {
+            throw $e;
+        }
+    }
+
+    private static function createHsmKey(string $id)
+    {
+        $keyRingName = self::$kmsClient->keyRingName(self::$projectId, self::$locationId, self::$keyRingId);
+        $key = (new CryptoKey())
+            ->setPurpose(CryptoKeyPurpose::ENCRYPT_DECRYPT)
+            ->setVersionTemplate((new CryptoKeyVersionTemplate)
+                ->setProtectionLevel(ProtectionLevel::HSM)
+                ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION))
+            ->setLabels(['foo' => 'bar', 'zip' => 'zap']);
+        $createCryptoKeyRequest = (new CreateCryptoKeyRequest())
+            ->setParent($keyRingName)
+            ->setCryptoKeyId($id)
+            ->setCryptoKey($key);
+        $cryptoKey = self::$kmsClient->createCryptoKey($createCryptoKeyRequest);
+        self::$cryptoKey = $cryptoKey->getName();
+        return self::waitForReady($cryptoKey);
+    }
+
+    private static function createUpdatedHsmKey(string $id)
+    {
+        $keyRingName = self::$kmsClient->keyRingName(self::$projectId, self::$locationId, self::$keyRingId);
+        $key = (new CryptoKey())
+            ->setPurpose(CryptoKeyPurpose::ENCRYPT_DECRYPT)
+            ->setVersionTemplate((new CryptoKeyVersionTemplate)
+                ->setProtectionLevel(ProtectionLevel::HSM)
+                ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION))
+            ->setLabels(['foo' => 'bar', 'zip' => 'zap']);
+        $createCryptoKeyRequest = (new CreateCryptoKeyRequest())
+            ->setParent($keyRingName)
+            ->setCryptoKeyId($id)
+            ->setCryptoKey($key);
+        $cryptoKey = self::$kmsClient->createCryptoKey($createCryptoKeyRequest);
+        self::$cryptoUpdatedKey = $cryptoKey->getName();
+        return self::waitForReady($cryptoKey);
+    }
+
+    private static function waitForReady(CryptoKey $key)
+    {
+        $versionName = $key->getName() . '/cryptoKeyVersions/1';
+        $getCryptoKeyVersionRequest = (new GetCryptoKeyVersionRequest())
+            ->setName($versionName);
+        $version = self::$kmsClient->getCryptoKeyVersion($getCryptoKeyVersionRequest);
+        $attempts = 0;
+        while ($version->getState() != CryptoKeyVersionState::ENABLED) {
+            if ($attempts > 10) {
+                $msg = sprintf('key version %s was not ready after 10 attempts', $versionName);
+                throw new \Exception($msg);
+            }
+            usleep(500);
+            $getCryptoKeyVersionRequest = (new GetCryptoKeyVersionRequest())
+                ->setName($versionName);
+            $version = self::$kmsClient->getCryptoKeyVersion($getCryptoKeyVersionRequest);
+            $attempts += 1;
+        }
+        return $key;
+    }
+
+    public function testCreateParamWithKmsKey()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithKms);
+
+        $output = $this->runFunctionSnippet('create_param_with_kms_key', [
+            $name['project'],
+            $name['parameter'],
+            self::$cryptoKey,
+        ]);
+
+        $this->assertStringContainsString('Created parameter', $output);
+        $this->assertStringContainsString('with kms key ' . self::$cryptoKey, $output);
+    }
+
+    public function testUpdateParamKmsKey()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithKms);
+
+        $output = $this->runFunctionSnippet('update_param_kms_key', [
+            $name['project'],
+            $name['parameter'],
+            self::$cryptoUpdatedKey,
+        ]);
+
+        $this->assertStringContainsString('Updated parameter ', $output);
+        $this->assertStringContainsString('with kms key ' . self::$cryptoUpdatedKey, $output);
+    }
+
+    public function testRemoveParamKmsKey()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithKms);
+
+        $output = $this->runFunctionSnippet('remove_param_kms_key', [
+            $name['project'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Removed kms key for parameter ', $output);
+    }
+
+}

--- a/parametermanager/test/regionalparametermanagerTest.php
+++ b/parametermanager/test/regionalparametermanagerTest.php
@@ -1,0 +1,234 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+use Exception;
+use Google\ApiCore\ApiException;
+use Google\Cloud\Kms\V1\CreateCryptoKeyRequest;
+use Google\Cloud\Kms\V1\CreateKeyRingRequest;
+use Google\Cloud\Kms\V1\CryptoKey;
+use Google\Cloud\Kms\V1\CryptoKey\CryptoKeyPurpose;
+use Google\Cloud\Kms\V1\CryptoKeyVersion\CryptoKeyVersionAlgorithm;
+use Google\Cloud\Kms\V1\CryptoKeyVersion\CryptoKeyVersionState;
+use Google\Cloud\Kms\V1\CryptoKeyVersionTemplate;
+use Google\Cloud\Kms\V1\DestroyCryptoKeyVersionRequest;
+use Google\Cloud\Kms\V1\GetCryptoKeyVersionRequest;
+use Google\Cloud\Kms\V1\KeyRing;
+use Google\Cloud\Kms\V1\ListCryptoKeysRequest;
+use Google\Cloud\Kms\V1\ListCryptoKeyVersionsRequest;
+use Google\Cloud\Kms\V1\ProtectionLevel;
+use Google\Cloud\TestUtils\TestTrait;
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\Kms\V1\Client\KeyManagementServiceClient;
+use PHPUnit\Framework\TestCase;
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+
+class regionalparametermanagerTest extends TestCase
+{
+    use TestTrait;
+
+    public const JSON_PAYLOAD = '{"username": "test-user", "host": "localhost"}';
+    private static $kmsClient;
+    private static $client;
+    private static $locationId = 'us-central1';
+    private static $keyRingId;
+    private static $cryptoKey;
+    private static $cryptoUpdatedKey;
+    private static $testParameterNameWithKms;
+
+    public static function setUpBeforeClass(): void
+    {
+        $options = ['apiEndpoint' => 'parametermanager.' . self::$locationId . '.rep.googleapis.com'];
+        self::$client = new ParameterManagerClient($options);
+        self::$kmsClient = new KeyManagementServiceClient();
+
+        self::$testParameterNameWithKms = self::$client->parameterName(self::$projectId, self::$locationId, self::randomId());
+
+        self::$keyRingId = self::createKeyRing();
+        $hsmKey = self::randomId();
+        self::createHsmKey($hsmKey);
+
+        $hsmUdpatedKey = self::randomId();
+        self::createUpdatedHsmKey($hsmUdpatedKey);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $keyRingName = self::$kmsClient->keyRingName(self::$projectId, self::$locationId, self::$keyRingId);
+        $listCryptoKeysRequest = (new ListCryptoKeysRequest())
+            ->setParent($keyRingName);
+        $keys = self::$kmsClient->listCryptoKeys($listCryptoKeysRequest);
+        foreach ($keys as $key) {
+            $listCryptoKeyVersionsRequest = (new ListCryptoKeyVersionsRequest())
+                ->setParent($key->getName())
+                ->setFilter('state != DESTROYED AND state != DESTROY_SCHEDULED');
+
+            $versions = self::$kmsClient->listCryptoKeyVersions($listCryptoKeyVersionsRequest);
+            foreach ($versions as $version) {
+                $destroyCryptoKeyVersionRequest = (new DestroyCryptoKeyVersionRequest())
+                    ->setName($version->getName());
+                self::$kmsClient->destroyCryptoKeyVersion($destroyCryptoKeyVersionRequest);
+            }
+        }
+
+        self::deleteParameter(self::$testParameterNameWithKms);
+    }
+
+    private static function deleteParameter(string $name)
+    {
+        try {
+            $deleteParameterRequest = (new DeleteParameterRequest())
+                ->setName($name);
+            self::$client->deleteParameter($deleteParameterRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function randomId(): string
+    {
+        return uniqid('php-snippets-');
+    }
+
+    private static function createKeyRing()
+    {
+        $id = 'test-pm-snippets';
+        $locationName = self::$kmsClient->locationName(self::$projectId, self::$locationId);
+        $keyRing = new KeyRing();
+        try {
+            $createKeyRingRequest = (new CreateKeyRingRequest())
+                ->setParent($locationName)
+                ->setKeyRingId($id)
+                ->setKeyRing($keyRing);
+            $keyRing = self::$kmsClient->createKeyRing($createKeyRingRequest);
+            return $keyRing->getName();
+        } catch (ApiException $e) {
+            if ($e->getStatus() == 'ALREADY_EXISTS') {
+                return $id;
+            }
+        } catch (Exception $e) {
+            throw $e;
+        }
+    }
+
+    private static function createHsmKey(string $id)
+    {
+        $keyRingName = self::$kmsClient->keyRingName(self::$projectId, self::$locationId, self::$keyRingId);
+        $key = (new CryptoKey())
+            ->setPurpose(CryptoKeyPurpose::ENCRYPT_DECRYPT)
+            ->setVersionTemplate((new CryptoKeyVersionTemplate)
+                ->setProtectionLevel(ProtectionLevel::HSM)
+                ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION))
+            ->setLabels(['foo' => 'bar', 'zip' => 'zap']);
+        $createCryptoKeyRequest = (new CreateCryptoKeyRequest())
+            ->setParent($keyRingName)
+            ->setCryptoKeyId($id)
+            ->setCryptoKey($key);
+        $cryptoKey = self::$kmsClient->createCryptoKey($createCryptoKeyRequest);
+        self::$cryptoKey = $cryptoKey->getName();
+        return self::waitForReady($cryptoKey);
+    }
+
+    private static function createUpdatedHsmKey(string $id)
+    {
+        $keyRingName = self::$kmsClient->keyRingName(self::$projectId, self::$locationId, self::$keyRingId);
+        $key = (new CryptoKey())
+            ->setPurpose(CryptoKeyPurpose::ENCRYPT_DECRYPT)
+            ->setVersionTemplate((new CryptoKeyVersionTemplate)
+                ->setProtectionLevel(ProtectionLevel::HSM)
+                ->setAlgorithm(CryptoKeyVersionAlgorithm::GOOGLE_SYMMETRIC_ENCRYPTION))
+            ->setLabels(['foo' => 'bar', 'zip' => 'zap']);
+        $createCryptoKeyRequest = (new CreateCryptoKeyRequest())
+            ->setParent($keyRingName)
+            ->setCryptoKeyId($id)
+            ->setCryptoKey($key);
+        $cryptoKey = self::$kmsClient->createCryptoKey($createCryptoKeyRequest);
+        self::$cryptoUpdatedKey = $cryptoKey->getName();
+        return self::waitForReady($cryptoKey);
+    }
+
+    private static function waitForReady(CryptoKey $key)
+    {
+        $versionName = $key->getName() . '/cryptoKeyVersions/1';
+        $getCryptoKeyVersionRequest = (new GetCryptoKeyVersionRequest())
+            ->setName($versionName);
+        $version = self::$kmsClient->getCryptoKeyVersion($getCryptoKeyVersionRequest);
+        $attempts = 0;
+        while ($version->getState() != CryptoKeyVersionState::ENABLED) {
+            if ($attempts > 10) {
+                $msg = sprintf('key version %s was not ready after 10 attempts', $versionName);
+                throw new \Exception($msg);
+            }
+            usleep(500);
+            $getCryptoKeyVersionRequest = (new GetCryptoKeyVersionRequest())
+                ->setName($versionName);
+            $version = self::$kmsClient->getCryptoKeyVersion($getCryptoKeyVersionRequest);
+            $attempts += 1;
+        }
+        return $key;
+    }
+
+    public function testCreateRegionalParamWithKmsKey()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithKms);
+
+        $output = $this->runFunctionSnippet('create_regional_param_with_kms_key', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            self::$cryptoKey,
+        ]);
+
+        $this->assertStringContainsString('Created regional parameter', $output);
+        $this->assertStringContainsString('with kms key ' . self::$cryptoKey, $output);
+    }
+
+    public function testUpdateRegionalParamKmsKey()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithKms);
+
+        $output = $this->runFunctionSnippet('update_regional_param_kms_key', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            self::$cryptoUpdatedKey,
+        ]);
+
+        $this->assertStringContainsString('Updated regional parameter ', $output);
+        $this->assertStringContainsString('with kms key ' . self::$cryptoUpdatedKey, $output);
+    }
+
+    public function testRemoveRegionalParamKmsKey()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithKms);
+
+        $output = $this->runFunctionSnippet('remove_regional_param_kms_key', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Removed kms key for regional parameter ', $output);
+    }
+
+}


### PR DESCRIPTION
## Description
Added samples for Global and Regional Parameter Manager API with CMEK key

- create_param_with_kms_key
- update_param_kms_key
- remove_param_kms_key
- create_regional_param_with_kms_key
- update_regional_param_kms_key
- remove_regional_param_kms_key

Added test cases for both global and regional parameter.
**Note: The KMS service needs to be enabled in the testing project to pass the integration tests.**

## Checklist
- [x] I have followed guidelines from the [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/CONTRIBUTING.md)
- [x] Appropriate changes to README are included in PR
- [x] Test passed: `../testing/vendor/bin/phpunit test/ -v`
- [x] Lint passed: `php-cs-fixer fix . --config .php-cs-fixer.dist.php`
- [x] Please merge this PR for me once it is approved