### PR TITLE
feat(parametermanager): Added samples for global & regional parameter manager

### DIFF
--- a/parametermanager/README.md
+++ b/parametermanager/README.md
@@ -1,0 +1,65 @@
+# Google Parameter Manager PHP Sample Application
+
+[![Open in Cloud Shell][shell_img]][shell_link]
+
+[shell_img]: http://gstatic.com/cloudssh/images/open-btn.svg
+[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googlecloudplatform/php-docs-samples&page=editor&working_dir=parametermanager
+
+## Description
+
+This simple command-line application demonstrates how to invoke
+[Google Parameter Manager][parametermanager] from PHP.
+
+## Build and Run
+
+1.  **Enable APIs** - [Enable the Parameter Manager
+    API](https://console.cloud.google.com/apis/enableflow?apiid=parametermanager.googleapis.com)
+    and create a new project or select an existing project.
+
+1.  **Download The Credentials** - Click "Go to credentials" after enabling the
+    APIs. Click "New Credentials" and select "Service Account Key". Create a new
+    service account, use the JSON key type, and select "Create". Once
+    downloaded, set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to
+    the path of the JSON key that was downloaded.
+
+1.  **Clone the repo** and cd into this directory
+
+    ```text
+    $ git clone https://github.com/GoogleCloudPlatform/php-docs-samples
+    $ cd php-docs-samples/parametermanager
+    ```
+
+1.  **Install dependencies** via [Composer][install-composer]. If composer is
+    installed locally:
+
+
+    ```text
+    $ php composer.phar install
+    ```
+
+    If composer is installed globally:
+
+    ```text
+    $ composer install
+    ```
+
+1.  Execute the snippets in the [src/](src/) directory by running:
+
+    ```text
+    $ php src/SNIPPET_NAME.php
+    ```
+
+    The usage will print for each if no arguments are provided.
+
+See the [Parameter Manager Documentation](https://cloud.google.com/secret-manager/parameter-manager/docs/overview) for more information.
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](../CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](../LICENSE)
+
+[install-composer]: http://getcomposer.org/doc/00-intro.md
+[parametermanager]: https://cloud.google.com/secret-manager/parameter-manager/docs/overview

--- a/parametermanager/composer.json
+++ b/parametermanager/composer.json
@@ -1,0 +1,6 @@
+{
+  "require": {
+    "google/cloud-secret-manager": "^1.15.2",
+    "google/cloud-parametermanager": "^0.1.1"
+  }
+}

--- a/parametermanager/phpunit.xml.dist
+++ b/parametermanager/phpunit.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2025 Google LLC.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<phpunit bootstrap="../testing/bootstrap.php">
+  <testsuites>
+    <testsuite name="PHP Parameter Manager test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <log type="coverage-clover" target="build/logs/clover.xml"/>
+  </logging>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./src</directory>
+      <exclude>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
+</phpunit>
+

--- a/parametermanager/src/create_param.php
+++ b/parametermanager/src/create_param.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_param]
+// Import necessary classes for creating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+
+/**
+ * Creates a parameter of type "unformatted" using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function create_param(string $projectId, string $parameterId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parent object.
+    $parent = $client->locationName($projectId, 'global');
+
+    // Create a new Parameter object.
+    $parameter = new Parameter();
+
+    // Prepare the request with the parent, parameter ID, and the parameter object.
+    $request = (new CreateParameterRequest())
+        ->setParent($parent)
+        ->setParameterId($parameterId)
+        ->setParameter($parameter);
+
+    // Crete the parameter.
+    $newParameter = $client->createParameter($request);
+
+    // Print the new parameter name
+    printf('Created parameter: %s' . PHP_EOL, $newParameter->getName());
+
+}
+// [END parametermanager_create_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_param_version.php
+++ b/parametermanager/src/create_param_version.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_param_version]
+// Import necessary classes for creating a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+
+/**
+ * Creates a parameter version with an unformatted payload.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ * @param string $payload The unformatted string payload (e.g. 'test123')
+ */
+function create_param_version(string $projectId, string $parameterId, string $versionId, string $payload): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parent object.
+    $parent = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Create a new ParameterVersionPayload object and set the unformatted data.
+    $parameterVersionPayload = new ParameterVersionPayload();
+    $parameterVersionPayload->setData($payload);
+
+    // Create a new ParameterVersion object and set the payload.
+    $parameterVersion = new ParameterVersion();
+    $parameterVersion->setPayload($parameterVersionPayload);
+
+    // Prepare the request with the parent and parameter version object.
+    $request = (new CreateParameterVersionRequest())
+        ->setParent($parent)
+        ->setParameterVersionId($versionId)
+        ->setParameterVersion($parameterVersion);
+
+    // Call the API to create the parameter version.
+    $newParameterVersion = $client->createParameterVersion($request);
+    printf('Created parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+}
+// [END parametermanager_create_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_param_version_with_secret.php
+++ b/parametermanager/src/create_param_version_with_secret.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_param_version_with_secret]
+// Import necessary classes for creating a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+
+/**
+ * Creates a parameter version with an secret reference.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ * @param string $secretId The ID of the secret to be referenced (e.g. 'projects/my-project/secrets/my-secret/versions/latest')
+ */
+function create_param_version_with_secret(string $projectId, string $parameterId, string $versionId, string $secretId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parent object.
+    $parent = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Build payload.
+    $payload = sprintf('{"username": "test-user", "password": "__REF__(//secretmanager.googleapis.com/%s)"}', $secretId);
+
+    // Create a new ParameterVersionPayload object and set the payload with secret reference.
+    $parameterVersionPayload = new ParameterVersionPayload();
+    $parameterVersionPayload->setData($payload);
+
+    // Create a new ParameterVersion object and set the payload.
+    $parameterVersion = new ParameterVersion();
+    $parameterVersion->setPayload($parameterVersionPayload);
+
+    // Prepare the request with the parent and parameter version object.
+    $request = (new CreateParameterVersionRequest())
+        ->setParent($parent)
+        ->setParameterVersionId($versionId)
+        ->setParameterVersion($parameterVersion);
+
+    // Call the API to create the parameter version.
+    $newParameterVersion = $client->createParameterVersion($request);
+    printf('Created parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+}
+// [END parametermanager_create_param_version_with_secret]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_regional_param.php
+++ b/parametermanager/src/create_regional_param.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_regional_param]
+// Import necessary classes for creating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+
+/**
+ * Creates a regional parameter of type "unformatted" using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function create_regional_param(string $projectId, string $locationId, string $parameterId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parent object.
+    $parent = $client->locationName($projectId, $locationId);
+
+    // Create a new Parameter object.
+    $parameter = new Parameter();
+
+    // Prepare the request with the parent, parameter ID, and the parameter object.
+    $request = (new CreateParameterRequest())
+        ->setParent($parent)
+        ->setParameterId($parameterId)
+        ->setParameter($parameter);
+
+    // Crete the parameter.
+    $newParameter = $client->createParameter($request);
+
+    // Print the new parameter name
+    printf('Created regional parameter: %s' . PHP_EOL, $newParameter->getName());
+}
+// [END parametermanager_create_regional_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_regional_param_version.php
+++ b/parametermanager/src/create_regional_param_version.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_regional_param_version]
+// Import necessary classes for creating a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+
+/**
+ * Creates a regional parameter version with an unformatted payload.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ * @param string $payload The unformatted string payload (e.g. 'test123')
+ */
+function create_regional_param_version(string $projectId, string $locationId, string $parameterId, string $versionId, string $payload): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parent object.
+    $parent = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Create a new ParameterVersionPayload object and set the unformatted data.
+    $parameterVersionPayload = new ParameterVersionPayload();
+    $parameterVersionPayload->setData($payload);
+
+    // Create a new ParameterVersion object and set the payload.
+    $parameterVersion = new ParameterVersion();
+    $parameterVersion->setPayload($parameterVersionPayload);
+
+    // Prepare the request with the parent and parameter version object.
+    $request = (new CreateParameterVersionRequest())
+        ->setParent($parent)
+        ->setParameterVersionId($versionId)
+        ->setParameterVersion($parameterVersion);
+
+    // Call the API to create the parameter version.
+    $newParameterVersion = $client->createParameterVersion($request);
+    printf('Created regional parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+}
+// [END parametermanager_create_regional_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_regional_param_version_with_secret.php
+++ b/parametermanager/src/create_regional_param_version_with_secret.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_regional_param_version_with_secret]
+// Import necessary classes for creating a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+
+/**
+ * Creates a regional parameter version with an secret reference.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ * @param string $secretId The ID of the secret to be referenced (e.g. 'projects/my-project/locations/us-central1/secrets/my-secret/versions/latest')
+ */
+function create_regional_param_version_with_secret(string $projectId, string $locationId, string $parameterId, string $versionId, string $secretId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parent object.
+    $parent = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Build payload.
+    $payload = sprintf('{"username": "test-user", "password": "__REF__(//secretmanager.googleapis.com/%s)"}', $secretId);
+
+    // Create a new ParameterVersionPayload object and set the payload with secret reference.
+    $parameterVersionPayload = new ParameterVersionPayload();
+    $parameterVersionPayload->setData($payload);
+
+    // Create a new ParameterVersion object and set the payload.
+    $parameterVersion = new ParameterVersion();
+    $parameterVersion->setPayload($parameterVersionPayload);
+
+    // Prepare the request with the parent and parameter version object.
+    $request = (new CreateParameterVersionRequest())
+        ->setParent($parent)
+        ->setParameterVersionId($versionId)
+        ->setParameterVersion($parameterVersion);
+
+    // Call the API to create the parameter version.
+    $newParameterVersion = $client->createParameterVersion($request);
+    printf('Created regional parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+}
+// [END parametermanager_create_regional_param_version_with_secret]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_structured_param.php
+++ b/parametermanager/src/create_structured_param.php
@@ -1,0 +1,68 @@
+<?php
+/*
+* Copyright 2025 Google LLC.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+* For instructions on how to run the full sample:
+*
+* @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_structured_param]
+// Import necessary classes for creating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+
+/**
+ * Creates a parameter with the specified format.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $format The format type of the parameter (UNFORMATTED, YAML, JSON)
+ */
+function create_structured_param(string $projectId, string $parameterId, string $format): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parent object.
+    $parent = $client->locationName($projectId, 'global');
+
+    // Create a new Parameter object and set the format.
+    $parameter = (new Parameter())
+        ->setFormat(ParameterFormat::value($format));
+
+    // Prepare the request with the parent, parameter ID, and the parameter object.
+    $request = (new CreateParameterRequest())
+        ->setParent($parent)
+        ->setParameterId($parameterId)
+        ->setParameter($parameter);
+
+    // Call the API and handle any network failures with print statements.
+    $newParameter = $client->createParameter($request);
+    printf('Created parameter %s with format %s' . PHP_EOL, $newParameter->getName(), ParameterFormat::name($newParameter->getFormat()));
+}
+// [END parametermanager_create_structured_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_structured_param_version.php
+++ b/parametermanager/src/create_structured_param_version.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_structured_param_version]
+// Import necessary classes for creating a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+
+/**
+ * Creates a parameter version with an json payload.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ * @param string $payload The JSON dictionary payload (e.g. '{"username": "test-user", "host": "localhost"}')
+ */
+function create_structured_param_version(string $projectId, string $parameterId, string $versionId, string $payload): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parent object.
+    $parent = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Create a new ParameterVersionPayload object and set the json data.
+    $parameterVersionPayload = new ParameterVersionPayload();
+    $parameterVersionPayload->setData($payload);
+
+    // Create a new ParameterVersion object and set the payload.
+    $parameterVersion = new ParameterVersion();
+    $parameterVersion->setPayload($parameterVersionPayload);
+
+    // Prepare the request with the parent and parameter version object.
+    $request = (new CreateParameterVersionRequest())
+        ->setParent($parent)
+        ->setParameterVersionId($versionId)
+        ->setParameterVersion($parameterVersion);
+
+    // Call the API to create the parameter version.
+    $newParameterVersion = $client->createParameterVersion($request);
+    printf('Created parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+}
+// [END parametermanager_create_structured_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_structured_regional_param.php
+++ b/parametermanager/src/create_structured_regional_param.php
@@ -1,0 +1,72 @@
+<?php
+/*
+* Copyright 2025 Google LLC.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+* For instructions on how to run the full sample:
+*
+* @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_structured_regional_param]
+// Import necessary classes for creating a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+
+/**
+ * Creates a regional parameter with the specified format.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $format The format type of the parameter (UNFORMATTED, YAML, JSON).
+ */
+function create_structured_regional_param(string $projectId, string $locationId, string $parameterId, string $format): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parent object.
+    $parent = $client->locationName($projectId, $locationId);
+
+    // Create a new Parameter object and set the format.
+    $parameter = (new Parameter())
+        ->setFormat(ParameterFormat::value($format));
+
+    // Prepare the request with the parent, parameter ID, and the parameter object.
+    $request = (new CreateParameterRequest())
+        ->setParent($parent)
+        ->setParameterId($parameterId)
+        ->setParameter($parameter);
+
+    // Call the API and handle any network failures with print statements.
+    $newParameter = $client->createParameter($request);
+    printf('Created regional parameter %s with format %s' . PHP_EOL, $newParameter->getName(), ParameterFormat::name($newParameter->getFormat()));
+}
+// [END parametermanager_create_structured_regional_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/create_structured_regional_param_version.php
+++ b/parametermanager/src/create_structured_regional_param_version.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_create_structured_regional_param_version]
+// Import necessary classes for creating a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+
+/**
+ * Creates a regional parameter version with an json payload.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ * @param string $payload The JSON dictionary payload (e.g. '{"username": "test-user", "host": "localhost"}')
+ */
+function create_structured_regional_param_version(string $projectId, string $locationId, string $parameterId, string $versionId, string $payload): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parent object.
+    $parent = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Create a new ParameterVersionPayload object and set the json data.
+    $parameterVersionPayload = new ParameterVersionPayload();
+    $parameterVersionPayload->setData($payload);
+
+    // Create a new ParameterVersion object and set the payload.
+    $parameterVersion = new ParameterVersion();
+    $parameterVersion->setPayload($parameterVersionPayload);
+
+    // Prepare the request with the parent and parameter version object.
+    $request = (new CreateParameterVersionRequest())
+        ->setParent($parent)
+        ->setParameterVersionId($versionId)
+        ->setParameterVersion($parameterVersion);
+
+    // Call the API to create the parameter version.
+    $newParameterVersion = $client->createParameterVersion($request);
+    printf('Created regional parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+}
+// [END parametermanager_create_structured_regional_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/delete_param.php
+++ b/parametermanager/src/delete_param.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_delete_param]
+// Import necessary classes for delete a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+
+/**
+ * Deletes a parameter using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function delete_param(string $projectId, string $parameterId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the paramete.
+    $parameterName = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Prepare the request to delete the parameter.
+    $request = (new DeleteParameterRequest())
+        ->setName($parameterName);
+
+    // Delete the parameter using the client.
+    $client->deleteParameter($request);
+
+    printf('Deleted parameter: %s' . PHP_EOL, $parameterId);
+}
+// [END parametermanager_delete_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/delete_param_version.php
+++ b/parametermanager/src/delete_param_version.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_delete_param_version]
+// Import necessary classes for delete a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterVersionRequest;
+
+/**
+ * Deletes a parameter version using the Parameter Manager SDK for GCP.
+ * 
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function delete_param_version(string $projectId, string $parameterId, string $versionId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, 'global', $parameterId, $versionId);
+
+    // Prepare the request to delete the parameter version.
+    $request = (new DeleteParameterVersionRequest())
+        ->setName($parameterVersionName);
+
+    // Delete the parameter version using the client.
+    $client->deleteParameterVersion($request);
+
+    printf('Deleted parameter version: %s' . PHP_EOL, $versionId);
+}
+// [END parametermanager_delete_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/delete_regional_param.php
+++ b/parametermanager/src/delete_regional_param.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_delete_regional_param]
+// Import necessary classes for delete a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+
+/**
+ * Deletes a regional parameter using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function delete_regional_param(string $projectId, string $locationId, string $parameterId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the paramete.
+    $parameterName = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Prepare the request to delete the parameter.
+    $request = (new DeleteParameterRequest())
+        ->setName($parameterName);
+
+    // Delete the parameter using the client.
+    $client->deleteParameter($request);
+
+    printf('Deleted regional parameter: %s' . PHP_EOL, $parameterId);
+}
+// [END parametermanager_delete_regional_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/delete_regional_param_version.php
+++ b/parametermanager/src/delete_regional_param_version.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_delete_regional_param_version]
+// Import necessary classes for delete a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterVersionRequest;
+
+/**
+ * Deletes a regional parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function delete_regional_param_version(string $projectId, string $locationId, string $parameterId, string $versionId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, $locationId, $parameterId, $versionId);
+
+    // Prepare the request to delete the parameter version.
+    $request = (new DeleteParameterVersionRequest())
+        ->setName($parameterVersionName);
+
+    // Delete the parameter version using the client.
+    $client->deleteParameterVersion($request);
+
+    printf('Deleted regional parameter version: %s' . PHP_EOL, $versionId);
+}
+// [END parametermanager_delete_regional_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/disable_param_version.php
+++ b/parametermanager/src/disable_param_version.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_disable_param_version]
+// Import necessary classes for disable a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\UpdateParameterVersionRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Disables a parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function disable_param_version(string $projectId, string $parameterId, string $versionId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, 'global', $parameterId, $versionId);
+
+    // Update the parameter version.
+    $parameterVersion = (new ParameterVersion())
+        ->setName($parameterVersionName)
+        ->setDisabled(true);
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['disabled']);
+
+    // Prepare the request to disable the parameter version.
+    $request = (new UpdateParameterVersionRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameterVersion($parameterVersion);
+
+    // Disable the parameter version using the client.
+    $client->updateParameterVersion($request);
+
+    // Print the parameter version details.
+    printf('Disabled parameter version %s for parameter %s' . PHP_EOL, $versionId, $parameterId);
+}
+// [END parametermanager_disable_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/disable_regional_param_version.php
+++ b/parametermanager/src/disable_regional_param_version.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_disable_regional_param_version]
+// Import necessary classes for disable a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\UpdateParameterVersionRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Disables a regional parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function disable_regional_param_version(string $projectId, string $locationId, string $parameterId, string $versionId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, $locationId, $parameterId, $versionId);
+
+    // Update the parameter version.
+    $parameterVersion = (new ParameterVersion())
+        ->setName($parameterVersionName)
+        ->setDisabled(true);
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['disabled']);
+
+    // Prepare the request to disable the parameter version.
+    $request = (new UpdateParameterVersionRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameterVersion($parameterVersion);
+
+    // Disable the parameter version using the client.
+    $client->updateParameterVersion($request);
+
+    // Print the parameter version details.
+    printf('Disabled regional parameter version %s for parameter %s' . PHP_EOL, $versionId, $parameterId);
+}
+// [END parametermanager_disable_regional_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/enable_param_version.php
+++ b/parametermanager/src/enable_param_version.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_enable_param_version]
+// Import necessary classes for enable a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\UpdateParameterVersionRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Enables a parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function enable_param_version(string $projectId, string $parameterId, string $versionId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, 'global', $parameterId, $versionId);
+
+    // Update the parameter version.
+    $parameterVersion = (new ParameterVersion())
+        ->setName($parameterVersionName)
+        ->setDisabled(false);
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['disabled']);
+
+    // Prepare the request to enable the parameter version.
+    $request = (new UpdateParameterVersionRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameterVersion($parameterVersion);
+
+    // Enable the parameter version using the client.
+    $client->updateParameterVersion($request);
+
+    // Print the parameter version details.
+    printf('Enabled parameter version %s for parameter %s' . PHP_EOL, $versionId, $parameterId);
+}
+// [END parametermanager_enable_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/enable_regional_param_version.php
+++ b/parametermanager/src/enable_regional_param_version.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_enable_regional_param_version]
+// Import necessary classes for enable a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\UpdateParameterVersionRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Enables a regional parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function enable_regional_param_version(string $projectId, string $locationId, string $parameterId, string $versionId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, $locationId, $parameterId, $versionId);
+
+    // Update the parameter version.
+    $parameterVersion = (new ParameterVersion())
+        ->setName($parameterVersionName)
+        ->setDisabled(false);
+
+    $updateMask = (new FieldMask())
+        ->setPaths(['disabled']);
+
+    // Prepare the request to enable the parameter version.
+    $request = (new UpdateParameterVersionRequest())
+        ->setUpdateMask($updateMask)
+        ->setParameterVersion($parameterVersion);
+
+    // Enable the parameter version using the client.
+    $client->updateParameterVersion($request);
+
+    // Print the parameter version details.
+    printf('Enabled regional parameter version %s for parameter %s' . PHP_EOL, $versionId, $parameterId);
+}
+// [END parametermanager_enable_regional_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/get_param.php
+++ b/parametermanager/src/get_param.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+* For instructions on how to run the full sample:
+*
+* @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_get_param]
+// Import necessary classes for retrieve a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterRequest;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+
+/**
+ * Retrieves a parameter using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function get_param(string $projectId, string $parameterId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter.
+    $parameterName = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Prepare the request to get the parameter.
+    $request = (new GetParameterRequest())
+        ->setName($parameterName);
+
+    // Retrieve the parameter using the client.
+    $parameter = $client->getParameter($request);
+
+    // Print the retrieved parameter details.
+    printf('Found parameter %s with format %s' . PHP_EOL, $parameter->getName(), ParameterFormat::name($parameter->getFormat()));
+}
+// [END parametermanager_get_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/get_param_version.php
+++ b/parametermanager/src/get_param_version.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_get_param_version]
+// Import necessary classes for retrieve a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterVersionRequest;
+
+/**
+ * Retrieves a parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function get_param_version(string $projectId, string $parameterId, string $versionId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, 'global', $parameterId, $versionId);
+
+    // Prepare the request to get the parameter version.
+    $request = (new GetParameterVersionRequest())
+        ->setName($parameterVersionName);
+
+    // Retrieve the parameter version using the client.
+    $parameterVersion = $client->getParameterVersion($request);
+
+    // Print the retrieved parameter version details.
+    printf('Found parameter version %s with state %s' . PHP_EOL, $parameterVersion->getName(), $parameterVersion->getDisabled() ? 'disabled' : 'enabled');
+    if (!($parameterVersion->getDisabled())) {
+        printf('Payload: %s' . PHP_EOL, $parameterVersion->getPayload()->getData());
+    }
+}
+// [END parametermanager_get_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/get_regional_param.php
+++ b/parametermanager/src/get_regional_param.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+* For instructions on how to run the full sample:
+*
+* @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_get_regional_param]
+// Import necessary classes for retrieve a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterRequest;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+
+/**
+ * Retrieves a regional parameter using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function get_regional_param(string $projectId, string $locationId, string $parameterId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter.
+    $parameterName = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Prepare the request to get the parameter.
+    $request = (new GetParameterRequest())
+        ->setName($parameterName);
+
+    // Retrieve the parameter using the client.
+    $parameter = $client->getParameter($request);
+
+    // Print the retrieved parameter details.
+    printf('Found regional parameter %s with format %s' . PHP_EOL, $parameter->getName(), ParameterFormat::name($parameter->getFormat()));
+}
+// [END parametermanager_get_regional_param]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/get_regional_param_version.php
+++ b/parametermanager/src/get_regional_param_version.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_get_regional_param_version]
+// Import necessary classes for retrieve a parameter.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\GetParameterVersionRequest;
+
+/**
+ * Retrieves a regional parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function get_regional_param_version(string $projectId, string $locationId, string $parameterId, string $versionId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, $locationId, $parameterId, $versionId);
+
+    // Prepare the request to get the parameter version.
+    $request = (new GetParameterVersionRequest())
+        ->setName($parameterVersionName);
+
+    // Retrieve the parameter version using the client.
+    $parameterVersion = $client->getParameterVersion($request);
+
+    printf('Found regional parameter version %s with state %s' . PHP_EOL, $parameterVersion->getName(), $parameterVersion->getDisabled() ? 'disabled' : 'enabled');
+    if (!($parameterVersion->getDisabled())) {
+        printf('Payload: %s' . PHP_EOL, $parameterVersion->getPayload()->getData());
+    }
+}
+// [END parametermanager_get_regional_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/list_param_versions.php
+++ b/parametermanager/src/list_param_versions.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_list_param_versions]
+// Import necessary classes for list a parameter versions.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ListParameterVersionsRequest;
+
+/**
+ * Lists a parameter versions using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function list_param_versions(string $projectId, string $parameterId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter.
+    $parent = $client->parameterName($projectId, 'global', $parameterId);
+
+    // Prepare the request to list the parameter versions.
+    $request = (new ListParameterVersionsRequest())
+        ->setParent($parent);
+
+    // Retrieve the parameter version using the client.
+    foreach ($client->listParameterVersions($request) as $parameterVersion) {
+        printf('Found parameter version: %s' . PHP_EOL, $parameterVersion->getName());
+    }
+}
+// [END parametermanager_list_param_versions]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/list_params.php
+++ b/parametermanager/src/list_params.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_list_params]
+// Import necessary classes for list a parameters.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ListParametersRequest;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+
+/**
+ * Lists a parameters using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ */
+function list_params(string $projectId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter.
+    $parent = $client->locationName($projectId, 'global');
+
+    // Prepare the request to list the parameters.
+    $request = (new ListParametersRequest())
+        ->setParent($parent);
+
+    // Retrieve the parameter using the client.
+    foreach ($client->listParameters($request) as $parameter) {
+        printf('Found parameter %s with format %s' . PHP_EOL, $parameter->getName(), ParameterFormat::name($parameter->getFormat()));
+    }
+}
+// [END parametermanager_list_params]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/list_regional_param_versions.php
+++ b/parametermanager/src/list_regional_param_versions.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_list_regional_param_versions]
+// Import necessary classes for list a parameter versions.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ListParameterVersionsRequest;
+
+/**
+ * Lists a regional parameter versions using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ */
+function list_regional_param_versions(string $projectId, string $locationId, string $parameterId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter.
+    $parent = $client->parameterName($projectId, $locationId, $parameterId);
+
+    // Prepare the request to list the parameter versions.
+    $request = (new ListParameterVersionsRequest())
+        ->setParent($parent);
+
+    // Retrieve the parameter version using the client.
+    foreach ($client->listParameterVersions($request) as $parameterVersion) {
+        printf('Found regional parameter version: %s' . PHP_EOL, $parameterVersion->getName());
+    }
+}
+// [END parametermanager_list_regional_param_versions]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/list_regional_params.php
+++ b/parametermanager/src/list_regional_params.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_list_regional_params]
+// Import necessary classes for list a parameters.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\ListParametersRequest;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+
+/**
+ * Lists a regional parameters using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ */
+function list_regional_params(string $projectId, string $locationId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter.
+    $parent = $client->locationName($projectId, $locationId);
+
+    // Prepare the request to list the parameters.
+    $request = (new ListParametersRequest())
+        ->setParent($parent);
+
+    // Retrieve the parameter using the client.
+    foreach ($client->listParameters($request) as $parameter) {
+        printf('Found regional parameter %s with format %s' . PHP_EOL, $parameter->getName(), ParameterFormat::name($parameter->getFormat()));
+    }
+}
+// [END parametermanager_list_regional_params]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/quickstart.php
+++ b/parametermanager/src/quickstart.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 4) {
+    return printf("Usage: php %s PROJECT_ID PARAMETER_ID VERSION_ID\n", basename(__FILE__));
+}
+list($_, $projectId, $parameterId, $versionId) = $argv;
+
+// [START parametermanager_quickstart]
+// Import the Parameter Manager client library.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\GetParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+use Google\Cloud\ParameterManager\V1\Parameter;
+
+/** Uncomment and populate these variables in your code */
+// $projectId = 'YOUR_GOOGLE_CLOUD_PROJECT' (e.g. 'my-project');
+// $parameterId = 'YOUR_PARAMETER_ID' (e.g. 'my-param');
+// $versionId = 'YOUR_VERSION_ID' (e.g. 'my-version');
+
+// Create a client for the Parameter Manager service.
+$client = new ParameterManagerClient();
+
+// Build the resource name of the parent object.
+$parent = $client->locationName($projectId, 'global');
+
+// Create a new Parameter object and set the format.
+$parameter = (new Parameter())
+    ->setFormat(ParameterFormat::JSON);
+
+// Prepare the request with the parent, parameter ID, and the parameter object.
+$request = (new CreateParameterRequest())
+    ->setParent($parent)
+    ->setParameterId($parameterId)
+    ->setParameter($parameter);
+
+// Crete the parameter.
+$newParameter = $client->createParameter($request);
+
+// Print the new parameter name
+printf('Created parameter %s with format %s' . PHP_EOL, $newParameter->getName(), ParameterFormat::name($newParameter->getFormat()));
+
+// Create a new ParameterVersionPayload object and set the json data.
+$payload = '{"username": "test-user", "host": "localhost"}';
+$parameterVersionPayload = new ParameterVersionPayload();
+$parameterVersionPayload->setData($payload);
+
+// Create a new ParameterVersion object and set the payload.
+$parameterVersion = new ParameterVersion();
+$parameterVersion->setPayload($parameterVersionPayload);
+
+// Prepare the request with the parent and parameter version object.
+$request = (new CreateParameterVersionRequest())
+    ->setParent($newParameter->getName())
+    ->setParameterVersionId($versionId)
+    ->setParameterVersion($parameterVersion);
+
+// Create the parameter version.
+$newParameterVersion = $client->createParameterVersion($request);
+
+// Print the new parameter version name
+printf('Created parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+
+// Prepare the request with the parent for retrieve parameter version.
+$request = (new GetParameterVersionRequest())
+    ->setName($newParameterVersion->getName());
+
+// Get the parameter version.
+$parameterVersion = $client->getParameterVersion($request);
+
+// Print the parameter version payload
+// WARNING: Do not print the secret in a production environment - this
+// snippet is showing how to access the secret material.
+printf('Payload: %s' . PHP_EOL, $parameterVersion->getPayload()->getData());
+// [END parametermanager_quickstart]

--- a/parametermanager/src/regional_quickstart.php
+++ b/parametermanager/src/regional_quickstart.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 5) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID PARAMETER_ID VERSION_ID\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $parameterId, $versionId) = $argv;
+
+// [START parametermanager_regional_quickstart]
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\GetParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+use Google\Cloud\ParameterManager\V1\Parameter;
+
+/** Uncomment and populate these variables in your code */
+// $projectId = 'YOUR_GOOGLE_CLOUD_PROJECT' (e.g. 'my-project');
+// $locationId = 'YOUR_LOCATION_ID' (e.g. 'us-central1');
+// $parameterId = 'YOUR_PARAMETER_ID' (e.g. 'my-param');
+// $versionId = 'YOUR_VERSION_ID' (e.g. 'my-version');
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+// Create a client for the Parameter Manager service.
+$client = new ParameterManagerClient($options);
+
+// Build the resource name of the parent object.
+$parent = $client->locationName($projectId, $locationId);
+
+// Create a new Parameter object and set the format.
+$parameter = (new Parameter())
+    ->setFormat(ParameterFormat::JSON);
+
+// Prepare the request with the parent, parameter ID, and the parameter object.
+$request = (new CreateParameterRequest())
+    ->setParent($parent)
+    ->setParameterId($parameterId)
+    ->setParameter($parameter);
+
+// Crete the parameter.
+$newParameter = $client->createParameter($request);
+
+// Print the new parameter name
+printf('Created regional parameter %s with format %s' . PHP_EOL, $newParameter->getName(), ParameterFormat::name($newParameter->getFormat()));
+
+// Create a new ParameterVersionPayload object and set the json data.
+$payload = '{"username": "test-user", "host": "localhost"}';
+$parameterVersionPayload = new ParameterVersionPayload();
+$parameterVersionPayload->setData($payload);
+
+// Create a new ParameterVersion object and set the payload.
+$parameterVersion = new ParameterVersion();
+$parameterVersion->setPayload($parameterVersionPayload);
+
+// Prepare the request with the parent and parameter version object.
+$request = (new CreateParameterVersionRequest())
+    ->setParent($newParameter->getName())
+    ->setParameterVersionId($versionId)
+    ->setParameterVersion($parameterVersion);
+
+// Create the parameter version.
+$newParameterVersion = $client->createParameterVersion($request);
+
+// Print the new parameter version name
+printf('Created regional parameter version: %s' . PHP_EOL, $newParameterVersion->getName());
+
+// Prepare the request with the parent for retrieve parameter version.
+$request = (new GetParameterVersionRequest())
+    ->setName($newParameterVersion->getName());
+
+// Get the parameter version.
+$parameterVersion = $client->getParameterVersion($request);
+
+// Print the parameter version name
+printf('Payload: %s' . PHP_EOL, $parameterVersion->getPayload()->getData());
+// [END parametermanager_regional_quickstart]

--- a/parametermanager/src/render_param_version.php
+++ b/parametermanager/src/render_param_version.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_render_param_version]
+// Import necessary classes for render a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\RenderParameterVersionRequest;
+
+/**
+ * Renders a parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function render_param_version(string $projectId, string $parameterId, string $versionId): void
+{
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient();
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, 'global', $parameterId, $versionId);
+
+    // Prepare the request to render the parameter version.
+    $request = (new RenderParameterVersionRequest())->setName($parameterVersionName);
+
+    // Retrieve the render parameter version using the client.
+    $parameterVersion = $client->renderParameterVersion($request);
+
+    // Print the retrieved parameter version details.
+    printf('Rendered parameter version payload: %s' . PHP_EOL, $parameterVersion->getRenderedPayload());
+}
+// [END parametermanager_render_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/src/render_regional_param_version.php
+++ b/parametermanager/src/render_regional_param_version.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/parametermanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+// [START parametermanager_render_regional_param_version]
+// Import necessary classes for render a parameter version.
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\RenderParameterVersionRequest;
+
+/**
+ * Renders a regional parameter version using the Parameter Manager SDK for GCP.
+ *
+ * @param string $projectId The Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId The Parameter Location (e.g. 'us-central1')
+ * @param string $parameterId The Parameter ID (e.g. 'my-param')
+ * @param string $versionId The Version ID (e.g. 'my-param-version')
+ */
+function render_regional_param_version(string $projectId, string $locationId, string $parameterId, string $versionId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "parametermanager.$locationId.rep.googleapis.com"];
+
+    // Create a client for the Parameter Manager service.
+    $client = new ParameterManagerClient($options);
+
+    // Build the resource name of the parameter version.
+    $parameterVersionName = $client->parameterVersionName($projectId, $locationId, $parameterId, $versionId);
+
+    // Prepare the request to render the parameter version.
+    $request = (new RenderParameterVersionRequest())->setName($parameterVersionName);
+
+    // Retrieve the render parameter version using the client.
+    $parameterVersion = $client->renderParameterVersion($request);
+
+    // Print the retrieved parameter version details.
+    printf('Rendered regional parameter version payload: %s' . PHP_EOL, $parameterVersion->getRenderedPayload());
+}
+// [END parametermanager_render_regional_param_version]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/parametermanager/test/parametermanagerTest.php
+++ b/parametermanager/test/parametermanagerTest.php
@@ -1,0 +1,437 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+use Google\Cloud\TestUtils\TestTrait;
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\SecretManager\V1\AddSecretVersionRequest;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\DeleteSecretRequest;
+use PHPUnit\Framework\TestCase;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\SecretVersion;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\SecretPayload;
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+use Google\Cloud\ParameterManager\V1\DeleteParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+use Google\Cloud\Iam\V1\Binding;
+use Google\Cloud\Iam\V1\GetIamPolicyRequest;
+use Google\Cloud\Iam\V1\SetIamPolicyRequest;
+
+class parametermanagerTest extends TestCase
+{
+    use TestTrait;
+
+    public const PAYLOAD = 'test123';
+    public const JSON_PAYLOAD = '{"username": "test-user", "host": "localhost"}';
+    public const SECRET_ID = 'projects/project-id/secrets/secret-id/versions/latest';
+
+    private static $secretClient;
+    private static $client;
+    private static $locationId = 'global';
+
+    private static $testParameterName;
+    private static $testParameterNameWithFormat;
+
+    private static $testParameterForVersion;
+    private static $testParameterVersionName;
+
+    private static $testParameterForVersionWithFormat;
+    private static $testParameterVersionNameWithFormat;
+    private static $testParameterVersionNameWithSecretReference;
+
+    private static $testParameterToGet;
+    private static $testParameterVersionToGet;
+    private static $testParameterVersionToGet1;
+
+    private static $testParameterToRender;
+    private static $testParameterVersionToRender;
+    private static $testSecret;
+
+    private static $testParameterToDelete;
+    private static $testParameterToDeleteVersion;
+    private static $testParameterVersionToDelete;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$secretClient = new SecretManagerServiceClient();
+        self::$client = new ParameterManagerClient();
+
+        self::$testParameterName = self::$client->parameterName(self::$projectId, self::$locationId, self::randomId());
+        self::$testParameterNameWithFormat = self::$client->parameterName(self::$projectId, self::$locationId, self::randomId());
+
+        $testParameterId = self::randomId();
+        self::$testParameterForVersion = self::createParameter($testParameterId, ParameterFormat::UNFORMATTED);
+        self::$testParameterVersionName = self::$client->parameterVersionName(self::$projectId, self::$locationId, $testParameterId, self::randomId());
+
+        $testParameterId = self::randomId();
+        self::$testParameterForVersionWithFormat = self::createParameter($testParameterId, ParameterFormat::JSON);
+        self::$testParameterVersionNameWithFormat = self::$client->parameterVersionName(self::$projectId, self::$locationId, $testParameterId, self::randomId());
+        self::$testParameterVersionNameWithSecretReference = self::$client->parameterVersionName(self::$projectId, self::$locationId, $testParameterId, self::randomId());
+
+        $testParameterId = self::randomId();
+        self::$testParameterToGet = self::createParameter($testParameterId, ParameterFormat::UNFORMATTED);
+        self::$testParameterVersionToGet = self::createParameterVersion($testParameterId, self::randomId(), self::PAYLOAD);
+        self::$testParameterVersionToGet1 = self::createParameterVersion($testParameterId, self::randomId(), self::PAYLOAD);
+
+        $testParameterId = self::randomId();
+        self::$testParameterToRender = self::createParameter($testParameterId, ParameterFormat::JSON);
+        self::$testSecret = self::createSecret(self::randomId());
+        self::addSecretVersion(self::$testSecret);
+        $payload = sprintf('{"username": "test-user", "password": "__REF__(//secretmanager.googleapis.com/%s/versions/latest)"}', self::$testSecret->getName());
+        self::$testParameterVersionToRender = self::createParameterVersion($testParameterId, self::randomId(), $payload);
+        self::iamGrantAccess(self::$testSecret->getName(), self::$testParameterToRender->getPolicyMember()->getIamPolicyUidPrincipal());
+
+        self::$testParameterToDelete = self::createParameter(self::randomId(), ParameterFormat::JSON);
+        $testParameterId = self::randomId();
+        self::$testParameterToDeleteVersion = self::createParameter($testParameterId, ParameterFormat::JSON);
+        self::$testParameterVersionToDelete = self::createParameterVersion($testParameterId, self::randomId(), self::JSON_PAYLOAD);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::deleteParameter(self::$testParameterName);
+        self::deleteParameter(self::$testParameterNameWithFormat);
+
+        self::deleteParameterVersion(self::$testParameterVersionName);
+        self::deleteParameter(self::$testParameterForVersion->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionNameWithFormat);
+        self::deleteParameterVersion(self::$testParameterVersionNameWithSecretReference);
+        self::deleteParameter(self::$testParameterForVersionWithFormat->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionToGet->getName());
+        self::deleteParameterVersion(self::$testParameterVersionToGet1->getName());
+        self::deleteParameter(self::$testParameterToGet->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionToRender->getName());
+        self::deleteParameter(self::$testParameterToRender->getName());
+        self::deleteSecret(self::$testSecret->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionToDelete->getName());
+        self::deleteParameter(self::$testParameterToDeleteVersion->getName());
+        self::deleteParameter(self::$testParameterToDelete->getName());
+    }
+
+    private static function randomId(): string
+    {
+        return uniqid('php-snippets-');
+    }
+
+    private static function createParameter(string $parameterId, int $format): Parameter
+    {
+        $parent = self::$client->locationName(self::$projectId, self::$locationId);
+        $parameter = (new Parameter())
+            ->setFormat($format);
+
+        $request = (new CreateParameterRequest())
+            ->setParent($parent)
+            ->setParameterId($parameterId)
+            ->setParameter($parameter);
+
+        return self::$client->createParameter($request);
+    }
+
+    private static function createParameterVersion(string $parameterId, string $versionId, string $payload): ParameterVersion
+    {
+        $parent = self::$client->parameterName(self::$projectId, self::$locationId, $parameterId);
+
+        $parameterVersionPayload = new ParameterVersionPayload();
+        $parameterVersionPayload->setData($payload);
+
+        $parameterVersion = new ParameterVersion();
+        $parameterVersion->setPayload($parameterVersionPayload);
+
+        $request = (new CreateParameterVersionRequest())
+            ->setParent($parent)
+            ->setParameterVersionId($versionId)
+            ->setParameterVersion($parameterVersion);
+
+        return self::$client->createParameterVersion($request);
+    }
+
+    private static function deleteParameter(string $name)
+    {
+        try {
+            $deleteParameterRequest = (new DeleteParameterRequest())
+                ->setName($name);
+            self::$client->deleteParameter($deleteParameterRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function deleteParameterVersion(string $name)
+    {
+        try {
+            $deleteParameterVersionRequest = (new DeleteParameterVersionRequest())
+                ->setName($name);
+            self::$client->deleteParameterVersion($deleteParameterVersionRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function createSecret(string $secretId): Secret
+    {
+        $parent = self::$secretClient->projectName(self::$projectId);
+        $createSecretRequest = (new CreateSecretRequest())
+            ->setParent($parent)
+            ->setSecretId($secretId)
+            ->setSecret(new Secret([
+                'replication' => new Replication([
+                    'automatic' => new Automatic(),
+                ]),
+            ]));
+
+        return self::$secretClient->createSecret($createSecretRequest);
+    }
+
+    private static function addSecretVersion(Secret $secret): SecretVersion
+    {
+        $addSecretVersionRequest = (new AddSecretVersionRequest())
+            ->setParent($secret->getName())
+            ->setPayload(new SecretPayload([
+                'data' => self::PAYLOAD,
+            ]));
+        return self::$secretClient->addSecretVersion($addSecretVersionRequest);
+    }
+
+    private static function deleteSecret(string $name)
+    {
+        try {
+            $deleteSecretRequest = (new DeleteSecretRequest())
+                ->setName($name);
+            self::$secretClient->deleteSecret($deleteSecretRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function iamGrantAccess(string $secretName, string $member)
+    {
+        $policy = self::$secretClient->getIamPolicy((new GetIamPolicyRequest())->setResource($secretName));
+
+        $bindings = $policy->getBindings();
+        $bindings[] = new Binding([
+            'members' => [$member],
+            'role' => 'roles/secretmanager.secretAccessor',
+        ]);
+
+        $policy->setBindings($bindings);
+        $request = (new SetIamPolicyRequest())
+            ->setResource($secretName)
+            ->setPolicy($policy);
+        self::$secretClient->setIamPolicy($request);
+    }
+
+    public function testCreateParam()
+    {
+        $name = self::$client->parseName(self::$testParameterName);
+
+        $output = $this->runFunctionSnippet('create_param', [
+            $name['project'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Created parameter', $output);
+    }
+
+    public function testCreateStructuredParameter()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithFormat);
+
+        $output = $this->runFunctionSnippet('create_structured_param', [
+            $name['project'],
+            $name['parameter'],
+            'JSON',
+        ]);
+
+        $this->assertStringContainsString('Created parameter', $output);
+    }
+
+    public function testCreateParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionName);
+
+        $output = $this->runFunctionSnippet('create_param_version', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+            self::PAYLOAD,
+        ]);
+
+        $this->assertStringContainsString('Created parameter version', $output);
+    }
+
+    public function testCreateStructuredParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionNameWithFormat);
+
+        $output = $this->runFunctionSnippet('create_structured_param_version', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+            self::JSON_PAYLOAD,
+        ]);
+
+        $this->assertStringContainsString('Created parameter version', $output);
+    }
+
+    public function testCreateParamVersionWithSecret()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionNameWithSecretReference);
+
+        $output = $this->runFunctionSnippet('create_param_version_with_secret', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+            self::SECRET_ID,
+        ]);
+
+        $this->assertStringContainsString('Created parameter version', $output);
+    }
+
+    public function testGetParam()
+    {
+        $name = self::$client->parseName(self::$testParameterToGet->getName());
+
+        $output = $this->runFunctionSnippet('get_param', [
+            $name['project'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Found parameter', $output);
+    }
+
+    public function testGetParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToGet->getName());
+
+        $output = $this->runFunctionSnippet('get_param_version', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Found parameter version', $output);
+        $this->assertStringContainsString('Payload', $output);
+    }
+
+    public function testListParam()
+    {
+        $output = $this->runFunctionSnippet('list_params', [
+            self::$projectId,
+        ]);
+
+        $this->assertStringContainsString('Found parameter', $output);
+    }
+
+    public function testListParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterToGet->getName());
+
+        $output = $this->runFunctionSnippet('list_param_versions', [
+            $name['project'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Found parameter version', $output);
+    }
+
+    public function testRenderParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToRender->getName());
+
+        $output = $this->runFunctionSnippet('render_param_version', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Rendered parameter version payload', $output);
+    }
+
+    public function testDisableParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToGet->getName());
+
+        $output = $this->runFunctionSnippet('disable_param_version', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Disabled parameter version', $output);
+    }
+
+    public function testEnableParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToGet->getName());
+
+        $output = $this->runFunctionSnippet('enable_param_version', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Enabled parameter version', $output);
+    }
+
+    public function testDeleteParam()
+    {
+        $name = self::$client->parseName(self::$testParameterToDelete->getName());
+
+        $output = $this->runFunctionSnippet('delete_param', [
+            $name['project'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Deleted parameter', $output);
+    }
+
+    public function testDeleteParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToDelete->getName());
+
+        $output = $this->runFunctionSnippet('delete_param_version', [
+            $name['project'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Deleted parameter version', $output);
+    }
+}

--- a/parametermanager/test/quickstartTest.php
+++ b/parametermanager/test/quickstartTest.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+use Google\Cloud\ParameterManager\V1\DeleteParameterVersionRequest;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+class quickstartTest extends TestCase
+{
+    use TestTrait;
+
+    private static $parameterId;
+    private static $locationId;
+    private static $versionId;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$parameterId = uniqid('php-quickstart-');
+        self::$versionId = uniqid('php-quickstart-');
+        self::$locationId = 'global';
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $client = new ParameterManagerClient();
+        $parameterName = $client->parameterName(self::$projectId, self::$locationId, self::$parameterId);
+        $parameterVersionName = $client->parameterVersionName(self::$projectId, self::$locationId, self::$parameterId, self::$versionId);
+
+        try {
+            $deleteVersionRequest = (new DeleteParameterVersionRequest())
+                ->setName($parameterVersionName);
+            $client->deleteParameterVersion($deleteVersionRequest);
+
+            $deleteParameterRequest = (new DeleteParameterRequest())
+                ->setName($parameterName);
+            $client->deleteParameter($deleteParameterRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    public function testQuickstart()
+    {
+        $output = self::runSnippet('quickstart', [
+            self::$projectId,
+            self::$parameterId,
+            self::$versionId,
+        ]);
+
+        $this->assertStringContainsString('Created parameter', $output);
+        $this->assertStringContainsString('Created parameter version', $output);
+        $this->assertStringContainsString('Payload', $output);
+    }
+}

--- a/parametermanager/test/regionalparametermanagerTest.php
+++ b/parametermanager/test/regionalparametermanagerTest.php
@@ -1,0 +1,448 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ParameterManager;
+
+use Google\Cloud\TestUtils\TestTrait;
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\SecretManager\V1\AddSecretVersionRequest;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\DeleteSecretRequest;
+use PHPUnit\Framework\TestCase;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\SecretVersion;
+use Google\Cloud\SecretManager\V1\SecretPayload;
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\CreateParameterRequest;
+use Google\Cloud\ParameterManager\V1\CreateParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+use Google\Cloud\ParameterManager\V1\DeleteParameterVersionRequest;
+use Google\Cloud\ParameterManager\V1\Parameter;
+use Google\Cloud\ParameterManager\V1\ParameterFormat;
+use Google\Cloud\ParameterManager\V1\ParameterVersion;
+use Google\Cloud\ParameterManager\V1\ParameterVersionPayload;
+use Google\Cloud\Iam\V1\Binding;
+use Google\Cloud\Iam\V1\GetIamPolicyRequest;
+use Google\Cloud\Iam\V1\SetIamPolicyRequest;
+
+class regionalparametermanagerTest extends TestCase
+{
+    use TestTrait;
+
+    public const PAYLOAD = 'test123';
+    public const JSON_PAYLOAD = '{"username": "test-user", "host": "localhost"}';
+    public const SECRET_ID = 'projects/project-id/locations/us-central1/secrets/secret-id/versions/latest';
+
+    private static $secretClient;
+    private static $client;
+    private static $locationId = 'us-central1';
+
+    private static $testParameterName;
+    private static $testParameterNameWithFormat;
+
+    private static $testParameterForVersion;
+    private static $testParameterVersionName;
+
+    private static $testParameterForVersionWithFormat;
+    private static $testParameterVersionNameWithFormat;
+    private static $testParameterVersionNameWithSecretReference;
+
+    private static $testParameterToGet;
+    private static $testParameterVersionToGet;
+    private static $testParameterVersionToGet1;
+
+    private static $testParameterToRender;
+    private static $testParameterVersionToRender;
+    private static $testSecret;
+
+    private static $testParameterToDelete;
+    private static $testParameterToDeleteVersion;
+    private static $testParameterVersionToDelete;
+
+    public static function setUpBeforeClass(): void
+    {
+        $optionsForSecretManager = ['apiEndpoint' => 'secretmanager.' . self::$locationId . '.rep.googleapis.com'];
+        self::$secretClient = new SecretManagerServiceClient($optionsForSecretManager);
+        $options = ['apiEndpoint' => 'parametermanager.' . self::$locationId . '.rep.googleapis.com'];
+        self::$client = new ParameterManagerClient($options);
+
+        self::$testParameterName = self::$client->parameterName(self::$projectId, self::$locationId, self::randomId());
+        self::$testParameterNameWithFormat = self::$client->parameterName(self::$projectId, self::$locationId, self::randomId());
+
+        $testParameterId = self::randomId();
+        self::$testParameterForVersion = self::createParameter($testParameterId, ParameterFormat::UNFORMATTED);
+        self::$testParameterVersionName = self::$client->parameterVersionName(self::$projectId, self::$locationId, $testParameterId, self::randomId());
+
+        $testParameterId = self::randomId();
+        self::$testParameterForVersionWithFormat = self::createParameter($testParameterId, ParameterFormat::JSON);
+        self::$testParameterVersionNameWithFormat = self::$client->parameterVersionName(self::$projectId, self::$locationId, $testParameterId, self::randomId());
+        self::$testParameterVersionNameWithSecretReference = self::$client->parameterVersionName(self::$projectId, self::$locationId, $testParameterId, self::randomId());
+
+        $testParameterId = self::randomId();
+        self::$testParameterToGet = self::createParameter($testParameterId, ParameterFormat::UNFORMATTED);
+        self::$testParameterVersionToGet = self::createParameterVersion($testParameterId, self::randomId(), self::PAYLOAD);
+        self::$testParameterVersionToGet1 = self::createParameterVersion($testParameterId, self::randomId(), self::PAYLOAD);
+
+        $testParameterId = self::randomId();
+        self::$testParameterToRender = self::createParameter($testParameterId, ParameterFormat::JSON);
+        self::$testSecret = self::createSecret(self::randomId());
+        self::addSecretVersion(self::$testSecret);
+        $payload = sprintf('{"username": "test-user", "password": "__REF__(//secretmanager.googleapis.com/%s/versions/latest)"}', self::$testSecret->getName());
+        self::$testParameterVersionToRender = self::createParameterVersion($testParameterId, self::randomId(), $payload);
+        self::iamGrantAccess(self::$testSecret->getName(), self::$testParameterToRender->getPolicyMember()->getIamPolicyUidPrincipal());
+        sleep(120);
+
+        self::$testParameterToDelete = self::createParameter(self::randomId(), ParameterFormat::JSON);
+        $testParameterId = self::randomId();
+        self::$testParameterToDeleteVersion = self::createParameter($testParameterId, ParameterFormat::JSON);
+        self::$testParameterVersionToDelete = self::createParameterVersion($testParameterId, self::randomId(), self::JSON_PAYLOAD);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::deleteParameter(self::$testParameterName);
+        self::deleteParameter(self::$testParameterNameWithFormat);
+
+        self::deleteParameterVersion(self::$testParameterVersionName);
+        self::deleteParameter(self::$testParameterForVersion->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionNameWithFormat);
+        self::deleteParameterVersion(self::$testParameterVersionNameWithSecretReference);
+        self::deleteParameter(self::$testParameterForVersionWithFormat->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionToGet->getName());
+        self::deleteParameterVersion(self::$testParameterVersionToGet1->getName());
+        self::deleteParameter(self::$testParameterToGet->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionToRender->getName());
+        self::deleteParameter(self::$testParameterToRender->getName());
+        self::deleteSecret(self::$testSecret->getName());
+
+        self::deleteParameterVersion(self::$testParameterVersionToDelete->getName());
+        self::deleteParameter(self::$testParameterToDeleteVersion->getName());
+        self::deleteParameter(self::$testParameterToDelete->getName());
+    }
+
+    private static function randomId(): string
+    {
+        return uniqid('php-snippets-');
+    }
+
+    private static function createParameter(string $parameterId, int $format): Parameter
+    {
+        $parent = self::$client->locationName(self::$projectId, self::$locationId);
+        $parameter = (new Parameter())
+            ->setFormat($format);
+
+        $request = (new CreateParameterRequest())
+            ->setParent($parent)
+            ->setParameterId($parameterId)
+            ->setParameter($parameter);
+
+        return self::$client->createParameter($request);
+    }
+
+    private static function createParameterVersion(string $parameterId, string $versionId, string $payload): ParameterVersion
+    {
+        $parent = self::$client->parameterName(self::$projectId, self::$locationId, $parameterId);
+
+        $parameterVersionPayload = new ParameterVersionPayload();
+        $parameterVersionPayload->setData($payload);
+
+        $parameterVersion = new ParameterVersion();
+        $parameterVersion->setPayload($parameterVersionPayload);
+
+        $request = (new CreateParameterVersionRequest())
+            ->setParent($parent)
+            ->setParameterVersionId($versionId)
+            ->setParameterVersion($parameterVersion);
+
+        return self::$client->createParameterVersion($request);
+    }
+
+    private static function deleteParameter(string $name)
+    {
+        try {
+            $deleteParameterRequest = (new DeleteParameterRequest())
+                ->setName($name);
+            self::$client->deleteParameter($deleteParameterRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function deleteParameterVersion(string $name)
+    {
+        try {
+            $deleteParameterVersionRequest = (new DeleteParameterVersionRequest())
+                ->setName($name);
+            self::$client->deleteParameterVersion($deleteParameterVersionRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function createSecret(string $secretId): Secret
+    {
+        $parent = self::$secretClient->locationName(self::$projectId, self::$locationId);
+        $createSecretRequest = (new CreateSecretRequest())
+            ->setParent($parent)
+            ->setSecretId($secretId)
+            ->setSecret(new Secret());
+
+        return self::$secretClient->createSecret($createSecretRequest);
+    }
+
+    private static function addSecretVersion(Secret $secret): SecretVersion
+    {
+        $addSecretVersionRequest = (new AddSecretVersionRequest())
+            ->setParent($secret->getName())
+            ->setPayload(new SecretPayload([
+                'data' => self::PAYLOAD,
+            ]));
+        return self::$secretClient->addSecretVersion($addSecretVersionRequest);
+    }
+
+    private static function deleteSecret(string $name)
+    {
+        try {
+            $deleteSecretRequest = (new DeleteSecretRequest())
+                ->setName($name);
+            self::$secretClient->deleteSecret($deleteSecretRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    private static function iamGrantAccess(string $secretName, string $member)
+    {
+        $policy = self::$secretClient->getIamPolicy((new GetIamPolicyRequest())->setResource($secretName));
+
+        $bindings = $policy->getBindings();
+        $bindings[] = new Binding([
+            'members' => [$member],
+            'role' => 'roles/secretmanager.secretAccessor',
+        ]);
+
+        $policy->setBindings($bindings);
+        $request = (new SetIamPolicyRequest())
+            ->setResource($secretName)
+            ->setPolicy($policy);
+        self::$secretClient->setIamPolicy($request);
+    }
+
+    public function testCreateRegionalParam()
+    {
+        $name = self::$client->parseName(self::$testParameterName);
+
+        $output = $this->runFunctionSnippet('create_regional_param', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Created regional parameter', $output);
+    }
+
+    public function testCreateStructuredRegionalParam()
+    {
+        $name = self::$client->parseName(self::$testParameterNameWithFormat);
+
+        $output = $this->runFunctionSnippet('create_structured_regional_param', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            'JSON',
+        ]);
+
+        $this->assertStringContainsString('Created regional parameter', $output);
+    }
+
+    public function testCreateRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionName);
+
+        $output = $this->runFunctionSnippet('create_regional_param_version', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+            self::PAYLOAD,
+        ]);
+
+        $this->assertStringContainsString('Created regional parameter version', $output);
+    }
+
+    public function testCreateStructuredRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionNameWithFormat);
+
+        $output = $this->runFunctionSnippet('create_structured_regional_param_version', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+            self::JSON_PAYLOAD,
+        ]);
+
+        $this->assertStringContainsString('Created regional parameter version', $output);
+    }
+
+    public function testCreateRegionalParamVersionWithSecret()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionNameWithSecretReference);
+
+        $output = $this->runFunctionSnippet('create_regional_param_version_with_secret', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+            self::SECRET_ID,
+        ]);
+
+        $this->assertStringContainsString('Created regional parameter version', $output);
+    }
+
+    public function testGetRegionalParam()
+    {
+        $name = self::$client->parseName(self::$testParameterToGet->getName());
+
+        $output = $this->runFunctionSnippet('get_regional_param', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Found regional parameter', $output);
+    }
+
+    public function testGetRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToGet->getName());
+
+        $output = $this->runFunctionSnippet('get_regional_param_version', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Found regional parameter version', $output);
+        $this->assertStringContainsString('Payload', $output);
+    }
+
+    public function testListRegionalParam()
+    {
+        $output = $this->runFunctionSnippet('list_regional_params', [
+            self::$projectId,
+            self::$locationId,
+        ]);
+
+        $this->assertStringContainsString('Found regional parameter', $output);
+    }
+
+    public function testListRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterToGet->getName());
+
+        $output = $this->runFunctionSnippet('list_regional_param_versions', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Found regional parameter version', $output);
+    }
+
+    public function testRenderRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToRender->getName());
+
+        $output = $this->runFunctionSnippet('render_regional_param_version', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Rendered regional parameter version payload', $output);
+    }
+
+    public function testDisableRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToGet->getName());
+
+        $output = $this->runFunctionSnippet('disable_regional_param_version', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Disabled regional parameter version', $output);
+    }
+
+    public function testEnableRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToGet->getName());
+
+        $output = $this->runFunctionSnippet('enable_regional_param_version', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Enabled regional parameter version', $output);
+    }
+
+    public function testDeleteRegionalParam()
+    {
+        $name = self::$client->parseName(self::$testParameterToDelete->getName());
+
+        $output = $this->runFunctionSnippet('delete_regional_param', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+        ]);
+
+        $this->assertStringContainsString('Deleted regional parameter', $output);
+    }
+
+    public function testDeleteRegionalParamVersion()
+    {
+        $name = self::$client->parseName(self::$testParameterVersionToDelete->getName());
+
+        $output = $this->runFunctionSnippet('delete_regional_param_version', [
+            $name['project'],
+            $name['location'],
+            $name['parameter'],
+            $name['parameter_version'],
+        ]);
+
+        $this->assertStringContainsString('Deleted regional parameter version', $output);
+    }
+}

--- a/parametermanager/test/regionalquickstartTest.php
+++ b/parametermanager/test/regionalquickstartTest.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\ParameterManager\V1\Client\ParameterManagerClient;
+use Google\Cloud\ParameterManager\V1\DeleteParameterRequest;
+use Google\Cloud\ParameterManager\V1\DeleteParameterVersionRequest;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+class regionalquickstartTest extends TestCase
+{
+    use TestTrait;
+
+    private static $parameterId;
+    private static $locationId;
+    private static $versionId;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$parameterId = uniqid('php-quickstart-');
+        self::$versionId = uniqid('php-quickstart-');
+        self::$locationId = 'us-central1';
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $options = ['apiEndpoint' => 'parametermanager.' . self::$locationId . '.rep.googleapis.com'];
+        $client = new ParameterManagerClient($options);
+        $parameterName = $client->parameterName(self::$projectId, self::$locationId, self::$parameterId);
+        $parameterVersionName = $client->parameterVersionName(self::$projectId, self::$locationId, self::$parameterId, self::$versionId);
+
+        try {
+            $deleteVersionRequest = (new DeleteParameterVersionRequest())
+                ->setName($parameterVersionName);
+            $client->deleteParameterVersion($deleteVersionRequest);
+
+            $deleteParameterRequest = (new DeleteParameterRequest())
+                ->setName($parameterName);
+            $client->deleteParameter($deleteParameterRequest);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+
+    public function testQuickstart()
+    {
+        $output = self::runSnippet('regional_quickstart', [
+            self::$projectId,
+            self::$locationId,
+            self::$parameterId,
+            self::$versionId,
+        ]);
+
+        $this->assertStringContainsString('Created regional parameter', $output);
+        $this->assertStringContainsString('Created regional parameter version', $output);
+        $this->assertStringContainsString('Payload', $output);
+    }
+}


### PR DESCRIPTION
## Description

Created samples for Global and Regional Parameter Manager API

#### Samples (Global, Regional)

1. quickstart
2. [parameter-structured-data](https://cloud.google.com/secret-manager/parameter-manager/docs/createparameter#parameter-structured-data)
3. [parameter-unstructured-data](https://cloud.google.com/secret-manager/parameter-manager/docs/create-parameter#parameter-unstructured-data)
4. [add-parameter-version](https://cloud.google.com/secret-manager/parameter-manager/docs/add-parameter-version#add-parameter-version) (structured, unstructured)
5. [create-parameter-secret-reference](https://cloud.google.com/secret-manager/parameter-manager/docs/reference-secrets-in-parameter#create-parameter-secret-reference)
6. [list-all-parameters](https://cloud.google.com/secret-manager/parameter-manager/docs/list-parameter#list-all-parameters)
7. [view-parameter-details](https://cloud.google.com/secret-manager/parameter-manager/docs/view-parameter-details#view-parameter-details)
8. [delete-parameter](https://cloud.google.com/secret-manager/parameter-manager/docs/delete-parameters#list-all-parameters)
9. [list-all-parameters-versions](https://cloud.google.com/secret-manager/parameter-manager/docs/list-parameter-versions#list-all-parameters-versions)
10. [view-parameter-version-details](https://cloud.google.com/secret-manager/parameter-manager/docs/view-parameter-version-details#view-parameter-version-details)
11. [render-secret-parameter-version](https://cloud.google.com/secret-manager/parameter-manager/docs/render-parameter-version#render-secret-parameter-version)
12. [disable-parameters-version](https://cloud.google.com/secret-manager/parameter-manager/docs/disable-parameter-versions#disable-parameters-version)
13. [enable-disabled-parameters-version](https://cloud.google.com/secret-manager/parameter-manager/docs/enable-disabled-versions#enable-disabled-parameters-version)
14. [delete-parameter-version](https://cloud.google.com/secret-manager/parameter-manager/docs/delete-parameter-version#list-all-parameters)

## Checklist
- [X] I have followed guidelines from the [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/CONTRIBUTING.md)
- [X] Appropriate changes to README are included in PR
- [X] Test passed: ../testing/vendor/bin/phpunit test/ -v
- [X] Lint passed: php-cs-fixer fix . --config .php-cs-fixer.dist.php
- [X] These samples need a new API enabled in testing projects to pass (let us know which ones) - This requires [Parameter manager API](https://cloud.google.com/secret-manager/parameter-manager/docs/prepare-environment) to be enabled

 Please merge this PR for me once it is approved