### PR TITLE
ARC112  - Deploy and Manage Applications on Google App Engine: Challenge Lab

### DIFF
--- a/appengine/standard/helloworld/app.yaml
+++ b/appengine/standard/helloworld/app.yaml
@@ -1,4 +1,4 @@
-runtime: php81
+runtime: php84
 
 # Defaults to "serve index.php" and "serve public/index.php". Can be used to
 # serve a custom PHP front controller (e.g. "serve backend/index.php") or to


### PR DESCRIPTION
- Upgrade App Engine PHP runtime from php81 to php84.
- Related bug: http://b/522895836