### PR TITLE
feat(secretmanager): Added samples for tags field

### DIFF
--- a/secretmanager/composer.json
+++ b/secretmanager/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "google/cloud-secret-manager": "^2.0.0"
+        "google/cloud-secret-manager": "^2.1.0",
+        "google/cloud-resource-manager": "^1.0"
     }
 }

--- a/secretmanager/src/bind_tags_to_regional_secret.php
+++ b/secretmanager/src/bind_tags_to_regional_secret.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_bind_tags_to_regional_secret]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\ResourceManager\V3\Client\TagBindingsClient;
+use Google\Cloud\ResourceManager\V3\CreateTagBindingRequest;
+use Google\Cloud\ResourceManager\V3\TagBinding;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $tagValue   Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function bind_tags_to_regional_secret(string $projectId, string $locationId, string $secretId, string $tagValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the parent project.
+    $parent = $client->locationName($projectId, $locationId);
+
+    $secret = new Secret();
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s' . PHP_EOL, $newSecret->getName());
+
+    // Specify regional endpoint.
+    $tagBindOptions = ['apiEndpoint' => "$locationId-cloudresourcemanager.googleapis.com"];
+    $tagBindingsClient = new TagBindingsClient($tagBindOptions);
+    $tagBinding = (new TagBinding())
+        ->setParent('//secretmanager.googleapis.com/' . $newSecret->getName())
+        ->setTagValue($tagValue);
+
+    // Build the request.
+    $request = (new CreateTagBindingRequest())
+        ->setTagBinding($tagBinding);
+
+    // Create the tag binding.
+    $operationResponse = $tagBindingsClient->createTagBinding($request);
+    $operationResponse->pollUntilComplete();
+
+    // Check if the operation succeeded.
+    if ($operationResponse->operationSucceeded()) {
+        printf('Tag binding created for secret %s with tag value %s' . PHP_EOL, $newSecret->getName(), $tagValue);
+    } else {
+        $error = $operationResponse->getError();
+        printf('Error in creating tag binding: %s' . PHP_EOL, $error->getMessage());
+    }
+}
+// [END secretmanager_bind_tags_to_regional_secret]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/bind_tags_to_secret.php
+++ b/secretmanager/src/bind_tags_to_secret.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_bind_tags_to_secret]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\ResourceManager\V3\Client\TagBindingsClient;
+use Google\Cloud\ResourceManager\V3\CreateTagBindingRequest;
+use Google\Cloud\ResourceManager\V3\TagBinding;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ * @param string $tagValue  Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function bind_tags_to_secret(string $projectId, string $secretId, string $tagValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $parent = $client->projectName($projectId);
+
+    $secret = new Secret([
+        'replication' => new Replication([
+            'automatic' => new Automatic(),
+        ]),
+    ]);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s' . PHP_EOL, $newSecret->getName());
+
+    $tagBindingsClient = new TagBindingsClient();
+    $tagBinding = (new TagBinding())
+        ->setParent('//secretmanager.googleapis.com/' . $newSecret->getName())
+        ->setTagValue($tagValue);
+
+    // Build the binding request.
+    $request = (new CreateTagBindingRequest())
+        ->setTagBinding($tagBinding);
+
+    // Create the tag binding.
+    $operationResponse = $tagBindingsClient->createTagBinding($request);
+    $operationResponse->pollUntilComplete();
+
+    // Check if the operation succeeded.
+    if ($operationResponse->operationSucceeded()) {
+        printf('Tag binding created for secret %s with tag value %s' . PHP_EOL, $newSecret->getName(), $tagValue);
+    } else {
+        $error = $operationResponse->getError();
+        printf('Error in creating tag binding: %s' . PHP_EOL, $error->getMessage());
+    }
+}
+// [END secretmanager_bind_tags_to_secret]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_regional_secret_with_tags.php
+++ b/secretmanager/src/create_regional_secret_with_tags.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_regional_create_secret_with_tags]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $tagKey     Your tag key (e.g. 'tagKeys/281475012216835')
+ * @param string $tagValue   Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function create_regional_secret_with_tags(string $projectId, string $locationId, string $secretId, string $tagKey, string $tagValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the parent project.
+    $parent = $client->locationName($projectId, $locationId);
+
+    $secret = new Secret();
+    
+    // set the tags.
+    $tags = [$tagKey => $tagValue];
+    $secret ->setTags($tags);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with tag', $newSecret->getName());
+}
+// [END secretmanager_regional_create_secret_with_tags]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_regional_secret_with_tags.php
+++ b/secretmanager/src/create_regional_secret_with_tags.php
@@ -50,7 +50,7 @@ function create_regional_secret_with_tags(string $projectId, string $locationId,
     $parent = $client->locationName($projectId, $locationId);
 
     $secret = new Secret();
-    
+
     // set the tags.
     $tags = [$tagKey => $tagValue];
     $secret ->setTags($tags);

--- a/secretmanager/src/create_secret_with_tags.php
+++ b/secretmanager/src/create_secret_with_tags.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_secret_with_tags]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ * @param string $tagKey    Your tag key (e.g. 'tagKeys/281475012216835')
+ * @param string $tagValue  Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function create_secret_with_tags(string $projectId, string $secretId, string $tagKey, string $tagValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $parent = $client->projectName($projectId);
+
+    $secret = new Secret([
+        'replication' => new Replication([
+            'automatic' => new Automatic(),
+        ]),
+    ]);
+    
+    // set the tags.
+    $tags = [$tagKey => $tagValue];
+    $secret->setTags($tags);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with tag', $newSecret->getName());
+}
+// [END secretmanager_create_secret_with_tags]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_secret_with_tags.php
+++ b/secretmanager/src/create_secret_with_tags.php
@@ -52,7 +52,7 @@ function create_secret_with_tags(string $projectId, string $secretId, string $ta
             'automatic' => new Automatic(),
         ]),
     ]);
-    
+
     // set the tags.
     $tags = [$tagKey => $tagValue];
     $secret->setTags($tags);

--- a/secretmanager/test/regionalsecretmanagerTest.php
+++ b/secretmanager/test/regionalsecretmanagerTest.php
@@ -170,7 +170,7 @@ class regionalsecretmanagerTest extends TestCase
         } else {
             $error = $operation->getError();
             printf("Error creating tag key: %s\n", $error->getMessage());
-            return "";
+            return '';
         }
     }
 
@@ -194,7 +194,7 @@ class regionalsecretmanagerTest extends TestCase
         } else {
             $error = $operation->getError();
             printf("Error creating tag value: %s\n", $error->getMessage());
-            return "";
+            return '';
         }
     }
 
@@ -207,7 +207,7 @@ class regionalsecretmanagerTest extends TestCase
         $operation->pollUntilComplete();
 
         if ($operation->operationSucceeded()) {
-            printf("Tag key deleted: %s\n",self::$testTagValue);
+            printf("Tag key deleted: %s\n", self::$testTagValue);
         } else {
             $error = $operation->getError();
             printf("Error deleting tag key: %s\n", $error->getMessage());
@@ -218,7 +218,7 @@ class regionalsecretmanagerTest extends TestCase
     {
         $request = (new DeleteTagValueRequest())
             ->setName(self::$testTagValue);
-    
+
         $operation = self::$tagValuesClient->deleteTagValue($request);
         $operation->pollUntilComplete();
 

--- a/secretmanager/test/regionalsecretmanagerTest.php
+++ b/secretmanager/test/regionalsecretmanagerTest.php
@@ -98,7 +98,7 @@ class regionalsecretmanagerTest extends TestCase
         self::deleteSecret(self::$testSecretToCreateName);
         self::deleteSecret(self::$testSecretWithTagToCreateName);
         self::deleteSecret(self::$testSecretBindTagToCreateName);
-        sleep(15);
+        sleep(15); // Added a sleep to wait for the tag unbinding
         self::deleteTagValue();
         self::deleteTagKey();
     }

--- a/secretmanager/test/regionalsecretmanagerTest.php
+++ b/secretmanager/test/regionalsecretmanagerTest.php
@@ -20,6 +20,14 @@ declare(strict_types=1);
 namespace Google\Cloud\Samples\SecretManager;
 
 use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\ResourceManager\V3\DeleteTagKeyRequest;
+use Google\Cloud\ResourceManager\V3\DeleteTagValueRequest;
+use Google\Cloud\ResourceManager\V3\Client\TagKeysClient;
+use Google\Cloud\ResourceManager\V3\CreateTagKeyRequest;
+use Google\Cloud\ResourceManager\V3\TagKey;
+use Google\Cloud\ResourceManager\V3\Client\TagValuesClient;
+use Google\Cloud\ResourceManager\V3\CreateTagValueRequest;
+use Google\Cloud\ResourceManager\V3\TagValue;
 use Google\Cloud\SecretManager\V1\AddSecretVersionRequest;
 use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
 use Google\Cloud\SecretManager\V1\CreateSecretRequest;
@@ -36,6 +44,9 @@ class regionalsecretmanagerTest extends TestCase
     use TestTrait;
 
     private static $client;
+    private static $tagKeyClient;
+    private static $tagValuesClient;
+
     private static $testSecret;
     private static $testSecretToDelete;
     private static $testSecretWithVersions;
@@ -44,14 +55,21 @@ class regionalsecretmanagerTest extends TestCase
     private static $testSecretVersionToDestroy;
     private static $testSecretVersionToDisable;
     private static $testSecretVersionToEnable;
+    private static $testSecretWithTagToCreateName;
+    private static $testSecretBindTagToCreateName;
 
     private static $iamUser = 'user:kapishsingh@google.com';
     private static $locationId = 'us-central1';
+
+    private static $testTagKey;
+    private static $testTagValue;
 
     public static function setUpBeforeClass(): void
     {
         $options = ['apiEndpoint' => 'secretmanager.' . self::$locationId . '.rep.googleapis.com' ];
         self::$client = new SecretManagerServiceClient($options);
+        self::$tagKeyClient = new TagKeysClient();
+        self::$tagValuesClient = new TagValuesClient();
 
         self::$testSecret = self::createSecret();
         self::$testSecretToDelete = self::createSecret();
@@ -61,7 +79,12 @@ class regionalsecretmanagerTest extends TestCase
         self::$testSecretVersionToDestroy = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToDisable = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToEnable = self::addSecretVersion(self::$testSecretWithVersions);
+        self::$testSecretWithTagToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
+        self::$testSecretBindTagToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
         self::disableSecretVersion(self::$testSecretVersionToEnable);
+
+        self::$testTagKey = self::createTagKey(self::randomSecretId());
+        self::$testTagValue = self::createTagValue(self::randomSecretId());
     }
 
     public static function tearDownAfterClass(): void
@@ -73,6 +96,11 @@ class regionalsecretmanagerTest extends TestCase
         self::deleteSecret(self::$testSecretToDelete->getName());
         self::deleteSecret(self::$testSecretWithVersions->getName());
         self::deleteSecret(self::$testSecretToCreateName);
+        self::deleteSecret(self::$testSecretWithTagToCreateName);
+        self::deleteSecret(self::$testSecretBindTagToCreateName);
+        sleep(15);
+        self::deleteTagValue();
+        self::deleteTagKey();
     }
 
     private static function randomSecretId(): string
@@ -119,6 +147,86 @@ class regionalsecretmanagerTest extends TestCase
             if ($e->getStatus() != 'NOT_FOUND') {
                 throw $e;
             }
+        }
+    }
+
+    private static function createTagKey(string $short_name): string
+    {
+        $parent = self::$client->projectName(self::$projectId);
+        $tagKey = (new TagKey())
+            ->setParent($parent)
+            ->setShortName($short_name);
+
+        $request = (new CreateTagKeyRequest())
+            ->setTagKey($tagKey);
+
+        $operation = self::$tagKeyClient->createTagKey($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            $createdTagKey = $operation->getResult();
+            printf("Tag key created: %s\n", $createdTagKey->getName());
+            return $createdTagKey->getName();
+        } else {
+            $error = $operation->getError();
+            printf("Error creating tag key: %s\n", $error->getMessage());
+            return "";
+        }
+    }
+
+    private static function createTagValue(string $short_name): string
+    {
+        $tagValuesClient = new TagValuesClient();
+        $tagValue = (new TagValue())
+            ->setParent(self::$testTagKey)
+            ->setShortName($short_name);
+
+        $request = (new CreateTagValueRequest())
+            ->setTagValue($tagValue);
+
+        $operation = self::$tagValuesClient->createTagValue($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            $createdTagValue = $operation->getResult();
+            printf("Tag value created: %s\n", $createdTagValue->getName());
+            return $createdTagValue->getName();
+        } else {
+            $error = $operation->getError();
+            printf("Error creating tag value: %s\n", $error->getMessage());
+            return "";
+        }
+    }
+
+    private static function deleteTagKey()
+    {
+        $request = (new DeleteTagKeyRequest())
+            ->setName(self::$testTagKey);
+
+        $operation = self::$tagKeyClient->deleteTagKey($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            printf("Tag key deleted: %s\n",self::$testTagValue);
+        } else {
+            $error = $operation->getError();
+            printf("Error deleting tag key: %s\n", $error->getMessage());
+        }
+    }
+
+    private static function deleteTagValue()
+    {
+        $request = (new DeleteTagValueRequest())
+            ->setName(self::$testTagValue);
+    
+        $operation = self::$tagValuesClient->deleteTagValue($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            printf("Tag value deleted: %s\n", self::$testTagValue);
+        } else {
+            $error = $operation->getError();
+            printf("Error deleting tag value: %s\n", $error->getMessage());
         }
     }
 
@@ -323,5 +431,35 @@ class regionalsecretmanagerTest extends TestCase
         ]);
 
         $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testCreateSecretWithTags()
+    {
+        $name = self::$client->parseName(self::$testSecretWithTagToCreateName);
+
+        $output = $this->runFunctionSnippet('create_regional_secret_with_tags', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testTagKey,
+            self::$testTagValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testBindTagsToSecret()
+    {
+        $name = self::$client->parseName(self::$testSecretBindTagToCreateName);
+
+        $output = $this->runFunctionSnippet('bind_tags_to_regional_secret', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testTagValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+        $this->assertStringContainsString('Tag binding created for secret', $output);
     }
 }

--- a/secretmanager/test/secretmanagerTest.php
+++ b/secretmanager/test/secretmanagerTest.php
@@ -175,7 +175,7 @@ class secretmanagerTest extends TestCase
         } else {
             $error = $operation->getError();
             printf("Error creating tag key: %s\n", $error->getMessage());
-            return "";
+            return '';
         }
     }
 
@@ -199,7 +199,7 @@ class secretmanagerTest extends TestCase
         } else {
             $error = $operation->getError();
             printf("Error creating tag value: %s\n", $error->getMessage());
-            return "";
+            return '';
         }
     }
 
@@ -212,7 +212,7 @@ class secretmanagerTest extends TestCase
         $operation->pollUntilComplete();
 
         if ($operation->operationSucceeded()) {
-            printf("Tag key deleted: %s\n",self::$testTagValue);
+            printf("Tag key deleted: %s\n", self::$testTagValue);
         } else {
             $error = $operation->getError();
             printf("Error deleting tag key: %s\n", $error->getMessage());
@@ -223,7 +223,7 @@ class secretmanagerTest extends TestCase
     {
         $request = (new DeleteTagValueRequest())
             ->setName(self::$testTagValue);
-    
+
         $operation = self::$tagValuesClient->deleteTagValue($request);
         $operation->pollUntilComplete();
 

--- a/secretmanager/test/secretmanagerTest.php
+++ b/secretmanager/test/secretmanagerTest.php
@@ -20,6 +20,14 @@ declare(strict_types=1);
 namespace Google\Cloud\Samples\SecretManager;
 
 use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\ResourceManager\V3\DeleteTagKeyRequest;
+use Google\Cloud\ResourceManager\V3\DeleteTagValueRequest;
+use Google\Cloud\ResourceManager\V3\Client\TagKeysClient;
+use Google\Cloud\ResourceManager\V3\CreateTagKeyRequest;
+use Google\Cloud\ResourceManager\V3\TagKey;
+use Google\Cloud\ResourceManager\V3\Client\TagValuesClient;
+use Google\Cloud\ResourceManager\V3\CreateTagValueRequest;
+use Google\Cloud\ResourceManager\V3\TagValue;
 use Google\Cloud\SecretManager\V1\AddSecretVersionRequest;
 use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
 use Google\Cloud\SecretManager\V1\CreateSecretRequest;
@@ -38,6 +46,9 @@ class secretmanagerTest extends TestCase
     use TestTrait;
 
     private static $client;
+    private static $tagKeyClient;
+    private static $tagValuesClient;
+
     private static $testSecret;
     private static $testSecretToDelete;
     private static $testSecretWithVersions;
@@ -47,24 +58,36 @@ class secretmanagerTest extends TestCase
     private static $testSecretVersionToDestroy;
     private static $testSecretVersionToDisable;
     private static $testSecretVersionToEnable;
+    private static $testSecretWithTagToCreateName;
+    private static $testSecretBindTagToCreateName;
 
     private static $iamUser = 'user:sethvargo@google.com';
+
+    private static $testTagKey;
+    private static $testTagValue;
 
     public static function setUpBeforeClass(): void
     {
         self::$client = new SecretManagerServiceClient();
+        self::$tagKeyClient = new TagKeysClient();
+        self::$tagValuesClient = new TagValuesClient();
 
         self::$testSecret = self::createSecret();
         self::$testSecretToDelete = self::createSecret();
         self::$testSecretWithVersions = self::createSecret();
         self::$testSecretToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
         self::$testUmmrSecretToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
+        self::$testSecretWithTagToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
+        self::$testSecretBindTagToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
 
         self::$testSecretVersion = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToDestroy = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToDisable = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToEnable = self::addSecretVersion(self::$testSecretWithVersions);
         self::disableSecretVersion(self::$testSecretVersionToEnable);
+
+        self::$testTagKey = self::createTagKey(self::randomSecretId());
+        self::$testTagValue = self::createTagValue(self::randomSecretId());
     }
 
     public static function tearDownAfterClass(): void
@@ -74,6 +97,11 @@ class secretmanagerTest extends TestCase
         self::deleteSecret(self::$testSecretWithVersions->getName());
         self::deleteSecret(self::$testSecretToCreateName);
         self::deleteSecret(self::$testUmmrSecretToCreateName);
+        self::deleteSecret(self::$testSecretWithTagToCreateName);
+        self::deleteSecret(self::$testSecretBindTagToCreateName);
+        sleep(15);
+        self::deleteTagValue();
+        self::deleteTagKey();
     }
 
     private static function randomSecretId(): string
@@ -124,6 +152,86 @@ class secretmanagerTest extends TestCase
             if ($e->getStatus() != 'NOT_FOUND') {
                 throw $e;
             }
+        }
+    }
+
+    private static function createTagKey(string $short_name): string
+    {
+        $parent = self::$client->projectName(self::$projectId);
+        $tagKey = (new TagKey())
+            ->setParent($parent)
+            ->setShortName($short_name);
+
+        $request = (new CreateTagKeyRequest())
+            ->setTagKey($tagKey);
+
+        $operation = self::$tagKeyClient->createTagKey($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            $createdTagKey = $operation->getResult();
+            printf("Tag key created: %s\n", $createdTagKey->getName());
+            return $createdTagKey->getName();
+        } else {
+            $error = $operation->getError();
+            printf("Error creating tag key: %s\n", $error->getMessage());
+            return "";
+        }
+    }
+
+    private static function createTagValue(string $short_name): string
+    {
+        $tagValuesClient = new TagValuesClient();
+        $tagValue = (new TagValue())
+            ->setParent(self::$testTagKey)
+            ->setShortName($short_name);
+
+        $request = (new CreateTagValueRequest())
+            ->setTagValue($tagValue);
+
+        $operation = self::$tagValuesClient->createTagValue($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            $createdTagValue = $operation->getResult();
+            printf("Tag value created: %s\n", $createdTagValue->getName());
+            return $createdTagValue->getName();
+        } else {
+            $error = $operation->getError();
+            printf("Error creating tag value: %s\n", $error->getMessage());
+            return "";
+        }
+    }
+
+    private static function deleteTagKey()
+    {
+        $request = (new DeleteTagKeyRequest())
+            ->setName(self::$testTagKey);
+
+        $operation = self::$tagKeyClient->deleteTagKey($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            printf("Tag key deleted: %s\n",self::$testTagValue);
+        } else {
+            $error = $operation->getError();
+            printf("Error deleting tag key: %s\n", $error->getMessage());
+        }
+    }
+
+    private static function deleteTagValue()
+    {
+        $request = (new DeleteTagValueRequest())
+            ->setName(self::$testTagValue);
+    
+        $operation = self::$tagValuesClient->deleteTagValue($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            printf("Tag value deleted: %s\n", self::$testTagValue);
+        } else {
+            $error = $operation->getError();
+            printf("Error deleting tag value: %s\n", $error->getMessage());
         }
     }
 
@@ -327,5 +435,33 @@ class secretmanagerTest extends TestCase
         ]);
 
         $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testCreateSecretWithTags()
+    {
+        $name = self::$client->parseName(self::$testSecretWithTagToCreateName);
+
+        $output = $this->runFunctionSnippet('create_secret_with_tags', [
+            $name['project'],
+            $name['secret'],
+            self::$testTagKey,
+            self::$testTagValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testBindTagsToSecret()
+    {
+        $name = self::$client->parseName(self::$testSecretBindTagToCreateName);
+
+        $output = $this->runFunctionSnippet('bind_tags_to_secret', [
+            $name['project'],
+            $name['secret'],
+            self::$testTagValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+        $this->assertStringContainsString('Tag binding created for secret', $output);
     }
 }

--- a/secretmanager/test/secretmanagerTest.php
+++ b/secretmanager/test/secretmanagerTest.php
@@ -99,7 +99,7 @@ class secretmanagerTest extends TestCase
         self::deleteSecret(self::$testUmmrSecretToCreateName);
         self::deleteSecret(self::$testSecretWithTagToCreateName);
         self::deleteSecret(self::$testSecretBindTagToCreateName);
-        sleep(15);
+        sleep(15); // Added a sleep to wait for the tag unbinding
         self::deleteTagValue();
         self::deleteTagKey();
     }


### PR DESCRIPTION
## Description

Created samples for Global and Regional Secret Manager API

#### Samples (Global, Regional)

1. Create Secret With Tags
2. Bind Tags to Secret

Ref: https://cloud.google.com/secret-manager/docs/create-and-manage-tags 

## Checklist
- [X] I have followed guidelines from the [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/CONTRIBUTING.md)
- [X] Appropriate changes to README are included in PR
- [X] Test passed: ../testing/vendor/bin/phpunit test/ -v
- [X] Lint passed: php-cs-fixer fix . --config .php-cs-fixer.dist.php
- [X] These samples need a new API enabled in testing projects to pass (let us know which ones) (To use the tags field, add the `SM_TAGS_TESTER` label to the Secret Manager service in the project using: `tm labels add secretmanager.googleapis.com SM_TAGS_TESTER <project_name>` )

 Please merge this PR for me once it is approved