### PR TITLE
Update event function code samples when using CloudEventInterface 

### DIFF
--- a/functions/helloworld_pubsub/index.php
+++ b/functions/helloworld_pubsub/index.php
@@ -26,9 +26,7 @@ use Google\CloudFunctions\FunctionsFramework;
 // This enables omitting the `FUNCTIONS_SIGNATURE_TYPE=cloudevent` environment
 // variable when deploying. The `FUNCTION_TARGET` environment variable should
 // match the first parameter.
-FunctionsFramework::cloudEvent('helloworldPubsub', 'helloworldPubsub');
-
-function helloworldPubsub(CloudEventInterface $event): void
+FunctionsFramework::cloudEvent('helloworldPubsub', function helloworldPubsub(CloudEventInterface $event)
 {
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
 
@@ -37,6 +35,6 @@ function helloworldPubsub(CloudEventInterface $event): void
 
     $name = $pubSubData ? htmlspecialchars($pubSubData) : 'World';
     fwrite($log, "Hello, $name!" . PHP_EOL);
-}
+})
 // [END functions_helloworld_pubsub]
 // [END functions_cloudevent_pubsub]

--- a/functions/helloworld_pubsub/index.php
+++ b/functions/helloworld_pubsub/index.php
@@ -35,6 +35,6 @@ FunctionsFramework::cloudEvent('helloworldPubsub', function helloworldPubsub(Clo
 
     $name = $pubSubData ? htmlspecialchars($pubSubData) : 'World';
     fwrite($log, "Hello, $name!" . PHP_EOL);
-})
+});
 // [END functions_helloworld_pubsub]
 // [END functions_cloudevent_pubsub]

--- a/functions/helloworld_storage/index.php
+++ b/functions/helloworld_storage/index.php
@@ -38,7 +38,7 @@ FunctionsFramework::cloudEvent('helloGCS', function helloGCS(CloudEventInterface
     fwrite($log, 'Metageneration: ' . $data['metageneration'] . PHP_EOL);
     fwrite($log, 'Created: ' . $data['timeCreated'] . PHP_EOL);
     fwrite($log, 'Updated: ' . $data['updated'] . PHP_EOL);
-})
+});
 
 // [END functions_cloudevent_storage]
 // [END functions_helloworld_storage]

--- a/functions/helloworld_storage/index.php
+++ b/functions/helloworld_storage/index.php
@@ -26,9 +26,7 @@ use Google\CloudFunctions\FunctionsFramework;
 // This enables omitting the `FUNCTIONS_SIGNATURE_TYPE=cloudevent` environment
 // variable when deploying. The `FUNCTION_TARGET` environment variable should
 // match the first parameter.
-FunctionsFramework::cloudEvent('helloGCS', 'helloGCS');
-
-function helloGCS(CloudEventInterface $cloudevent)
+FunctionsFramework::cloudEvent('helloGCS', function helloGCS(CloudEventInterface $cloudevent)
 {
     // This function supports all Cloud Storage event types.
     $log = fopen(getenv('LOGGER_OUTPUT') ?: 'php://stderr', 'wb');
@@ -40,7 +38,7 @@ function helloGCS(CloudEventInterface $cloudevent)
     fwrite($log, 'Metageneration: ' . $data['metageneration'] . PHP_EOL);
     fwrite($log, 'Created: ' . $data['timeCreated'] . PHP_EOL);
     fwrite($log, 'Updated: ' . $data['updated'] . PHP_EOL);
-}
+})
 
 // [END functions_cloudevent_storage]
 // [END functions_helloworld_storage]


### PR DESCRIPTION
The previous code samples will fail during the deployment due to the error "PHP message: PHP Fatal error: Uncaught LogicException: Your function must have "Google\CloudFunctions\CloudEvent" as the typehint for ." 

See https://github.com/GoogleCloudPlatform/functions-framework-php/pull/116 for details. 