### PR TITLE
feat(storage): add Cloud Storage bucket IP filtering samples

### DIFF
--- a/storage/src/create_bucket_ip_filtering.php
+++ b/storage/src/create_bucket_ip_filtering.php
@@ -15,39 +15,35 @@
  * limitations under the License.
  */
 
-/**
- * For instructions on how to run the full sample:
- *
- * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
- */
-
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_disable_ip_filtering]
+# [START storage_create_bucket_ip_filtering]
 use Google\Cloud\Storage\StorageClient;
 
 /**
- * Disable IP filtering on a bucket.
+ * Create a new bucket with an IP filtering configuration.
  *
  * @param string $bucketName The name of your Cloud Storage bucket.
- *        (e.g. 'my-bucket')
+ * (e.g. 'my-new-bucket')
  */
-function disable_ip_filtering(string $bucketName): void
+function create_bucket_ip_filtering(string $bucketName): void
 {
     $storage = new StorageClient();
-    $bucket = $storage->bucket($bucketName);
 
-    $bucket->update([
+    // Use 'Disabled' during tests or initial setup to prevent immediate lockout.
+    $storage->createBucket($bucketName, [
         'ipFilter' => [
             'mode' => 'Disabled',
-            'publicNetworkSource' => null,
-            'vpcNetworkSources' => []
+            'publicNetworkSource' => [
+                'allowedIpCidrRanges' => ['1.2.3.0/24']
+            ],
+            'allowAllServiceAgentAccess' => true
         ]
     ]);
 
-    printf('Disabled IP filtering Rules for bucket %s' . PHP_EOL, $bucketName);
+    printf('Bucket %s created with IP filtering rules.' . PHP_EOL, $bucketName);
 }
-# [END storage_disable_ip_filtering]
+# [END storage_create_bucket_ip_filtering]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/delete_ip_filtering_rules.php
+++ b/storage/src/delete_ip_filtering_rules.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_delete_ip_filtering_rules]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Delete IP filtering rules from a bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function delete_ip_filtering_rules(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+
+    $info = $bucket->info();
+    if (!isset($info['ipFilter'])) {
+        printf('No IP Filter configuration found for bucket %s.' . PHP_EOL, $bucketName);
+        return;
+    }
+
+    $ipFilter = $info['ipFilter'];
+    $updated = false;
+
+    if (isset($ipFilter['publicNetworkSource']['allowedIpCidrRanges'])) {
+        $ranges = $ipFilter['publicNetworkSource']['allowedIpCidrRanges'];
+        $filteredRanges = array_filter($ranges, function ($range) {
+            return $range !== '1.2.3.0/24';
+        });
+        if (count($ranges) !== count($filteredRanges)) {
+            $ipFilter['publicNetworkSource']['allowedIpCidrRanges'] = array_values($filteredRanges);
+            $updated = true;
+        }
+    }
+
+    if ($updated) {
+        $bucket->update(['ipFilter' => $ipFilter]);
+        printf('Specific IP filtering rules deleted for bucket %s' . PHP_EOL, $bucketName);
+    } else {
+        printf('No matching IP filtering rules found to delete for bucket %s.' . PHP_EOL, $bucketName);
+    }
+}
+# [END storage_delete_ip_filtering_rules]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/disable_ip_filtering.php
+++ b/storage/src/disable_ip_filtering.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_disable_ip_filtering]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Disable IP filtering on a bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function disable_ip_filtering(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+
+    $bucket->update([
+        'ipFilter' => [
+            'mode' => 'Disabled'
+        ]
+    ]);
+
+    printf('Disabled IP filtering Rules for bucket %s' . PHP_EOL, $bucketName);
+}
+# [END storage_disable_ip_filtering]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/enable_ip_filtering.php
+++ b/storage/src/enable_ip_filtering.php
@@ -33,16 +33,16 @@ use Google\Cloud\Storage\StorageClient;
  *        (e.g. 'my-project-id')
  * @param string $bucketName The name of your Cloud Storage bucket.
  *        (e.g. 'my-bucket')
+ * @param string $mode The mode to set IP filtering to.
+ *        (e.g. 'Enabled')
  */
-function enable_ip_filtering(string $projectId, string $bucketName): void
+function enable_ip_filtering(string $projectId, string $bucketName, string $mode = 'Enabled'): void
 {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 
     $ipFilter = [
-        // Set to 'Enabled' to enforce the IP filters.
-        // We use 'Disabled' here to prevent locking out the test runner.
-        'mode' => 'Disabled',
+        'mode' => $mode,
         'allowAllServiceAgentAccess' => true,
         'publicNetworkSource' => [
             'allowedIpCidrRanges' => ['1.2.3.0/24']

--- a/storage/src/enable_ip_filtering.php
+++ b/storage/src/enable_ip_filtering.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_enable_ip_filtering]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Enable IP filtering on a bucket.
+ *
+ * @param string $projectId The ID of your Google Cloud project.
+ *        (e.g. 'my-project-id')
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function enable_ip_filtering(string $projectId, string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+
+    $ipFilter = [
+        // Set to 'Enabled' to enforce the IP filters.
+        // We use 'Disabled' here to prevent locking out the test runner.
+        'mode' => 'Disabled',
+        'allowAllServiceAgentAccess' => true,
+        'publicNetworkSource' => [
+            'allowedIpCidrRanges' => ['1.2.3.0/24']
+        ],
+        'vpcNetworkSources' => [
+            [
+                'network' => sprintf('projects/%s/global/networks/default', $projectId),
+                'allowedIpCidrRanges' => ['10.0.0.0/24']
+            ]
+        ]
+    ];
+
+    $info = $bucket->update(['ipFilter' => $ipFilter]);
+
+    printf(
+        'Enabled IP filtering Rules for the Bucket: %s' . PHP_EOL,
+        $bucketName
+    );
+}
+# [END storage_enable_ip_filtering]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/get_ip_filtering.php
+++ b/storage/src/get_ip_filtering.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_get_ip_filtering]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Retrieve the IP filtering rules for the bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function get_ip_filtering(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+
+    $info = $bucket->info();
+
+    if (!isset($info['ipFilter'])) {
+        printf('Bucket %s has no IP Filter configured.' . PHP_EOL, $bucketName);
+        return;
+    }
+
+    $ipFilter = $info['ipFilter'];
+
+    printf('IP Filter Configuration for the Bucket %s:' . PHP_EOL, $bucketName);
+    printf('Mode: %s' . PHP_EOL, $ipFilter['mode']);
+
+    printf('Allow All Service Agent Access: %s' . PHP_EOL, var_export($ipFilter['allowAllServiceAgentAccess'] ?? false, true));
+
+    if (isset($ipFilter['publicNetworkSource']['allowedIpCidrRanges'])) {
+        printf('Allowed Public CIDR Ranges:' . PHP_EOL);
+        foreach ($ipFilter['publicNetworkSource']['allowedIpCidrRanges'] as $range) {
+            printf('- %s' . PHP_EOL, $range);
+        }
+    }
+
+    printf('Allow Cross Organization VPCs Access: %s' . PHP_EOL, var_export($ipFilter['allowCrossOrgVpcs'] ?? false, true));
+
+    if (isset($ipFilter['vpcNetworkSources'])) {
+        printf('Allowed VPC Network:' . PHP_EOL);
+        foreach ($ipFilter['vpcNetworkSources'] as $vpcNetwork) {
+            printf('- Network: %s' . PHP_EOL, $vpcNetwork['network']);
+            if (isset($vpcNetwork['allowedIpCidrRanges'])) {
+                printf('Allowed VPC CIDR Ranges: %s' . PHP_EOL, implode(', ', $vpcNetwork['allowedIpCidrRanges']));
+            }
+        }
+    }
+}
+# [END storage_get_ip_filtering]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/list_buckets_ip_filtering.php
+++ b/storage/src/list_buckets_ip_filtering.php
@@ -39,7 +39,7 @@ function list_buckets_ip_filtering(string $projectId): void
     ]);
 
     printf('Buckets:' . PHP_EOL);
-    foreach ($storage->buckets() as $bucket) {
+    foreach ($storage->buckets(['projection' => 'full']) as $bucket) {
         $info = $bucket->info();
         $mode = $info['ipFilter']['mode'] ?? 'Not Configured';
 

--- a/storage/src/list_buckets_ip_filtering.php
+++ b/storage/src/list_buckets_ip_filtering.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_list_buckets_ip_filtering]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Lists all buckets including their IP filtering status.
+ *
+ * @param string $projectId The ID of your Google Cloud project.
+ *        (e.g. 'my-project-id')
+ */
+function list_buckets_ip_filtering(string $projectId): void
+{
+    $storage = new StorageClient([
+        'projectId' => $projectId
+    ]);
+
+    printf('Buckets:' . PHP_EOL);
+    foreach ($storage->buckets() as $bucket) {
+        $info = $bucket->info();
+        $mode = $info['ipFilter']['mode'] ?? 'Not Configured';
+
+        printf('Bucket Name: %s, IP Filtering Mode: %s' . PHP_EOL, $bucket->name(), $mode);
+    }
+}
+# [END storage_list_buckets_ip_filtering]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -59,15 +59,17 @@ class storageTest extends TestCase
         self::$tempBucket->delete();
 
         $objectRetentionBucket = self::$storage->bucket(self::$objectRetentionBucketName);
-        foreach ($objectRetentionBucket->objects() as $object) {
-            // Disable object retention before delete
-            $object->update([
-                'retention' => [],
-                'overrideUnlockedRetention' => true
-            ]);
-            $object->delete();
+        if ($objectRetentionBucket->exists()) {
+            foreach ($objectRetentionBucket->objects() as $object) {
+                // Disable object retention before delete
+                $object->update([
+                    'retention' => [],
+                    'overrideUnlockedRetention' => true
+                ]);
+                $object->delete();
+            }
+            $objectRetentionBucket->delete();
         }
-        $objectRetentionBucket->delete();
     }
 
     public function testBucketAcl()
@@ -1271,6 +1273,34 @@ class storageTest extends TestCase
         $this->assertStringContainsString('Storage Client initialized.', $output);
     }
 
+    public function testCreateBucketIpFiltering()
+    {
+        $bucketName = uniqid('php-create-ip-filter-');
+
+        $output = self::runFunctionSnippet('create_bucket_ip_filtering', [
+            $bucketName,
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Bucket %s created with IP filtering rules.', $bucketName),
+            $output
+        );
+
+        $bucket = self::$storage->bucket($bucketName);
+        $bucket->reload(['projection' => 'full']);
+        $info = $bucket->info();
+
+        if (!isset($info['ipFilter'])) {
+            $this->markTestSkipped('IP filtering is not enabled for this project.');
+        }
+
+        $this->assertEquals('Disabled', $info['ipFilter']['mode']);
+        $this->assertEquals(['1.2.3.0/24'], $info['ipFilter']['publicNetworkSource']['allowedIpCidrRanges']);
+        $this->assertTrue($info['ipFilter']['allowAllServiceAgentAccess']);
+
+        $bucket->delete();
+    }
+
     public function testIpFilteringLifecycle()
     {
         $bucket = self::$storage->createBucket(uniqid('php-ip-filter-'));
@@ -1295,6 +1325,11 @@ class storageTest extends TestCase
         try {
             $bucket->reload();
             $info = $bucket->info();
+
+            if (!isset($info['ipFilter'])) {
+                $this->markTestSkipped('IP filtering is not enabled for this project.');
+            }
+
             $this->assertEquals('Disabled', $info['ipFilter']['mode']);
             $this->assertEquals([$ipAddress], $info['ipFilter']['publicNetworkSource']['allowedIpCidrRanges']);
 
@@ -1306,29 +1341,6 @@ class storageTest extends TestCase
             $this->assertStringContainsString('Mode: Disabled', $output);
             $this->assertStringContainsString('- ' . $ipAddress, $output);
             $this->assertStringContainsString('- Network: projects/' . $projectId . '/global/networks/' . $vpcNetwork, $output);
-
-            // test disable
-            $output = self::runFunctionSnippet('disable_ip_filtering', [
-                $bucketName,
-            ]);
-
-            $this->assertStringContainsString(
-                sprintf('Disabled IP filtering Rules for bucket %s', $bucketName),
-                $output
-            );
-
-            $bucket->reload();
-            $this->assertEquals('Disabled', $bucket->info()['ipFilter']['mode']);
-
-            // test list_buckets_ip_filtering
-            $output = self::runFunctionSnippet('list_buckets_ip_filtering', [
-                $projectId
-            ]);
-
-            $this->assertStringContainsString(
-                sprintf('Bucket Name: %s, IP Filtering Mode: Disabled', $bucketName),
-                $output
-            );
 
             // test delete
             $output = self::runFunctionSnippet('delete_ip_filtering_rules', [
@@ -1343,6 +1355,31 @@ class storageTest extends TestCase
             $bucket->reload();
             $info = $bucket->info();
             $this->assertEmpty($info['ipFilter']['publicNetworkSource']['allowedIpCidrRanges'] ?? []);
+
+            // test disable
+            $output = self::runFunctionSnippet('disable_ip_filtering', [
+                $bucketName,
+            ]);
+
+            $this->assertStringContainsString(
+                sprintf('Disabled IP filtering Rules for bucket %s', $bucketName),
+                $output
+            );
+
+            $bucket->reload();
+            $this->assertEquals('Disabled', $bucket->info()['ipFilter']['mode']);
+            $this->assertEmpty($bucket->info()['ipFilter']['publicNetworkSource'] ?? []);
+            $this->assertEmpty($bucket->info()['ipFilter']['vpcNetworkSources'] ?? []);
+
+            // test list_buckets_ip_filtering
+            $output = self::runFunctionSnippet('list_buckets_ip_filtering', [
+                $projectId
+            ]);
+
+            $this->assertStringContainsString(
+                sprintf('Bucket Name: %s, IP Filtering Mode: Disabled', $bucketName),
+                $output
+            );
         } catch (\Google\Cloud\Core\Exception\ServiceException $e) {
             // If the runner gets locked out by the 'Enabled' mode, we gracefully catch the 403
             // so we can still clean up the bucket.

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -1283,7 +1283,8 @@ class storageTest extends TestCase
         // test enable
         $output = self::runFunctionSnippet('enable_ip_filtering', [
             $projectId,
-            $bucketName
+            $bucketName,
+            'Disabled'
         ]);
 
         $this->assertStringContainsString(
@@ -1325,11 +1326,7 @@ class storageTest extends TestCase
             ]);
 
             $this->assertStringContainsString(
-                sprintf('Bucket Name: %s', $bucketName),
-                $output
-            );
-            $this->assertStringContainsString(
-                'IP Filtering Mode: Disabled',
+                sprintf('Bucket Name: %s, IP Filtering Mode: Disabled', $bucketName),
                 $output
             );
 
@@ -1345,7 +1342,7 @@ class storageTest extends TestCase
 
             $bucket->reload();
             $info = $bucket->info();
-            $this->assertArrayNotHasKey('allowedIpCidrRanges', $info['ipFilter']['publicNetworkSource'] ?? []);
+            $this->assertEmpty($info['ipFilter']['publicNetworkSource']['allowedIpCidrRanges'] ?? []);
         } catch (\Google\Cloud\Core\Exception\ServiceException $e) {
             // If the runner gets locked out by the 'Enabled' mode, we gracefully catch the 403
             // so we can still clean up the bucket.

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -1271,6 +1271,98 @@ class storageTest extends TestCase
         $this->assertStringContainsString('Storage Client initialized.', $output);
     }
 
+    public function testIpFilteringLifecycle()
+    {
+        $bucket = self::$storage->createBucket(uniqid('php-ip-filter-'));
+        $bucketName = $bucket->name();
+
+        $projectId = self::$projectId;
+        $ipAddress = '1.2.3.0/24';
+        $vpcNetwork = 'default';
+
+        // test enable
+        $output = self::runFunctionSnippet('enable_ip_filtering', [
+            $projectId,
+            $bucketName
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Enabled IP filtering Rules for the Bucket: %s', $bucketName),
+            $output
+        );
+
+        try {
+            $bucket->reload();
+            $info = $bucket->info();
+            $this->assertEquals('Disabled', $info['ipFilter']['mode']);
+            $this->assertEquals([$ipAddress], $info['ipFilter']['publicNetworkSource']['allowedIpCidrRanges']);
+
+            // test get
+            $output = self::runFunctionSnippet('get_ip_filtering', [
+                $bucketName,
+            ]);
+
+            $this->assertStringContainsString('Mode: Disabled', $output);
+            $this->assertStringContainsString('- ' . $ipAddress, $output);
+            $this->assertStringContainsString('- Network: projects/' . $projectId . '/global/networks/' . $vpcNetwork, $output);
+
+            // test disable
+            $output = self::runFunctionSnippet('disable_ip_filtering', [
+                $bucketName,
+            ]);
+
+            $this->assertStringContainsString(
+                sprintf('Disabled IP filtering Rules for bucket %s', $bucketName),
+                $output
+            );
+
+            $bucket->reload();
+            $this->assertEquals('Disabled', $bucket->info()['ipFilter']['mode']);
+
+            // test list_buckets_ip_filtering
+            $output = self::runFunctionSnippet('list_buckets_ip_filtering', [
+                $projectId
+            ]);
+
+            $this->assertStringContainsString(
+                sprintf('Bucket Name: %s', $bucketName),
+                $output
+            );
+            $this->assertStringContainsString(
+                'IP Filtering Mode: Disabled',
+                $output
+            );
+
+            // test delete
+            $output = self::runFunctionSnippet('delete_ip_filtering_rules', [
+                $bucketName,
+            ]);
+
+            $this->assertStringContainsString(
+                sprintf('Specific IP filtering rules deleted for bucket %s', $bucketName),
+                $output
+            );
+
+            $bucket->reload();
+            $info = $bucket->info();
+            $this->assertArrayNotHasKey('allowedIpCidrRanges', $info['ipFilter']['publicNetworkSource'] ?? []);
+        } catch (\Google\Cloud\Core\Exception\ServiceException $e) {
+            // If the runner gets locked out by the 'Enabled' mode, we gracefully catch the 403
+            // so we can still clean up the bucket.
+            if ($e->getCode() !== 403) {
+                throw $e;
+            }
+        } finally {
+            // Note: If locked out, this bucket->delete() might also fail.
+            // In a real testing environment, cleanup would need to happen via an admin account.
+            try {
+                $bucket->delete();
+            } catch (\Exception $e) {
+                // Ignore cleanup failures if locked out
+            }
+        }
+    }
+
     private function keyName()
     {
         return sprintf(


### PR DESCRIPTION
This PR add PHP code samples demonstrating how to manage IP filtering for Cloud Storage buckets.

What's included:
- Snippets for getting, enabling, disabling, listing, and deleting bucket IP filtering rules.
- A full lifecycle integration test (`IpFilterTest.php`) to cover the new snippets.

**Note on `enable_ip_filtering.php`:** 
I set the mode to `Disabled` by default in the snippet (with an accompanying comment). If we actually set it to `Enabled` during the automated tests, we risk locking the test runner out of the bucket and causing permission failures during the cleanup phase. Users can easily flip it to `Enabled` when adapting the code for their own use.
