### PR TITLE
chore(secretmanager): Added code samples for delayed destroy

### DIFF
--- a/secretmanager/src/create_regional_secret_with_delayed_destroy.php
+++ b/secretmanager/src/create_regional_secret_with_delayed_destroy.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_regional_secret_with_delayed_destroy]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Protobuf\Duration;
+
+/**
+ * @param string $projectId      Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId     Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId       Your secret ID (e.g. 'my-secret')
+ * @param int $versionDestroyTtl Your Version Destroy Ttl (e.g. 86400)
+ */
+function create_regional_secret_with_delayed_destroy(string $projectId, string $locationId, string $secretId, int $versionDestroyTtl): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the parent project.
+    $parent = $client->locationName($projectId, $locationId);
+
+    // Build the secret.
+    $secret = new Secret([
+        'version_destroy_ttl' => new Duration([
+            'seconds' => $versionDestroyTtl
+        ])
+    ]);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret: %s', $newSecret->getName());
+}
+// [END secretmanager_create_regional_secret_with_delayed_destroy]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_secret_with_delayed_destroy.php
+++ b/secretmanager/src/create_secret_with_delayed_destroy.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_secret_with_delayed_destroy]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Protobuf\Duration;
+
+/**
+ * @param string $projectId      Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId       Your secret ID (e.g. 'my-secret')
+ * @param int $versionDestroyTtl Your Version Destroy Ttl (e.g. 86400)
+ */
+function create_secret_with_delayed_destroy(string $projectId, string $secretId, int $versionDestroyTtl): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $parent = $client->projectName($projectId);
+
+    // Build the secret.
+    $secret = new Secret([
+        'replication' => new Replication([
+            'automatic' => new Automatic(),
+        ]),
+        'version_destroy_ttl' => new Duration([
+            'seconds' => $versionDestroyTtl
+        ])
+    ]);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret: %s', $newSecret->getName());
+}
+// [END secretmanager_create_secret_with_delayed_destroy]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/disable_regional_secret_delayed_destroy.php
+++ b/secretmanager/src/disable_regional_secret_delayed_destroy.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_disable_regional_secret_delayed_destroy]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ */
+function disable_regional_secret_delayed_destroy(string $projectId, string $locationId, string $secretId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the secret.
+    $secret = new Secret([
+        'name' => $name,
+    ]);
+
+    // Set the field mask.
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['version_destroy_ttl']);
+
+    // Build the request.
+    $request = new UpdateSecretRequest();
+    $request->setSecret($secret);
+    $request->setUpdateMask($fieldMask);
+
+    // Update the secret.
+    $newSecret = $client->updateSecret($request);
+
+    // Print the new secret name.
+    printf('Updated secret: %s', $newSecret->getName());
+}
+// [END secretmanager_disable_regional_secret_delayed_destroy]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/disable_secret_delayed_destroy.php
+++ b/secretmanager/src/disable_secret_delayed_destroy.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_disable_secret_delayed_destroy]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ */
+function disable_secret_delayed_destroy(string $projectId, string $secretId): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the secret.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the secret.
+    $secret = new Secret([
+        'name' => $name
+    ]);
+
+    // Set the field mask.
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['version_destroy_ttl']);
+
+    // Build the request.
+    $request = new UpdateSecretRequest();
+    $request->setSecret($secret);
+    $request->setUpdateMask($fieldMask);
+
+    // Update the secret.
+    $newSecret = $client->updateSecret($request);
+
+    // Print the new secret name.
+    printf('Updated secret: %s', $newSecret->getName());
+}
+// [END secretmanager_disable_secret_delayed_destroy]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/update_regional_secret_with_delayed_destroy.php
+++ b/secretmanager/src/update_regional_secret_with_delayed_destroy.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_update_regional_secret_with_delayed_destroy]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\Duration;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId      Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId     Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId       Your secret ID (e.g. 'my-secret')
+ * @param int $versionDestroyTtl Your Version Destroy Ttl (e.g. 86400)
+ */
+function update_regional_secret_with_delayed_destroy(string $projectId, string $locationId, string $secretId, string $versionDestroyTtl): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the secret.
+    $secret = new Secret([
+        'name' => $name,
+        'version_destroy_ttl' => new Duration([
+            'seconds' => $versionDestroyTtl,
+        ])
+    ]);
+
+    // Set the field mask.
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['version_destroy_ttl']);
+
+    // Build the request.
+    $request = new UpdateSecretRequest();
+    $request->setSecret($secret);
+    $request->setUpdateMask($fieldMask);
+
+    // Update the secret.
+    $newSecret = $client->updateSecret($request);
+
+    // Print the new secret name.
+    printf('Updated secret: %s', $newSecret->getName());
+}
+// [END secretmanager_update_regional_secret_with_delayed_destroy]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/update_secret_with_delayed_destroy.php
+++ b/secretmanager/src/update_secret_with_delayed_destroy.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_update_secret_with_delayed_destroy]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\Duration;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId      Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId       Your secret ID (e.g. 'my-secret')
+ * @param int $versionDestroyTtl Your Version Destroy Ttl (e.g. 86400)
+ */
+function update_secret_with_delayed_destroy(string $projectId, string $secretId, string $versionDestroyTtl): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the secret.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the secret.
+    $secret = new Secret([
+        'name' => $name,
+        'version_destroy_ttl' => new Duration([
+            'seconds' => $versionDestroyTtl,
+        ])
+    ]);
+
+    // Set the field mask.
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['version_destroy_ttl']);
+
+    // Build the request.
+    $request = new UpdateSecretRequest();
+    $request->setSecret($secret);
+    $request->setUpdateMask($fieldMask);
+
+    // Update the secret.
+    $newSecret = $client->updateSecret($request);
+
+    // Print the new secret name.
+    printf('Updated secret: %s', $newSecret->getName());
+}
+// [END secretmanager_update_secret_with_delayed_destroy]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/test/regionalsecretmanagerTest.php
+++ b/secretmanager/test/regionalsecretmanagerTest.php
@@ -59,6 +59,7 @@ class regionalsecretmanagerTest extends TestCase
     private static $testSecretBindTagToCreateName;
     private static $testSecretWithLabelsToCreateName;
     private static $testSecretWithAnnotationsToCreateName;
+    private static $testSecretWithDelayedDestroyToCreateName;
 
     private static $iamUser = 'user:kapishsingh@google.com';
     private static $locationId = 'us-central1';
@@ -68,6 +69,7 @@ class regionalsecretmanagerTest extends TestCase
     private static $testAnnotationKey = 'test-annotation-key';
     private static $testAnnotationValue = 'test-annotation-value';
     private static $testUpdatedAnnotationValue = 'test-annotation-new-value';
+    private static $testDelayedDestroyTime = 86400;
 
     private static $testTagKey;
     private static $testTagValue;
@@ -91,6 +93,7 @@ class regionalsecretmanagerTest extends TestCase
         self::$testSecretBindTagToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
         self::$testSecretWithLabelsToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
         self::$testSecretWithAnnotationsToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
+        self::$testSecretWithDelayedDestroyToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
         self::disableSecretVersion(self::$testSecretVersionToEnable);
 
         self::$testTagKey = self::createTagKey(self::randomSecretId());
@@ -110,6 +113,7 @@ class regionalsecretmanagerTest extends TestCase
         self::deleteSecret(self::$testSecretBindTagToCreateName);
         self::deleteSecret(self::$testSecretWithLabelsToCreateName);
         self::deleteSecret(self::$testSecretWithAnnotationsToCreateName);
+        self::deleteSecret(self::$testSecretWithDelayedDestroyToCreateName);
         sleep(15); // Added a sleep to wait for the tag unbinding
         self::deleteTagValue();
         self::deleteTagKey();
@@ -584,6 +588,47 @@ class regionalsecretmanagerTest extends TestCase
             $name['location'],
             $name['secret'],
             self::$testAnnotationKey
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testCreateSecretWithDelayedDestroyed()
+    {
+        $name = self::$client->parseName(self::$testSecretWithDelayedDestroyToCreateName);
+
+        $output = $this->runFunctionSnippet('create_regional_secret_with_delayed_destroy', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testDelayedDestroyTime
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testDisableSecretDelayedDestroy()
+    {
+        $name = self::$client->parseName(self::$testSecretWithDelayedDestroyToCreateName);
+
+        $output = $this->runFunctionSnippet('disable_regional_secret_delayed_destroy', [
+            $name['project'],
+            $name['location'],
+            $name['secret']
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testUpdateSecretWithDelayedDestroyed()
+    {
+        $name = self::$client->parseName(self::$testSecretWithDelayedDestroyToCreateName);
+
+        $output = $this->runFunctionSnippet('update_regional_secret_with_delayed_destroy', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testDelayedDestroyTime
         ]);
 
         $this->assertStringContainsString('Updated secret', $output);

--- a/secretmanager/test/secretmanagerTest.php
+++ b/secretmanager/test/secretmanagerTest.php
@@ -62,6 +62,7 @@ class secretmanagerTest extends TestCase
     private static $testSecretBindTagToCreateName;
     private static $testSecretWithLabelsToCreateName;
     private static $testSecretWithAnnotationsToCreateName;
+    private static $testSecretWithDelayedDestroyToCreateName;
 
     private static $iamUser = 'user:sethvargo@google.com';
     private static $testLabelKey = 'test-label-key';
@@ -70,6 +71,7 @@ class secretmanagerTest extends TestCase
     private static $testAnnotationKey = 'test-annotation-key';
     private static $testAnnotationValue = 'test-annotation-value';
     private static $testUpdatedAnnotationValue = 'test-annotation-new-value';
+    private static $testDelayedDestroyTime = 86400;
 
     private static $testTagKey;
     private static $testTagValue;
@@ -89,6 +91,7 @@ class secretmanagerTest extends TestCase
         self::$testSecretBindTagToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
         self::$testSecretWithLabelsToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
         self::$testSecretWithAnnotationsToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
+        self::$testSecretWithDelayedDestroyToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
 
         self::$testSecretVersion = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToDestroy = self::addSecretVersion(self::$testSecretWithVersions);
@@ -111,6 +114,7 @@ class secretmanagerTest extends TestCase
         self::deleteSecret(self::$testSecretBindTagToCreateName);
         self::deleteSecret(self::$testSecretWithLabelsToCreateName);
         self::deleteSecret(self::$testSecretWithAnnotationsToCreateName);
+        self::deleteSecret(self::$testSecretWithDelayedDestroyToCreateName);
         sleep(15); // Added a sleep to wait for the tag unbinding
         self::deleteTagValue();
         self::deleteTagKey();
@@ -578,6 +582,44 @@ class secretmanagerTest extends TestCase
             $name['project'],
             $name['secret'],
             self::$testAnnotationKey
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testCreateSecretWithDelayedDestroyed()
+    {
+        $name = self::$client->parseName(self::$testSecretWithDelayedDestroyToCreateName);
+
+        $output = $this->runFunctionSnippet('create_secret_with_delayed_destroy', [
+            $name['project'],
+            $name['secret'],
+            self::$testDelayedDestroyTime
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testDisableSecretDelayedDestroy()
+    {
+        $name = self::$client->parseName(self::$testSecretWithDelayedDestroyToCreateName);
+
+        $output = $this->runFunctionSnippet('disable_secret_delayed_destroy', [
+            $name['project'],
+            $name['secret'],
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testUpdateSecretWithDelayedDestroyed()
+    {
+        $name = self::$client->parseName(self::$testSecretWithDelayedDestroyToCreateName);
+
+        $output = $this->runFunctionSnippet('update_secret_with_delayed_destroy', [
+            $name['project'],
+            $name['secret'],
+            self::$testDelayedDestroyTime
         ]);
 
         $this->assertStringContainsString('Updated secret', $output);


### PR DESCRIPTION
## Description

Created samples for Global and Regional Secret Manager API

#### Samples (Global, Regional)

1. Create Secret With Delayed Destroy
2. Disable Secret Delayed Destroy
3. Update Secret With Delayed Destroy

## Checklist
- [X] I have followed guidelines from the [CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/CONTRIBUTING.md)
- [X] Appropriate changes to README are included in PR
- [X] Test passed: ../testing/vendor/bin/phpunit test/ -v
- [X] Lint passed: php-cs-fixer fix . --config .php-cs-fixer.dist.php
- [ ] These samples need a new API enabled in testing projects to pass (let us know which ones)

 Please merge this PR for me once it is approved