### PR TITLE
feat(modelarmor): Added snippets for updating templates

### DIFF
--- a/modelarmor/composer.json
+++ b/modelarmor/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "google/cloud-modelarmor": "^0.1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Google\\Cloud\\Samples\\ModelArmor\\": "test"
+        }
+    }
+}

--- a/modelarmor/phpunit.xml.dist
+++ b/modelarmor/phpunit.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Copyright 2025 Google LLC.
+
+  Licensed under the Apache License, Version 2.0 (the 'License');
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an 'AS IS' BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. 
+-->
+ 
+<phpunit bootstrap="../testing/bootstrap.php">
+  <testsuites>
+    <testsuite name="PHP Model Armor test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <log type="coverage-clover" target="build/logs/clover.xml"/>
+  </logging>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./src</directory>
+      <exclude>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
+</phpunit>

--- a/modelarmor/src/create_template.php
+++ b/modelarmor/src/create_template.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 4) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId) = $argv;
+
+// [START modelarmor_create_template]
+// Import the ModelArmor client library.
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\Template;
+use Google\Cloud\ModelArmor\V1\CreateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\FilterConfig;
+use Google\Cloud\ModelArmor\V1\RaiFilterType;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings\RaiFilter;
+use Google\Cloud\ModelArmor\V1\DetectionConfidenceLevel;
+
+/** Uncomment and populate these variables in your code. */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; // e.g. 'my-project';
+// $locationId = 'YOUR_LOCATION_ID'; // e.g. 'us-central1';
+// $templateId = 'YOUR_TEMPLATE_ID'; // e.g. 'my-template';
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+// Instantiates a client.
+$client = new ModelArmorClient($options);
+
+// Build the resource name of the parent location.
+$parent = $client->locationName($projectId, $locationId);
+
+/** Build the Model Armor template with preferred filters.
+ * For more details on filters, refer to:
+ * https://cloud.google.com/security-command-center/docs/key-concepts-model-armor#ma-filters
+ */
+
+$raiFilters = [
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::DANGEROUS)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HATE_SPEECH)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::SEXUALLY_EXPLICIT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::LOW_AND_ABOVE),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HARASSMENT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::MEDIUM_AND_ABOVE),
+];
+
+$raiFilterSetting = (new RaiFilterSettings())->setRaiFilters($raiFilters);
+
+$templateFilterConfig = (new FilterConfig())->setRaiSettings($raiFilterSetting);
+
+$template = (new Template())->setFilterConfig($templateFilterConfig);
+
+// Prepare the create template request.
+$request = (new CreateTemplateRequest)
+    ->setParent($parent)
+    ->setTemplateId($templateId)
+    ->setTemplate($template);
+
+$response = $client->createTemplate($request);
+
+printf("Template created: %s" . PHP_EOL, $response->getName());
+// [END modelarmor_create_template]

--- a/modelarmor/src/create_template_with_labels.php
+++ b/modelarmor/src/create_template_with_labels.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 6) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID LABEL_KEY LABEL_VALUE\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId, $labelKey, $labelValue) = $argv;
+
+// [START modelarmor_create_template_with_labels]
+// Import the ModelArmor client library.
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\Template;
+use Google\Cloud\ModelArmor\V1\CreateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\FilterConfig;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings\RaiFilter;
+use Google\Cloud\ModelArmor\V1\RaiFilterType;
+use Google\Cloud\ModelArmor\V1\DetectionConfidenceLevel;
+
+/** Uncomment and populate these variables in your code. */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; // e.g. 'my-project';
+// $locationId = 'YOUR_LOCATION_ID'; // e.g. 'us-central1';
+// $templateId = 'YOUR_TEMPLATE_ID'; // e.g. 'my-template';
+// $labelKey = 'YOUR_LABEL_KEY'; // e.g. 'my-label-key';
+// $labelValue = 'YOUR_LABEL_VALUE'; // e.g. 'my-label-value';
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+// Instantiates a client.
+$client = new ModelArmorClient($options);
+
+// Build the resource name of the parent location.
+$parent = $client->locationName($projectId, $locationId);
+
+/** Add template metadata to the template.
+ * For more details on template metadata, please refer to the following doc:
+ * https://cloud.google.com/security-command-center/docs/reference/model-armor/rest/v1/projects.locations.templates#templatemetadata
+ */
+
+$raiFilters = [
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::DANGEROUS)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HATE_SPEECH)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::SEXUALLY_EXPLICIT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::LOW_AND_ABOVE),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HARASSMENT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::MEDIUM_AND_ABOVE),
+];
+
+$raiSettings = (new RaiFilterSettings())->setRaiFilters($raiFilters);
+$filterConfig = (new FilterConfig())->setRaiSettings($raiSettings);
+
+// Build template with filters and labels.
+$template = (new Template())
+    ->setFilterConfig($filterConfig)
+    ->setLabels([$labelKey => $labelValue]);
+
+// Construct the request with template configuration and labels.
+$request = (new CreateTemplateRequest())
+    ->setParent($parent)
+    ->setTemplateId($templateId)
+    ->setTemplate($template);
+
+$response = $client->createTemplate($request);
+
+printf('Template created: %s' . PHP_EOL, $response->getName());
+// [END modelarmor_create_template_with_labels]

--- a/modelarmor/src/create_template_with_metadata.php
+++ b/modelarmor/src/create_template_with_metadata.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 4) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId) = $argv;
+
+// [START modelarmor_create_template_with_metadata]
+// Import the ModelArmor client library.
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\RaiFilterType;
+use Google\Cloud\ModelArmor\V1\Template;
+use Google\Cloud\ModelArmor\V1\FilterConfig;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings;
+use Google\Cloud\ModelArmor\V1\CreateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings\RaiFilter;
+use Google\Cloud\ModelArmor\V1\DetectionConfidenceLevel;
+use Google\Cloud\ModelArmor\V1\Template\TemplateMetadata;
+
+/** Uncomment and populate these variables in your code. */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; // e.g. 'my-project';
+// $locationId = 'YOUR_LOCATION_ID'; // e.g. 'us-central1';
+// $templateId = 'YOUR_TEMPLATE_ID'; // e.g. 'my-template';
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+// Instantiates a client.
+$client = new ModelArmorClient($options);
+
+// Build the resource name of the parent location.
+$parent = $client->locationName($projectId, $locationId);
+
+/** Add template metadata to the template.
+ * For more details on template metadata, please refer to the following doc:
+ * https://cloud.google.com/security-command-center/docs/reference/model-armor/rest/v1/projects.locations.templates#templatemetadata
+ */
+
+$raiFilters = [
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::DANGEROUS)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HATE_SPEECH)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::SEXUALLY_EXPLICIT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::LOW_AND_ABOVE),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HARASSMENT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::MEDIUM_AND_ABOVE),
+];
+
+$raiSettings = (new RaiFilterSettings())->setRaiFilters($raiFilters);
+$filterConfig = (new FilterConfig())->setRaiSettings($raiSettings);
+
+$templateMetadata = (new TemplateMetadata())
+    ->setLogTemplateOperations(true)
+    ->setLogSanitizeOperations(true);
+
+// Build template with filters and Metadata.
+$template = (new Template())
+    ->setFilterConfig($filterConfig)
+    ->setTemplateMetadata($templateMetadata);
+
+$request = (new CreateTemplateRequest())
+    ->setParent($parent)
+    ->setTemplateId($templateId)
+    ->setTemplate($template);
+
+$response = $client->createTemplate($request);
+
+printf('Template created: %s' . PHP_EOL, $response->getName());
+// [END modelarmor_create_template_with_metadata]

--- a/modelarmor/src/update_template.php
+++ b/modelarmor/src/update_template.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 4) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId) = $argv;
+
+// [START modelarmor_update_template]
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\DetectionConfidenceLevel;
+use Google\Cloud\ModelArmor\V1\PiAndJailbreakFilterSettings\PiAndJailbreakFilterEnforcement;
+use Google\Cloud\ModelArmor\V1\PiAndJailbreakFilterSettings;
+use Google\Cloud\ModelArmor\V1\MaliciousUriFilterSettings;
+use Google\Cloud\ModelArmor\V1\UpdateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\FilterConfig;
+use Google\Cloud\ModelArmor\V1\Template;
+
+/** Uncomment and populate these variables in your code. */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; // e.g. 'my-project';
+// $locationId = 'YOUR_LOCATION_ID'; // e.g. 'us-central1';
+// $templateId = 'YOUR_TEMPLATE_ID'; // e.g. 'my-template';
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+// Instantiates a client.
+$client = new ModelArmorClient($options);
+
+$templateFilterConfig = new FilterConfig()
+    ->setPiAndJailbreakFilterSettings(
+        (new PiAndJailbreakFilterSettings())
+            ->setFilterEnforcement(PiAndJailbreakFilterEnforcement::ENABLED)
+            ->setConfidenceLevel(DetectionConfidenceLevel::LOW_AND_ABOVE)
+    )
+    ->setMaliciousUriFilterSettings(
+        (new MaliciousUriFilterSettings())
+            ->setFilterEnforcement(PiAndJailbreakFilterEnforcement::ENABLED)
+    );
+
+$template = (new Template())
+    ->setFilterConfig($templateFilterConfig)
+    ->setName("projects/$projectId/locations/$locationId/templates/$templateId");
+
+$updateTemplateRequest = (new UpdateTemplateRequest())->setTemplate($template);
+
+// Send the request to update the template.
+$response = $client->updateTemplate($updateTemplateRequest);
+
+printf('Template updated: %s' . PHP_EOL, $response->getName());
+// [END modelarmor_update_template]

--- a/modelarmor/src/update_template_labels.php
+++ b/modelarmor/src/update_template_labels.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 6) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID LABEL_KEY LABEL_VALUE\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId, $labelKey, $labelValue) = $argv;
+
+// [START modelarmor_update_template_with_labels]
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\UpdateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\Template;
+use Google\Protobuf\FieldMask;
+
+/** Uncomment and populate these variables in your code. */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; // e.g. 'my-project';
+// $locationId = 'YOUR_LOCATION_ID'; // e.g. 'us-central1';
+// $templateId = 'YOUR_TEMPLATE_ID'; // e.g. 'my-template';
+// $labelKey = 'YOUR_LABEL_KEY'; // e.g. 'my-label-key';
+// $labelValue = 'YOUR_LABEL_VALUE'; // e.g. 'my-label-value';
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+// Instantiates a client.
+$client = new ModelArmorClient($options);
+
+$template = (new Template())
+    ->setLabels([$labelKey => $labelValue])
+    ->setName("projects/$projectId/locations/$locationId/templates/$templateId");
+
+// Define the update mask to specify which fields to update.
+$updateMask = [
+    'paths' => ['labels'],
+];
+
+$updateRequest = (new UpdateTemplateRequest())
+    ->setTemplate($template)
+    ->setUpdateMask((new FieldMask($updateMask)));
+
+$response = $client->updateTemplate($updateRequest);
+
+printf('Template updated: %s' . PHP_EOL, $response->getName());
+// [END modelarmor_update_template_with_labels]

--- a/modelarmor/src/update_template_metadata.php
+++ b/modelarmor/src/update_template_metadata.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 4) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId) = $argv;
+
+// [START modelarmor_update_template_metadata]
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\DetectionConfidenceLevel;
+use Google\Cloud\ModelArmor\V1\PiAndJailbreakFilterSettings\PiAndJailbreakFilterEnforcement;
+use Google\Cloud\ModelArmor\V1\UpdateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\PiAndJailbreakFilterSettings;
+use Google\Cloud\ModelArmor\V1\MaliciousUriFilterSettings;
+use Google\Cloud\ModelArmor\V1\Template\TemplateMetadata;
+use Google\Cloud\ModelArmor\V1\FilterConfig;
+use Google\Cloud\ModelArmor\V1\Template;
+
+/** Uncomment and populate these variables in your code. */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; // e.g. 'my-project';
+// $locationId = 'YOUR_LOCATION_ID'; // e.g. 'us-central1';
+// $templateId = 'YOUR_TEMPLATE_ID'; // e.g. 'my-template';
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+// Instantiates a client.
+$client = new ModelArmorClient($options);
+
+$templateFilterConfig = new FilterConfig()
+    ->setPiAndJailbreakFilterSettings(
+        (new PiAndJailbreakFilterSettings())
+            ->setFilterEnforcement(PiAndJailbreakFilterEnforcement::ENABLED)
+            ->setConfidenceLevel(DetectionConfidenceLevel::LOW_AND_ABOVE)
+    )
+    ->setMaliciousUriFilterSettings(
+        (new MaliciousUriFilterSettings())
+            ->setFilterEnforcement(PiAndJailbreakFilterEnforcement::ENABLED)
+    );
+
+$templateMetadata = (new TemplateMetadata())
+    ->setLogTemplateOperations(true)
+    ->setLogSanitizeOperations(true);
+
+$template = (new Template())
+    ->setFilterConfig($templateFilterConfig)
+    ->setName("projects/$projectId/locations/$locationId/templates/$templateId")
+    ->setTemplateMetadata($templateMetadata);
+
+$updateTemplateRequest = (new UpdateTemplateRequest())->setTemplate($template);
+
+$response = $client->updateTemplate($updateTemplateRequest);
+
+printf('Template updated: %s' . PHP_EOL, $response->getName());
+// [END modelarmor_update_template_metadata]

--- a/modelarmor/test/BaseTestCase.php
+++ b/modelarmor/test/BaseTestCase.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\DeleteTemplateRequest;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTestCase extends TestCase
+{
+    use TestTrait;
+
+    protected static $client;
+    protected static $templateId;
+    protected static $locationId = 'us-central1';
+
+    public static function setUpBeforeClass(): void
+    {
+        $options = ['apiEndpoint' => 'modelarmor.' . self::$locationId . '.rep.googleapis.com'];
+        self::$client = new ModelArmorClient($options);
+        self::$templateId = static::getTemplatePrefix() . uniqid();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $templateName = self::$client->templateName(self::$projectId, self::$locationId, self::$templateId);
+        try {
+            static::customTeardown();
+            $request = (new DeleteTemplateRequest())->setName($templateName);
+            self::$client->deleteTemplate($request);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+        self::$client->close();
+    }
+
+    abstract protected static function getTemplatePrefix(): string;
+    protected static function customTeardown(): void {}
+
+    protected function runSnippetfile(string $snippetName, array $params = []): string
+    {
+        $output = $this->runSnippet($snippetName, $params);
+        return $output;
+    }
+
+    protected static function getProjectId()
+    {
+        return self::$projectId;
+    }
+}

--- a/modelarmor/test/updateTemplateLabelsTest.php
+++ b/modelarmor/test/updateTemplateLabelsTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+class updateTemplateLabelsTest extends BaseTestCase
+{
+    protected static function getTemplatePrefix(): string
+    {
+        return 'php-update-template-labels-';
+    }
+
+    public function testUpdateTemplateWithLabels()
+    {
+        $labelKey = 'environment';
+        $labelValue = 'test';
+        $projectId = self::getProjectId();
+
+        // Create template with labels before updating it.
+        $this->runSnippetfile('create_template_with_labels', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+            'environment',
+            'dev',
+        ]);
+
+        $output = $this->runSnippetfile('update_template_labels', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+            $labelKey,
+            $labelValue,
+        ]);
+
+        $expectedTemplateString = 'Template updated: projects/' . $projectId . '/locations/' . self::$locationId . '/templates/' . self::$templateId;
+        $this->assertStringContainsString($expectedTemplateString, $output);
+    }
+}

--- a/modelarmor/test/updateTemplateMetadataTest.php
+++ b/modelarmor/test/updateTemplateMetadataTest.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+class updateTemplateMetadataTest extends BaseTestCase
+{
+    protected static function getTemplatePrefix(): string
+    {
+        return 'php-update-template-metadata-';
+    }
+
+    public function testUpdateTemplateMetadata()
+    {
+        $projectId = self::getProjectId();
+
+        // Create template with metadata before updating it.
+        $this->runSnippetfile('create_template_with_metadata', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+        ]);
+
+        $output = $this->runSnippetfile('update_template_metadata', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+        ]);
+
+        $expectedTemplateString = 'Template updated: projects/' . $projectId . '/locations/' . self::$locationId . '/templates/' . self::$templateId;
+        $this->assertStringContainsString($expectedTemplateString, $output);
+    }
+}

--- a/modelarmor/test/updateTemplateTest.php
+++ b/modelarmor/test/updateTemplateTest.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+class updateTemplateTest extends BaseTestCase
+{
+    protected static function getTemplatePrefix(): string
+    {
+        return 'php-update-template-';
+    }
+
+    public function testUpdateTemplate()
+    {
+        $projectId = self::getProjectId();
+
+        // Create template before updating it.
+        $this->runSnippetfile('create_template', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+        ]);
+
+        $output = $this->runSnippetfile('update_template', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+        ]);
+
+        $expectedTemplateString = 'Template updated: projects/' . $projectId . '/locations/' . self::$locationId . '/templates/' . self::$templateId;
+        $this->assertStringContainsString($expectedTemplateString, $output);
+    }
+}


### PR DESCRIPTION
Added following samples for Model Armor:

- Update template
- Update template with labels
- Update Template with metadata

Note:
- Please enable the Model Armor API and grant modelarmor.admin IAM permission on the service account/project that is used in this repo.
- Please ignore the create template files in this PR. Since the relevant PR is open, I've included those files to pass the tests on this PR. Once merged, I'll resolve the conflicts and then merge this PR.
